### PR TITLE
Add Skill Quality Standards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,33 @@ A: For skills from git repositories, pull the latest changes. For manually insta
 
 </details>
 
+## Skill Quality Standards
+
+High-quality skills are easier to discover, more efficient with tokens, and more reliable in production. The guidelines below synthesize the [AgentSkills.io open specification](https://agentskills.io) and [Anthropic's best practices](https://platform.claude.com/docs/en/skills/best-practices) into an actionable checklist.
+
+### Quality Checklist
+
+- [ ] **Description**: Written in third person, states _what_ the skill does and _when_ to use it (e.g., "Generates PDF reports when the user requests document exports")
+- [ ] **Progressive disclosure**: Three layers — frontmatter (~100 tokens), full SKILL.md (<5k tokens), bundled resources (loaded on demand)
+- [ ] **Under 500 lines**: SKILL.md stays concise; move large reference material into `resources/`
+- [ ] **No absolute paths**: Use relative paths or environment variables so the skill works on any machine
+- [ ] **Scoped tools**: Only request the tool permissions the skill actually needs (least privilege)
+
+### Common Anti-Patterns
+
+| Anti-Pattern | Why It Hurts | Fix |
+|---|---|---|
+| Vague description ("A helpful skill") | Claude cannot match the skill to the right task | Be specific: what it does, when to use it |
+| Monolithic SKILL.md (>1k lines) | Wastes context window even when only metadata is needed | Split into frontmatter + instructions + resources |
+| Hardcoded Windows/macOS paths | Breaks portability across operating systems | Use relative paths or `$HOME` / `~` |
+| First/second person instructions ("You should…") | Inconsistent with Claude's own phrasing conventions | Write in third person or imperative mood |
+
+### Reference Links
+
+- [AgentSkills.io Specification](https://agentskills.io) — Canonical open standard for portable agent skills
+- [Anthropic Best Practices](https://platform.claude.com/docs/en/skills/best-practices) — Official guidance on skill design and testing
+- [anthropics/skills](https://github.com/anthropics/skills) — Reference implementations of official skills
+
 ## 🤝 Contributing
 
 Contributions welcome! See [contribution guidelines](CONTRIBUTING.md) for details. To add a skill or resource: fork, add to appropriate section, submit PR.


### PR DESCRIPTION
## Summary

- Adds a **Skill Quality Standards** section to the README with a concise quality checklist covering description quality, progressive disclosure, file size, path portability, and scoped tool permissions
- Includes a table of common anti-patterns (vague descriptions, monolithic SKILL.md, hardcoded paths, wrong narrative voice) with fixes
- Links to authoritative references: [AgentSkills.io](https://agentskills.io) open specification, [Anthropic best practices](https://platform.claude.com/docs/en/skills/best-practices), and the [anthropics/skills](https://github.com/anthropics/skills) official repo

## Motivation

The awesome list already has great sections on security, getting started, and creating skills. However, there is no consolidated guidance on what makes a skill _high quality_ from a discoverability and token-efficiency standpoint. This section gives skill authors a quick, actionable checklist they can reference before publishing.

## Test plan

- [x] Verified the new section renders correctly in Markdown
- [x] Placed before the Contributing section, consistent with README structure
- [x] All external links verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)