### PR TITLE
Add plannotator to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[backnotprop/plannotator](https://github.com/backnotprop/plannotator)** - Interactive plan review UI for Claude Code's planning workflow with visual annotation and offline sharing
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
## Summary

Adding [plannotator](https://github.com/backnotprop/plannotator) to the Tools section.

## About Plannotator

Plannotator is an interactive plan review UI that enhances Claude Code's planning workflow:

- Intercepts `ExitPlanMode` via hooks to provide a visual review interface
- Lets users annotate plans with comments, deletions, and replacements
- Supports offline URL sharing with compression
- Integrates with Obsidian and Bear for note-taking
- Configurable plan saving to custom paths

**Install:** `curl -fsSL https://plannotator.ai/install.sh | bash`

While not a Claude Skill (SKILL.md) per se, it's a tool that enhances the planning workflow experience in Claude Code, similar to how Skill_Seekers enhances skill creation.