### PR TITLE
Add pptx-from-layouts skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[pptx-from-layouts](https://github.com/tristan-mcinnis/pptx-from-layouts-skill)** | Generate consultant-quality PowerPoint presentations from markdown outlines using slide master layouts instead of text overlays. Includes template profiling, visual types, and edit mode. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds **pptx-from-layouts** to the Individual Skills table - a PowerPoint generation skill that uses slide master layouts properly instead of text overlays.

## What it does

Most PowerPoint generation approaches overlay text on template slides, fighting with backgrounds and decorative elements. This skill properly uses slide master layouts, placing content in actual placeholders to preserve professional design.

## Features

- Markdown outline → PPTX generation
- Template profiling for custom corporate templates
- Semantic visual types (hero, process, comparison, cards, tables)
- Typography markers for rich formatting
- Edit mode for surgical changes to existing decks
- Built-in quality validation

## Repository

https://github.com/tristan-mcinnis/pptx-from-layouts-skill

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)