### PR TITLE
Add claude-starter: Production-ready skills template with TOON format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[raintree-technology/claude-starter](https://github.com/raintree-technology/claude-starter)** - Production-ready Claude Code configuration template with 40 auto-activating skills, TOON format support (30-60% token savings), and comprehensive documentation
+  - Features 40 skills across 8 domains: AI (Anthropic API, Claude Code CLI), Payments (Stripe, Whop, Shopify), Banking (Plaid), Blockchain (Aptos, Shelby, Decibel), Backend (Supabase), Mobile (Expo, iOS), and Data (TOON formatter)
+  - Includes 7 slash commands for TOON conversion, token analysis, and skill marketplace integration
+  - Native Zig TOON encoder/decoder with format utilities (convert, encode, decode, validate, analyze)
+  - Installation: Copy `.claude/` directory to your project or selectively copy specific skill domains
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## Description

This PR adds **[claude-starter](https://github.com/raintree-technology/claude-starter)** to the Collections & Libraries section.

## What is claude-starter?

A production-ready Claude Code configuration template that provides:

- **40 auto-activating skills** across 8 domains
- **TOON format support** for 30-60% token savings on tabular data
- **7 slash commands** for format conversion and skill marketplace integration
- **Native Zig encoder/decoder** with comprehensive utilities
- **Complete documentation** for customization and extension

## Features

**8 Domain Categories:**
- AI & Claude Code (Anthropic API, Claude Code CLI, builders for commands/hooks/skills/MCP)
- Payments & Commerce (Stripe, Whop, Shopify)
- Banking (Plaid with Auth, Transactions, Identity, Accounts)
- Blockchain (Aptos, Shelby Protocol, Decibel)
- Backend (Supabase)
- Mobile (Expo with EAS Build/Update/Router, iOS)
- Data (TOON formatter)

**TOON Format:**
- 30-60% token savings on arrays and uniform objects
- Native Zig implementation (20x faster than JS)
- 5 slash commands: convert, encode, decode, validate, analyze
- Complete specification and examples

## Installation

```bash
# Full template
cp -r claude-starter/.claude /your-project/.claude

# Selective installation
cp -r claude-starter/.claude/skills/{stripe,supabase} /your-project/.claude/skills/

# Optional: Pull comprehensive API docs
pipx install docpull
docpull https://docs.stripe.com -o .claude/skills/stripe/docs
```

## Links

- Repository: https://github.com/raintree-technology/claude-starter
- Documentation: See README.md and .claude/DIRECTORY.md
- TOON Format: Native Zig implementation with comprehensive utilities

## Checklist

- [x] Added to Collections & Libraries section (multi-skill repository)
- [x] Follows established formatting pattern
- [x] Includes concise description and key features
- [x] Provides installation instructions
- [x] Repository is public and accessible
- [x] Documentation is comprehensive
- [x] Skills follow Claude Code best practices

Skills work immediately with built-in knowledge. Documentation can optionally be pulled from official sources for comprehensive API reference.