### PR TITLE
Add intel-skill: market intelligence for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[intel-skill](https://github.com/unisone/intel-skill)** | Market intelligence in seconds — research gaps, competitors, sentiment, pricing, trends, and pain points for any market. 7 modes for business decisions. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skill: intel-skill

**Repository:** https://github.com/unisone/intel-skill

**Description:** Market intelligence in seconds — research gaps, competitors, sentiment, pricing, trends, and pain points for any market.

**7 Modes:**
- `/intel gaps [topic]` — Find market gaps & opportunities
- `/intel competitors [product]` — Competitive landscape analysis
- `/intel sentiment [topic]` — Quantify what people love/hate
- `/intel pricing [category]` — Research pricing strategies
- `/intel trends [topic]` — Analyze direction & velocity
- `/intel pain [category]` — Find top frustrations
- `/intel full [topic]` — Complete market intelligence report

**Install:**
```bash
npx skills add unisone/intel-skill
```

No external API keys required — uses Claude Code's built-in WebSearch.

Tested across multiple scenarios with HIGH confidence outputs.