### PR TITLE
Add claude-code-terminal-title skill to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Skills for working with complex file formats:
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js | [⏳](https://github.com/travisvn/awesome-claude-skills/discussions/categories/skill-verification) |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases | [⏳](https://github.com/travisvn/awesome-claude-skills/discussions/categories/skill-verification) |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images | [⏳](https://github.com/travisvn/awesome-claude-skills/discussions/categories/skill-verification) |
+| **[claude-code-terminal-title](https://github.com/bluzername/claude-code-terminal-title)** | Gives each Claud-Code terminal window a dynamic title that describes the work being done so you don't lose track of what window is doing what | [⏳](https://github.com/travisvn/awesome-claude-skills/discussions/categories/skill-verification) |
+
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
adding the skill which should be helpful to any Claude-Code user. see description after the GitHub link.  Thanks for this great collection!