### PR TITLE
Add Swift Approachable Concurrency skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Skills for working with complex file formats:
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
+| **[swift-approachable-concurrency](https://github.com/YOUR_USERNAME/swift-approachable-concurrency)** | Swift 6.2 Approachable Concurrency guide for iOS 26+ with mental models, migration strategies, and safe concurrent patterns | [⏳](https://github.com/travisvn/awesome-claude-skills/discussions/categories/skill-verification) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds a skill for Swift 6.2 Approachable Concurrency targeting iOS 26+.
     
     - Migration strategies for Swift 5 → Swift 6
     - Common mistakes and fixes
     - Reference files for detailed examples and troubleshooting
     
     GitHub repo: https://github.com/PavelGnatyuk/swift-approachable-concurrency
