### PR TITLE
Add moo.md to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[saadshahd/moo.md](https://github.com/saadshahd/moo.md)** - Mental models for Claude Code with 39+ thinking frameworks (Ishikawa, Pre-mortem, Decision Matrix, Minto Pyramid)
+  - Features confidence gates, persistent learnings across sessions, and expert simulation (Hickey, Graham, Fowler)
+  - 7 plugins: hope (core thinking), product, wordsmith, founder, career, counsel, design
+  - Installation: `/plugin marketplace add saadshahd/moo.md`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## Summary

Adds [moo.md](https://github.com/saadshahd/moo.md) to the Collections & Libraries section.

## What is moo.md?

Mental models for Claude Code — a plugin collection that makes Claude think before building.

**Key features:**
- 39+ thinking frameworks (Ishikawa, Pre-mortem, Decision Matrix, Minto Pyramid)
- Confidence gates (no more "probably" — requires X-Y% with evidence)
- Persistent learnings across sessions (`~/.claude/learnings/`)
- Expert simulation (Hickey, Graham, Fowler, etc.)

**7 plugins:**
- `hope` — Core thinking framework
- `product` — PRDs, competitive analysis, metrics
- `wordsmith` — Editing, voice matching, structure
- `founder` — Startup validation, pitch, financials
- `career` — Interview prep, skill gaps
- `counsel` — Expert perspective simulation
- `design` — Design exploration workflows

**Install:**
```bash
/plugin marketplace add saadshahd/moo.md
/plugin install hope@moo.md
```

## Checklist

- [x] Entry follows existing format
- [x] Placed in appropriate section (Collections & Libraries)
- [x] Includes install command
- [x] Description is concise