### PR TITLE
Add kallyai-cli skill for AI phone calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[kallyai-cli](https://github.com/sltelitsyn/kallyai-cli)** | AI phone assistant that makes calls to businesses on your behalf - reservations, appointments, inquiries via CLI |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skill: kallyai-cli

**Repository:** https://github.com/sltelitsyn/kallyai-cli

### Description

KallyAI CLI is an AI phone assistant that makes calls to businesses on your behalf. It enables Claude to:

- Make restaurant reservations
- Schedule appointments (clinics, hotels)
- Inquire about business hours, availability, prices
- Check call history and transcripts
- Manage subscription and billing

### Installation

```bash
pip install kallyai-cli
mkdir -p ~/.claude/skills/kallyai-api
curl -o ~/.claude/skills/kallyai-api/SKILL.md \
  https://raw.githubusercontent.com/sltelitsyn/kallyai-cli/main/skill/SKILL.md
```

### Features

- OAuth authentication (Google/Apple sign-in)
- Automatic token refresh
- CSRF protection
- Secure token storage (0600 permissions)
- Full API integration

### Links

- [PyPI Package](https://pypi.org/project/kallyai-cli/)
- [API Documentation](https://github.com/sltelitsyn/kallyai-cli/blob/main/docs/api-reference.md)