### PR TITLE
Add dev-agent-skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[dev-agent-skills](https://github.com/fvadicamo/dev-agent-skills)** - Agent skills for Git and GitHub workflows (Conventional Commits, PR lifecycle). 5 skills in 2 plugins: github-workflow (git-commit, github-pr-creation, github-pr-merge, github-pr-review) and skill-authoring (creating-skills)
+  - Install: `/plugin marketplace add fvadicamo/dev-agent-skills && /plugin install github-workflow@dev-agent-skills`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## Summary
Adds dev-agent-skills to the Collections & Libraries section.

## Description
A collection of 5 agent skills organized in 2 plugins for Git and GitHub workflows:

### github-workflow plugin
- **git-commit**: Creates commits following Conventional Commits format with type/scope/subject
- **github-pr-creation**: PR creation with automated validation and task tracking
- **github-pr-merge**: Pre-merge checklist validation (tests, lint, CI, comments)
- **github-pr-review**: Review comment resolution with severity classification

### skill-authoring plugin
- **creating-skills**: Guide for creating Claude Code skills following Anthropic's best practices

## Repository
https://github.com/fvadicamo/dev-agent-skills

## Checklist
- [x] Repository is public
- [x] Skills have SKILL.md with proper frontmatter
- [x] README with installation instructions
- [x] MIT License
- [x] Links tested and working
- [x] Follows contribution guidelines format