### PR TITLE
Add fastlane-skill for iOS/macOS app automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[fastlane-skill](https://github.com/greenstevester/fastlane-skill)** | iOS/macOS app automation with Fastlane — setup, TestFlight uploads, and App Store submissions |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
## Summary

Adds [greenstevester/fastlane-skill](https://github.com/greenstevester/fastlane-skill) to the Individual Skills section.

This Claude Code skill plugin provides Fastlane automation for iOS/macOS projects:

| Skill | Description |
|-------|-------------|
| `setup-fastlane` | Initial Fastlane setup using Homebrew |
| `beta` | TestFlight uploads for beta testing |
| `release` | App Store metadata and submission |

### Why this skill?

- **First mover**: No Fastlane skills currently exist on SkillsMP
- **Value add**: More than just SKILL.md files — includes Xcode project introspection, metadata generation, and optional Xcode Cloud CI scripts
- **Avoids common pitfalls**: Uses Homebrew for installation (avoiding Ruby 4.0 compatibility issues with Bundler)

### Testing

Installation: `/plugin marketplace add greenstevester/fastlane-skill`

🤖 Generated with [Claude Code](https://claude.com/claude-code)