### PR TITLE
Add notebooklm skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills for working with complex file formats:
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
+| **[notebooklm](https://github.com/sanjay3290/ai-skills/tree/main/skills/notebooklm)** | Query and manage Google NotebookLM notebooks with persistent auth, batch/multi queries, source sync, and structured exports |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 
 _More community skills coming soon! Submit a PR to add your skill._


### PR DESCRIPTION
Adds [notebooklm](https://github.com/sanjay3290/ai-skills/tree/main/skills/notebooklm) to the **Individual Skills** table.

Query and manage Google NotebookLM notebooks with persistent profile auth, batch/multi queries, source sync, and structured markdown/JSON exports.

**Features:**
- Single, batch, and cross-notebook comparison queries
- Remote notebook and source management (create, add, sync, delete)
- Hash-based dedupe for file uploads
- `--dry-run` on all destructive operations
- Persistent Chrome profiles for auth