### PR TITLE
Add code-to-content skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[code-to-content](https://github.com/arome3/code-to-content)** | Transform codebases into developer content (blog, tutorial, Twitter, LinkedIn, README, newsletter, video script, conference talk) with a 5-phase quality-gated workflow and 3 parallel agents |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
## What

Adding [code-to-content](https://github.com/arome3/code-to-content) — a Claude Code skill for transforming codebases into developer content.

## Why it's valuable

- **Not trivial**: 90+ files including 3 specialized agents, 13 slash commands, 15 reference docs, 7 templates, and an 18-question evaluation suite
- **Unique use case**: Bridges the gap between coding and content creation for devrel/build-in-public
- **Quality-focused**: 5-phase mandatory workflow with gates (Analysis → Audience → Content → Optimization → Verification)

## Features

- 9 content formats: blog, tutorial, Twitter thread, LinkedIn, README, newsletter, video script, conference talk, product launch
- 3 parallel agents: `content-explorer`, `format-specialist`, `quality-reviewer`
- Evidence-grounded output (all claims traced to code/commits)
- Tech-stack-aware voice calibration
- Build-in-public journey system

## Checklist

- [x] Skill has clear documentation (README + SKILL.md)
- [x] Skill is functional and tested
- [x] More than just a single SKILL.md file
- [x] Provides value beyond what could be created in a quick session