### PR TITLE
Add ecommerce-seo-audit-skill to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Skills for working with complex file formats:
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
+| **[ecommerce-seo-audit-skill](https://github.com/affilino/ecommerce-seo-audit-skill)** | Comprehensive ecommerce SEO audits with 7 specialized audit types. Covers technical SEO, product pages, collections, log files, competitor analysis, and keyword research. By Affilino NZ. |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |


### PR DESCRIPTION
## Summary

Adding the Ecommerce SEO Audit skill by Affilino NZ to the community skills section.

## Skill Details

- **Name**: Ecommerce SEO Audit
- **Repository**: https://github.com/affilino/ecommerce-seo-audit-skill
- **Author**: Affilino NZ (Auckland Shopify SEO Agency)
- **Description**: Comprehensive ecommerce SEO audits with 7 specialized audit types. Covers technical SEO, product pages, collections, log files, competitor analysis, and keyword research.

## Changes

- Added entry to the Individual Skills table in alphabetical order
- Follows the existing format and style of the README

This skill is particularly useful for ecommerce businesses looking to improve their SEO performance across multiple dimensions including technical optimization, content analysis, and competitive insights.