### PR TITLE
Add jezweb/claude-skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ Skills for working with complex file formats:
 
 ### Collections & Libraries
 
+- **[jezweb/claude-skills](https://github.com/jezweb/claude-skills)** - 87 production-ready skills for Cloudflare Workers, React, Tailwind v4, AI/LLM integrations, and more
+  - Includes 39 bundled agents for debugging, deployment, testing, and code review
+  - ~60% average token savings with 400+ documented errors prevented
+  - Installation: `/plugin marketplace add jezweb/claude-skills`
+
 - **[obra/superpowers](https://github.com/obra/superpowers)** - Core skills library for Claude Code with 20+ battle-tested skills including TDD, debugging, and collaboration patterns
   - Features `/brainstorm`, `/write-plan`, `/execute-plan` commands and skills-search tool
   - [superpowers-skills](https://github.com/obra/superpowers-skills) - Community-editable skills repository


### PR DESCRIPTION
## Description

Adding a comprehensive collection of 87 production-ready Claude Code skills.

## About claude-skills

- **87 skills** across Cloudflare, AI/LLM, Frontend, Auth, Database, and Tooling domains
- **39 bundled agents** for specialized tasks (debugging, deployment, testing, etc.)
- **~60% average token savings** with documented error prevention
- **400+ errors prevented** through known-issue documentation
- Follows official Anthropic skill standards
- MIT licensed

### Key Domains

| Domain | Skills |
|--------|--------|
| Cloudflare Platform | 20 skills (Workers, D1, R2, KV, AI, etc.) |
| AI & Machine Learning | 10 skills (OpenAI, Gemini, Claude API, AI SDK) |
| Frontend & UI | 7 skills (Tailwind v4, shadcn, TanStack, etc.) |
| Auth & Security | 3 skills (Clerk, Better Auth) |
| Database & ORM | 4 skills (Drizzle, Neon, Vercel KV/Blob) |

### Installation

```bash
/plugin marketplace add jezweb/claude-skills
/plugin install cloudflare  # Install by bundle
```

## Checklist

- [x] Follows awesome list guidelines
- [x] Link is valid and points to active repository
- [x] Description is concise and accurate
- [x] Repository is MIT licensed