### PR TITLE
Add revealjs-skill to community skills list

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Skills for working with complex file formats:
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
+| **[revealjs-skill](https://github.com/ryanbbrown/revealjs-skill/tree/main)** | Generate polished, professional presentations using the Reveal.js HTML framework |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
# Add Reveal.js Presentations skill

## Summary

- Adds a new skill for creating polished, professional HTML presentations using reveal.js
- Generates complete presentation files (HTML + CSS) with no build step required
- Includes automated quality checks for content overflow and visual review

## What problem it solves

Creating professional presentations typically requires PowerPoint, Keynote, or Google Slides. This skill enables Claude Code to generate reveal.js presentations that:

- Are portable HTML files that work anywhere (no proprietary software needed)
- Support rich layouts, themes, and data visualizations via Chart.js
- Can be version-controlled alongside code
- Export to PDF for sharing
- Include speaker notes for live presentations

## Who uses this workflow

- Developers who want to create presentations without leaving their terminal
- Teams who want presentations stored in git alongside documentation
- Anyone who needs quick, professional slides from natural language descriptions
- Conference speakers and educators who want customizable HTML presentations

## Attribution/inspiration source

Built on top of [reveal.js](https://revealjs.com/), the open-source HTML presentation framework, and directly copies some of the powerpoint design instructions from Anthropic's [pptx skill](https://github.com/anthropics/skills/tree/main/skills/pptx).

## Example of how it's used

**User prompt:**
```
Create a 10-slide presentation about renewable energy trends
```

**Claude generates:**
- `presentation.html` - Complete reveal.js presentation
- `styles.css` - Custom theme with content-appropriate colors
- Screenshots of all slides for visual review

The presentation can be opened directly in any browser, with no build step required.
