### PR TITLE
Add reddit-fetch skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Skills for working with complex file formats:
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
+| **[reddit-fetch](https://github.com/ykdojo/claude-code-tips/tree/main/skills/reddit-fetch)** | Fetches Reddit content via Gemini CLI when WebFetch is blocked, using tmux for session management |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds the **reddit-fetch** skill to the Individual Skills table.

## Skill Details

- **Name**: reddit-fetch
- **Repository**: https://github.com/ykdojo/claude-code-tips/tree/main/skills/reddit-fetch
- **Author**: ykdojo
- **License**: All Rights Reserved

## Description

Fetches Reddit content via Gemini CLI when WebFetch is blocked. Uses tmux for session management to interact with Gemini CLI.

## Use Case

When Claude Code's WebFetch tool returns 403/blocked errors on Reddit URLs, this skill enables fetching the content by leveraging Gemini CLI which has web access.

## Prerequisites

- Gemini CLI installed
- tmux available