### PR TITLE
Add browser-history-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[browser-history-skill](https://github.com/mquandalle/browser-history-skill)** | Search local browser history to find visited pages, forgotten URLs, and time spent on sites |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
Adds [browser-history-skill](https://github.com/mquandalle/browser-history-skill) to the Individual Skills table.

## What it does

Search local browser history directly from Claude Code or Codex CLI. Queries the browser's SQLite database to find visited pages, forgotten URLs, and time spent on sites.

## Features

- Auto-detects installed browsers (Firefox, Chrome, Brave, Arc, etc.) by checking which was used most recently
- Works while browser is running using `?immutable=1` SQLite flag
- Supports time-spent analysis (Firefox) and ASCII chart visualizations
- Cross-platform: macOS, Linux, Windows

## Why it's useful

I built this after struggling to find a GitHub repo I had visited. Asked Claude to query my Firefox history directly — it found it in seconds. Turned it into a reusable skill.

## Structure

- `SKILL.md` — Instructions with SQL queries for Firefox and Chromium databases
- `find-browser.sh` — Cross-platform browser detection script
- `README.md` — Documentation with examples