### PR TITLE
Add shadcn-skills to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[shadcn-skills](https://github.com/mattbx/shadcn-skills)** | Discover 1,500+ shadcn components before building custom + review components against shadcn patterns and theme styles (Vega, Nova, Maia, Lyra, Mira) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adding [shadcn-skills](https://github.com/mattbx/shadcn-skills) - a collection of two skills for building better shadcn/ui applications:

1. **shadcn-component-discovery** - Search 1,500+ existing shadcn components before building custom
2. **shadcn-component-review** - Review components against shadcn patterns and theme styles (Vega, Nova, Maia, Lyra, Mira)

## Why this is useful

AI agents almost always try to build UI components from scratch, even when production-ready versions exist in the shadcn ecosystem. These skills teach agents to:
- Search first, build second
- Follow shadcn design patterns and theme conventions
- Use proper spacing, tokens, and structure

## Skill details

- **Repo:** https://github.com/mattbx/shadcn-skills
- **Install:** `/plugin marketplace add mattbx/shadcn-skills`
- **License:** MIT