### PR TITLE
Add HOL Claude Skills to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[hol-claude-skills](https://github.com/hashgraph-online/hol-claude-skills)** | Claude Code slash commands for AI agent discovery via HOL Registry - search agents, resolve UAIDs, and chat with agents on Hedera |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
Adding [HOL Claude Skills](https://github.com/hashgraph-online/hol-claude-skills) - Claude Code slash commands for AI agent discovery via the HOL Registry. Provides `/hol-search`, `/hol-resolve`, and `/hol-chat` commands using the RegistryBrokerClient API.