### PR TITLE
Add postgres and imagen skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ Skills for working with complex file formats:
 | --- | --- |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
+| **[imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen)** | Generate images using Google Gemini's image generation API for UI mockups, icons, and visual assets |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres)** | Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |


### PR DESCRIPTION
## New Community Skills

Adding two skills from [ai-skills](https://github.com/sanjay3290/ai-skills) to the Individual Skills table:

### postgres
- Execute safe read-only SQL queries against PostgreSQL databases
- Multi-connection support with intelligent auto-selection
- Defense-in-depth security

### imagen
- Generate images using Google Gemini's image generation API
- UI mockups, icons, illustrations, and visual assets
- Cross-platform support

Both skills tested with Claude Code.