### PR TITLE
Add plugin-authoring skill from claude-code-plugin-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills for working with complex file formats:
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[plugin-authoring](https://github.com/ivan-magda/claude-code-plugin-template)** | Guidance for creating, modifying, and debugging Claude Code plugins with schemas, templates, and validation workflows |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |


### PR DESCRIPTION
Adds the plugin-authoring skill from the claude-code-plugin-template repository.

This skill provides ambient guidance for developers creating, modifying, and debugging Claude Code plugins. It activates automatically when working with plugin-related files (.claude-plugin/, plugin.json, commands/, skills/, etc.).

**Features:**
- Schemas for plugin manifests, hooks, and marketplaces
- Templates for commands, skills, agents, and manifests
- Best practices and common mistakes documentation
- Validation checklists and troubleshooting guides

**Skill location:** `plugins/plugin-development/skills/plugin-authoring/`
**Repository:** https://github.com/ivan-magda/claude-code-plugin-template

The skill is part of a plugin development toolkit that also includes 7 slash commands for scaffolding, validation, and testing.