### PR TITLE
feat:add git-annual-summary-skill to tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[iiYeung/git-annual-summary-skill](https://github.com/iiYeung/git-annual-summary-skill)** - Generate comprehensive year-end summary reports for your Git repositories
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
Hi! I created a new Claude Skill for Generate comprehensive year-end summary reports for Git repositories. I've added it to the README following the existing format. Thanks!