### PR TITLE
Add Raysurfer Code Caching Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills for working with complex file formats:
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[raysurfer-code-caching-skill](https://github.com/rayxc-org/raysurfer-code-caching-skill)** | LLM output caching skill for Claude Code. Searches cache before coding, uploads after success. Retrieves cached outputs up to 30x faster. |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |


### PR DESCRIPTION
## What this adds

Adds [raysurfer-code-caching-skill](https://github.com/rayxc-org/raysurfer-code-caching-skill) to the **Individual Skills** table in the Community Skills section.

## What it does

An LLM output caching skill for Claude Code that:
- Automatically searches a shared cache before generating new code
- Uploads successful code outputs after task completion
- Retrieves cached outputs up to 30x faster than regenerating them

## Real-world use case

Developers using Claude Code often regenerate the same boilerplate and patterns across sessions. This skill eliminates that redundancy by caching and reusing prior outputs, reducing latency and token usage for repeated tasks.

## Placement

Added as a row in the Individual Skills table, following the existing table format.