### PR TITLE
Add QASkills.sh - Curated QA testing skills directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[QASkills.sh](https://qaskills.sh)** - Curated directory of 20+ QA testing skills for Claude Code and 27+ AI agents
+  - Covers E2E (Playwright, Cypress, Selenium), API (REST Assured, Postman), performance (k6, JMeter), security (OWASP), and more
+  - Easy CLI installation: `npx @qaskills/cli add <skill-name>`
+  - [GitHub repository](https://github.com/PramodDutta/qaskills) | [npm package](https://www.npmjs.com/package/@qaskills/cli)
+  - Built by [The Testing Academy](https://youtube.com/@TheTestingAcademy) (189K+ subscribers)
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## Summary

Adding QASkills.sh to the Collections & Libraries section - a comprehensive directory of QA testing skills for Claude Code and AI agents.

## About QASkills.sh

- **20+ curated QA skills** covering all testing types:
  - E2E: Playwright, Cypress, Selenium
  - API: REST Assured, Postman, Playwright API
  - Unit: Jest, Pytest, Vitest
  - Performance: k6, JMeter, Locust
  - Security: OWASP, penetration testing
  - Accessibility: WCAG, axe-core
  - Visual regression, Contract testing (Pact), BDD (Cucumber)
- **27+ AI agents supported**: Claude Code, Cursor, Copilot, Windsurf, Cline, Cody, Aider, and more
- **Easy CLI installation**: `npx @qaskills/cli add <skill-name>`
- **Quality scored**: All skills rated on a 100-point scale
- **Open source, MIT licensed**
- **Built by The Testing Academy** (189K+ YouTube subscribers)

## Why This Belongs Here

QASkills.sh fits perfectly in the Collections & Libraries section as it provides a curated collection of QA testing patterns specifically designed for Claude Code and AI agents - similar to how superpowers provides core skills for various development tasks.

## Example Usage

```bash
# Search for testing skills
npx @qaskills/cli search "playwright"

# Install a skill
npx @qaskills/cli add playwright-e2e

# List installed skills
npx @qaskills/cli list
```

## Links

- Website: https://qaskills.sh
- GitHub: https://github.com/PramodDutta/qaskills
- npm: https://npmjs.com/package/@qaskills/cli
- Skills Directory: https://qaskills.sh/skills

Thank you for maintaining this excellent resource!