### PR TITLE
Add codebase-context skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[codebase-context](https://github.com/airowe/codebase-context-skill)** | Generates pre-built context documents for AI agents, with staleness detection and auto-update. Reduces exploration tokens by providing project structure, patterns, and conventions upfront |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
## Summary

Adds **[codebase-context](https://github.com/airowe/codebase-context-skill)** to the Individual Skills table.

## What it does

Generates pre-built context documents (`.claude/codebase-context.md`) for AI agents working on codebases. Instead of agents spending tokens exploring your codebase every session, they read this context file first and immediately understand:

- Project structure and architecture
- Key files organized by feature
- Naming conventions and code style
- Database schema
- Common commands and gotchas

## Key Features

- **Staleness detection** - Automatically detects when context needs regeneration (directory changes, config changes, age > 7 days)
- **CLAUDE.md integration** - Provides instruction block to enforce context-first reading before exploration
- **Companion tools** - Documents grepai for semantic code search as a complement

## Links

- Repository: https://github.com/airowe/codebase-context-skill
- Example output: https://github.com/airowe/codebase-context-skill/blob/main/examples/codebase-context.md