### PR TITLE
Add elevenlabs text-to-speech and podcast skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[elevenlabs](https://github.com/sanjay3290/ai-skills/tree/main/skills/elevenlabs)** | Text-to-speech narration and two-host podcast generation from documents (PDF, DOCX, MD, TXT) using ElevenLabs API |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skill: elevenlabs

Adding [elevenlabs](https://github.com/sanjay3290/ai-skills/tree/main/skills/elevenlabs) to the **Individual Skills** table.

### What it does
- **Single-voice narration**: Convert documents (PDF, DOCX, MD, TXT) to spoken audio using ElevenLabs TTS API
- **Two-host podcast**: Generate conversational podcasts from documents with two distinct AI voices
- Sentence-aware text chunking with voice continuity across chunks
- ffmpeg-based audio concatenation

### Category
Individual Skills table