### PR TITLE
Add contract-review skill for legal document analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[contract-review](https://github.com/evolsb/claude-legal-skill)** | Legal contract review with CUAD-based risk detection, market benchmarks, and lawyer-ready redlines. Covers NDAs, SaaS agreements, M&A documents, and more |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skill: contract-review

**Repository:** https://github.com/evolsb/claude-legal-skill

### Description

Legal contract review skill with CUAD-based risk detection, market standard benchmarks, and lawyer-ready redlines.

### Features

- **41-point risk checklist** based on the CUAD dataset (NeurIPS 2021)
- **Position-aware review** — adjusts what's flagged based on user's role (customer, vendor, buyer, seller)
- **Market standard benchmarks** — compares terms to industry norms
- **Negotiability ratings** — indicates what's realistically changeable
- **Specific redlines** — actual replacement language, not just "negotiate this"
- **Document type checklists** — specialized for NDAs, SaaS, M&A, payment/merchant agreements

### Example Use Cases

- "Review this NDA - I'm the receiving party"
- "Analyze this SaaS agreement for red flags - I'm the customer"
- "Review this acquisition agreement - I'm the seller"

### Installation

```bash
git clone https://github.com/evolsb/claude-legal-skill ~/.claude/skills/contract-review
```