### PR TITLE
Add claude-code-handoff to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills for working with complex file formats:
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[claude-code-handoff](https://github.com/quantsquirrel/claude-code-handoff)** | Session handoff skill preserving context across sessions with failed approaches tracking, handoff chain, secret detection, quality validation, and Korean support |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |


### PR DESCRIPTION
## Summary

Adding [claude-handoff](https://github.com/quantsquirrel/claude-handoff) to the Individual Skills table.

## About the Skill

A session handoff skill for Claude Code that preserves context across sessions:

| Feature | Description |
|---------|-------------|
| **Failed Approaches** | Track what didn't work to avoid repeating mistakes |
| **Handoff Chain** | Link sessions for project history tracking |
| **Secret Detection** | Prevent credential leaks with pattern matching |
| **Quality Validation** | 0-100 scoring system for handoff completeness |
| **Korean Support** | Unique multilingual clipboard prompt |
| **Clipboard Auto-copy** | Seamless session continuation |
| **Compact Recovery** | Auto-draft at 70% context usage (v1.3.0) |

## Installation

```bash
/plugin marketplace add quantsquirrel/claude-handoff
```

---

🤖 Generated with [Claude Code](https://claude.ai/code)