### PR TITLE
Add chatgpt-app-builder skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills for working with complex file formats:
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
+| **[chatgpt-app-builder](https://github.com/BayramAnnakov/chatgpt-app-skill)** | Build ChatGPT Apps end-to-end: product fit evaluation, MCP server generation, React widgets, OAuth 2.1 setup, and App Store submission |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds the **chatgpt-app-builder** skill to the Community Skills section.

**Skill:** [chatgpt-app-builder](https://github.com/BayramAnnakov/chatgpt-app-skill)

**Description:** Build ChatGPT Apps end-to-end: product fit evaluation (Know/Do/Show framework), MCP server generation (Node.js/TypeScript), React widgets with ChatGPT theming, OAuth 2.1 authentication, and App Store submission checklist.

**Checklist:**
- [x] Functional and tested
- [x] Documentation present (SKILL.md + 7 reference docs)
- [x] Follows AgentSkills open standard (validated with skills-ref)
- [x] MIT licensed
- [x] Not a trivial single-file skill