### PR TITLE
Add academic-manuscript-skill to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[academic-manuscript-skill](https://github.com/kchemorion/academic-manuscript-skill)** | Generate publication-ready scientific manuscripts (.docx) with real CrossRef references, Zotero-compatible field codes, and journal formatting (Nature, Cell, Lancet, PLOS, IEEE) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds [academic-manuscript-skill](https://github.com/kchemorion/academic-manuscript-skill) to the community skills table

## What it does

Generates publication-ready scientific manuscripts (.docx) with:
- Real citation metadata from CrossRef API
- Zotero/Mendeley-compatible Word field codes (citations highlight grey on click)
- Multi-journal formatting (Nature, Cell, Lancet, PLOS ONE, IEEE)
- Vancouver, APA, and Nature citation styles

No similar skill exists for academic writing with reference manager integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)