### PR TITLE
Add SkillCheck-Free to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free)** - Validate skills against the agentskills spec. Catches structure, naming, semantic issues and recognizes quality patterns
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
## What

Adds [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) to the Tools section.

## Description

SkillCheck-Free is a skill that validates other skills against the [agentskills specification](https://agentskills.io). It catches:

- Structure issues (frontmatter, required fields)
- Naming issues (reserved words, vague terms)
- Semantic issues (contradictions, ambiguous terms)
- Quality patterns (recognizes good practices as "strengths")

It's a skill itself - say "skillcheck my skill" in Claude Code to validate.

## Why Tools section?

Like Skill_Seekers (which converts docs to skills), SkillCheck is a meta-tool for the skills ecosystem - it helps authors improve their skills before publishing.

## Links

- Repo: https://github.com/olgasafonova/SkillCheck-Free
- Pro version: https://getskillcheck.com
- Spec: https://agentskills.io