### PR TITLE
Add Ditto product research and product marketing skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[ditto-product-research-skill](https://github.com/Ask-Ditto/ditto-product-research-skill)** | Run synthetic customer research via Ditto API - pain discovery, concept validation, pricing tests, competitive analysis with 300K+ AI personas |
+| **[ditto-product-marketing](https://github.com/Ask-Ditto/ditto-product-marketing)** | PMM research skill - positioning validation, messaging testing, competitive intelligence, pricing, GTM, launches, buyer personas, and brand tracking |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Adding two Ditto skills to Individual Skills

### Skills added

| Skill | Description |
| --- | --- |
| **[ditto-product-research-skill](https://github.com/Ask-Ditto/ditto-product-research-skill)** | Run synthetic customer research via Ditto API - pain discovery, concept validation, pricing tests, competitive analysis with 300K+ AI personas |
| **[ditto-product-marketing](https://github.com/Ask-Ditto/ditto-product-marketing)** | PMM research skill - positioning validation, messaging testing, competitive intelligence, pricing, GTM, launches, buyer personas, and brand tracking |

### What these skills do

Both skills connect Claude Code to [Ditto](https://askditto.io) for synthetic market research using 300,000+ AI-powered personas calibrated to census data (EY validated at 92% correlation with traditional focus groups).

**Product Research** (6 files, 1,266 lines): General customer research including pain discovery, concept validation, pricing, competitive analysis, and startup diligence. Includes API reference, question playbook, and worked examples.

**Product Marketing** (5 files, 867 lines): PMM-specific workflows with 8 study types, each with a proven 7-question framework. Includes study templates, deliverable mapping, and a 3-phase worked example.

Both have SKILL.md with proper YAML frontmatter and follow the Agent Skills standard.

### Submission checklist

- [x] Clear name and repository link
- [x] 1-2 sentence description
- [x] SKILL.md with YAML frontmatter in both repos
- [x] Functional and tested
- [x] Provides substantial value (multi-file packages)
- [x] MIT licensed

### Note on stars

These are recently published skills from the Ditto team. The product research skill has been in production use across multiple organisations.