### PR TITLE
Add Trail of Bits Security Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills for working with complex file formats:
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |


### PR DESCRIPTION
Adds Trail of Bits Security Skills to the Community Skills section.

**Skill:** [Trail of Bits Security Skills](https://github.com/trailofbits/skills)

**Description:** Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection.

**Features:**
- 17 security-focused skills
- Static analysis toolkit integration
- Variant analysis across codebases
- Fix verification and differential code review

Licensed under CC BY-SA 4.0.