### PR TITLE
Add harmonyos-build-deploy skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[harmonyos-build-deploy](https://github.com/supermanaaaa/harmonyos-build-deploy)** | HarmonyOS/鸿蒙 app build, sign, deploy to real devices, and APP packaging for AppGallery submission |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Description

Add HarmonyOS build and deploy skill for Claude Code.

## Skill Details

- **Name**: harmonyos-build-deploy
- **Repository**: https://github.com/supermanaaaa/harmonyos-build-deploy
- **npm Package**: https://www.npmjs.com/package/harmonyos-deploy (v2.3.1)
- **License**: MIT

## Features

- One-command build and deploy for HarmonyOS/鸿蒙 apps
- Multi-module project support with automatic dependency resolution
- Product variants and build modes (debug/release/test)
- APP packaging for AppGallery submission (--app flag)
- Real-time device log streaming
- Skip-build safety checks
- Zero external dependencies

## Tested

- ✅ Tested with Claude Code on Windows and macOS
- ✅ Published to npm with 70+ downloads
- ✅ Used in production Jenkins CI/CD pipelines