### PR TITLE
Add session-log-skill to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills for working with complex file formats:
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
+| **[session-log-skill](https://github.com/DiamondEyesFox/session-log-skill)** | Log Claude Code exchanges to structured markdown files, perfect for Obsidian, Logseq, or any notes system |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
Adds [session-log-skill](https://github.com/DiamondEyesFox/session-log-skill) to the community skills table.

## About the Skill
A skill for logging Claude Code exchanges to structured markdown files, perfect for Obsidian, Logseq, or any markdown-based notes system.

### Features
- Date-based folder organization (YYYY/MM-Month/DD/)
- Structured log format with timestamps
- Tracks all actions: file operations, bash commands, searches
- Configurable path for any notes system
- Invoke with `/session-log` command

### Use Case
Keep a persistent record of your Claude Code sessions in your notes app. Great for:
- Reviewing what you worked on
- Tracking AI-assisted changes to codebases
- Learning patterns in how you use AI assistance

## Checklist
- [x] Skill is publicly available on GitHub
- [x] README with installation instructions
- [x] Clear description in table entry