### PR TITLE
Add AgentStore plugin marketplace tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[techgangboss/agentstore](https://github.com/techgangboss/agentstore)** - Open-source marketplace for Claude Code plugins and agents. Install plugins with `agentstore install`, or publish your own with a 3-field API call. Gasless USDC payments via x402.
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
## Summary

- Adds [AgentStore](https://github.com/techgangboss/agentstore) to the Tools section
- AgentStore is an open-source marketplace for discovering, installing, and publishing Claude Code plugins
- Gasless USDC payments via the x402 protocol; publishers earn 80% of sales
- CLI and web interface for browsing and installing plugins

## Why it fits the Tools section

AgentStore is a tool for managing and distributing skills/plugins, similar to how Skill_Seekers converts docs into skills. AgentStore provides the distribution layer -- install plugins via `agentstore install` or publish with a 3-field API call.

## Test plan

- [ ] Verify formatting matches existing Tools entries
- [ ] Confirm link resolves to the correct repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)