### PR TITLE
Add linear-claude-skill and varlock-claude-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Skills for working with complex file formats:
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
+| **[linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill)** | Manage Linear issues, projects, and teams with MCP tools, SDK scripts, and GraphQL fallbacks |
+| **[varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill)** | Secure environment variable management ensuring secrets never appear in Claude sessions |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
Adds two community skills to the Individual Skills table:

### Skills Added
| Skill | Description |
|-------|-------------|
| **linear-claude-skill** | Linear project management with MCP, SDK scripts, and GraphQL fallbacks |
| **varlock-claude-skill** | Secure environment variable management ensuring secrets never appear in Claude sessions |

## Repositories
- [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - MIT License
- [wrsmith108/varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill) - MIT License

## Checklist
- [x] Skills from trusted sources (my own repos)
- [x] Reviewed SKILL.md and scripts
- [x] Follows table format
- [x] Public repositories

🤖 Generated with [Claude Code](https://claude.com/claude-code)