### PR TITLE
Add claude-bootstrap to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[claude-bootstrap](https://github.com/alinaqi/claude-bootstrap)** | Opinionated project initialization with security-first guardrails, spec-driven atomic todos, LLM testing patterns, and CLI orchestration |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
## Add claude-bootstrap

[claude-bootstrap](https://github.com/alinaqi/claude-bootstrap) is an opinionated project initialization system for Claude Code featuring:

- **Security-first guardrails** - OWASP patterns, secrets management, pre-commit checks
- **Spec-driven development** - Atomic todos with validation criteria and test cases
- **LLM testing patterns** - Mocks, fixtures, and evals for AI-first apps
- **CLI orchestration** - Validates and coordinates gh, vercel, supabase CLIs
- **Modular skills** - Python, TypeScript, React, Node.js, React Native
- **Measurable constraints** - 20 lines/fn, 3 params max, 80% coverage

The `/initialize-project` slash command sets up new or existing projects with consistent structure and quality gates.

Built on learnings from 100+ projects.