### PR TITLE
Add perf-audit to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[perf-audit](https://github.com/Faresabdelghany/Perf-audit-skill)** | Comprehensive performance auditing for Next.js apps — Lighthouse scores, Core Web Vitals (FCP, LCP, CLS, TTFB), bundle analysis, interaction timing, and regression detection |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds **perf-audit** to the Community Skills > Individual Skills table
- Comprehensive performance auditing skill for Next.js applications

## What perf-audit does

- Measures FCP, LCP, CLS, TTFB across all pages (public + authenticated)
- Runs Lighthouse audits (Performance, Accessibility, Best Practices, SEO)
- Analyzes bundle size (top chunks, total JS)
- Tests UI interaction timing
- Detects regressions against previous runs
- Suggests specific fixes for failing metrics

## Links

- Repository: https://github.com/Faresabdelghany/Perf-audit-skill
- Also submitted to [anthropics/skills](https://github.com/anthropics/skills/pull/357)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>