### PR TITLE
Add skillify skill for context-saving extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills for working with complex file formats:
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
+| **[skillify](https://github.com/kevnk/skillify)** | Save context window by extracting verbose sections from large files (CLAUDE.md, commands, agents) into on-demand skills, plus amplify terse instructions via research |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 
 _More community skills coming soon! Submit a PR to add your skill._


### PR DESCRIPTION
## Add skillify skill

Adds [skillify](https://github.com/kevnk/skillify) to the Individual Skills table.

### What it does

**Skillify** saves context window by extracting verbose sections from large files (CLAUDE.md, AGENTS.md, commands, agents) into on-demand skills that load only when needed. It also amplifies terse "use X" instructions into comprehensive guidance via web research.

### Key features

- **6-step extraction workflow** with task tracking
- **Parallel research agents** for amplification  
- **Bundled reference guides** (6 markdown files) for decision-making
- **Summary reports** with context reduction metrics

### Why it's valuable

Large instruction files consume context window space every time Claude loads them. Skillify addresses this by:
1. Extracting verbose sections (>30 lines) into focused skills that load on-demand
2. Turning brief "use Chrome DevTools MCP" mentions into comprehensive guidance
3. Keeping original files lean with skill references

### Social proof note

I understand the 10-star requirement. This PR is submitted for when the skill reaches that threshold. The repo includes a proper `marketplace.json` for plugin installation and comprehensive documentation.

### Checklist

- [x] Skill has clear purpose and use case
- [x] Includes documentation (README + SKILL.md)
- [x] Follows Claude Skills best practices
- [x] Contains more than just a single SKILL.md (6 bundled references)
- [x] MIT licensed