### PR TITLE
Add ui-ux-design and formcarry skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[ui-ux-design](https://github.com/hicay/claude-code-skills/tree/main/ui-ux-design)** | Design and redesign interfaces using Dieter Rams' 10 principles — includes design tokens, component library (SwiftUI/React/CSS), and 60+ point review checklist |
+| **[formcarry](https://github.com/hicay/claude-code-skills/tree/main/formcarry)** | Build and deploy forms without a backend using Formcarry — 16 framework examples (React, Vue, Next.js, Astro), spam protection, file uploads, and full API reference |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds two skills from [hicay/claude-code-skills](https://github.com/hicay/claude-code-skills) to the Individual Skills table:

- **ui-ux-design** — Design and redesign interfaces using Dieter Rams' 10 principles. Includes a complete design system (8pt grid, typography scale, achromatic palette), 15-component library with SwiftUI/React/CSS code, and a 60+ point review checklist.

- **formcarry** — Build and deploy forms without writing backend code using Formcarry. Includes 16 complete framework examples (HTML, React, Vue, Next.js, Astro, etc.), spam protection patterns, file uploads, and full REST API reference.

Both skills follow the Anthropic skill format with progressive disclosure (SKILL.md + references/).