### PR TITLE
Add AID Skills - Complete AI Development methodology with 21 skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,19 @@ Skills for working with complex file formats:
   - [superpowers-skills](https://github.com/obra/superpowers-skills) - Community-editable skills repository
   - [Blog: Superpowers](https://blog.fsck.com/2025/10/09/superpowers/) - Author's overview by Jesse Vincent
   - Installation: `/plugin marketplace add obra/superpowers-marketplace`
- 
+
 - **[obra/superpowers-lab](https://github.com/obra/superpowers-lab)** - Experimental skills for `Claude Code Superpowers` (see above)
   - Uses new techniques that are still being refined and tested (i.e. skills here may change over time)
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
+
+- **[ilandahan/aid-skills](https://github.com/ilandahan/aid-skills)** - Complete AI Development (AID) methodology with 21 specialized skills for phase-gated software development
+  - System skills (always running): WHY-driven decisions, phase enforcement, context tracking, learning mode
+  - Phase skills (0-5): Discovery, PRD, Tech Spec, Development, QA & Ship
+  - Development skills: System Architect, Atomic Design, TDD, Code Review, Figma Design Review
+  - Role-based personas: Product Manager, Tech Lead, Developer, QA Engineer
+  - [Website](https://theaid.ai) | [Documentation](https://theaid.ai/toolkit/skills)
+  - Installation: `/plugin marketplace add ilandahan/aid-skills`
 
 
 ### Individual Skills


### PR DESCRIPTION
## Summary

Adding **AID (AI Development) Skills** - a comprehensive methodology with 21 specialized skills for structured software development.

### What is AID?

AID is a phase-gated development methodology that guides AI assistants through the complete software development lifecycle - from Discovery to Deployment.

**Website:** [theaid.ai](https://theaid.ai)  
**Skills Documentation:** [theaid.ai/toolkit/skills](https://theaid.ai/toolkit/skills)

### Skills Included (21 total)

**System Skills (Always Running):** why-driven-decision, phase-enforcement, context-tracking, learning-mode

**Phase Skills (0-5):** aid-discovery, pre-prd-research, aid-prd, aid-tech-spec, aid-development, aid-qa-ship

**Development Skills:** system-architect, atomic-design, atomic-page-builder, test-driven, code-review, figma-design-review

**Role Skills:** role-product-manager, role-tech-lead, role-developer, role-qa-engineer

**Optional:** nano-banana-visual (AI-powered diagrams)

### Installation

```bash
/plugin marketplace add ilandahan/aid-skills
/plugin install aid-complete@aid-skills
```

### Links

- Repository: https://github.com/ilandahan/aid-skills
- Website: https://theaid.ai
- Documentation: https://theaid.ai/toolkit/skills