### PR TITLE
Add manus skill for delegating tasks to Manus AI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[manus](https://github.com/sanjay3290/ai-skills/tree/main/skills/manus)** | Delegate complex tasks to Manus AI agent for deep research, market analysis, product comparisons, stock analysis, and report generation |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [manus](https://github.com/sanjay3290/ai-skills/tree/main/skills/manus) skill to the Individual Skills table.

**About Manus:**
- Deep research with parallel processing
- Market analysis, competitive landscaping
- Stock/financial analysis with charts
- Comprehensive report generation