### PR TITLE
Add athola/claude-night-market to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[athola/claude-night-market](https://github.com/athola/claude-night-market)** - Modular plugin ecosystem with 12+ specialized plugins for Claude Code workflows
+  - [Capabilities Reference](https://github.com/athola/claude-night-market/blob/master/docs/capabilities-reference.md) - Full list of skills, commands, agents, and hooks
+  - Installation: `/plugin marketplace add athola/claude-night-market`
 
 ### Individual Skills
 


### PR DESCRIPTION
## Summary

Adds [athola/claude-night-market](https://github.com/athola/claude-night-market) to the Collections & Libraries section under obra/superpowers-lab.

## About Claude Night Market

Claude Night Market is a modular plugin ecosystem with 12+ specialized plugins for Claude Code workflows:

| Plugin | Purpose |
|--------|---------|
| **abstract** | Meta-skills for skill/hook authoring and evaluation |
| **archetypes** | Architecture paradigm selection (hexagonal, microservices, etc.) |
| **conjure** | Delegation to external LLMs (Gemini, Qwen) |
| **conservation** | Context window optimization (MECW patterns) |
| **imbue** | Review workflows with evidence logging |
| **leyline** | Infrastructure patterns (quota, logging, auth) |
| **memory-palace** | Spatial knowledge organization |
| **parseltongue** | Modern Python development suite |
| **pensive** | Code review and analysis toolkit |
| **sanctum** | Git and workspace operations |
| **spec-kit** | Specification-driven development |

## Installation

```bash
/plugin marketplace add athola/claude-night-market
```

## Checklist

- [x] One item per PR
- [x] Follows entry format from CONTRIBUTING.md
- [x] Links verified working
- [x] No duplicates
- [x] Placed in appropriate section (Collections & Libraries)