### PR TITLE
Add Product-Manager-Skills to community skills table

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills)** | Product management skills library with frameworks for discovery, prioritization, PRDs, roadmap planning, and SaaS metrics |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
This PR adds `deanpeters/Product-Manager-Skills` to the Community Skills table.

Why this belongs:
- +40 PM-focused skills collection covering problem framing, discovery, opportunity selection,roadmaps, PRDs, prototypes, story splitting, and SaaS metrics.
- Public repo with active usage and social proof (21 stars as of Feb 11, 2026)
- Non-commercial, standalone value for Claude/Codex users