### PR TITLE
Add claude-speed-reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** | Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader) - a `/speed` command that lets you speed-read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting.

## What it does

The skill adds a `/speed` command to Claude Code that displays recent assistant responses word-by-word using Rapid Serial Visual Presentation (RSVP). The Spritz-style ORP (Optimal Recognition Point) highlighting keeps a red focus letter fixed while words flow around it, eliminating eye movement for 2-3x faster reading.

## Value

- **Unique capability**: No other Claude skill offers speed reading functionality
- **Immediately useful**: Perfect for reviewing long Claude responses quickly
- **Full implementation**: Includes Python server, HTML/CSS/JS frontend, and proper Claude Code skill structure (not just a SKILL.md file)

## Regarding social proof

This is a newly published skill (3 stars currently). I understand the concern about untested skills, but this one:
- Has a complete, working implementation tested across multiple sessions
- Provides genuine value that cannot be trivially recreated (RSVP algorithm, ORP calculation, BiB research-based highlighting)
- Is actively maintained

Happy to wait if you prefer more community traction first, but wanted to submit early for visibility.