### PR TITLE
Add claude-session-index skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[claude-session-index](https://github.com/lee-fuhr/claude-session-index)** | Index, search, and analyze Claude Code sessions with full-text search across thousands of sessions and resume links |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adding [claude-session-index](https://github.com/lee-fuhr/claude-session-index) to the Individual Skills table under Community Skills.

- **Name:** claude-session-index
- **Author:** [Lee Fuhr](https://github.com/lee-fuhr)
- **Description:** Index, search, and analyze Claude Code sessions with full-text search across thousands of sessions and resume links
- **License:** MIT

## What it does

Indexes Claude Code's JSONL session files into a local SQLite FTS5 database for instant full-text search. Returns conversation snippets with `claude --resume` links. Zero dependencies. Installable as a skill via `npx skills add lee-fuhr/claude-session-index` or as a standalone CLI via `pip install claude-session-index`.

The skill includes both a SKILL.md and supporting Python scripts -- it is more than a single SKILL.md file. It provides standalone value with no commercial dependencies.

## Placement

Added as a new row at the end of the Individual Skills table.