### PR TITLE
 Add claude-agent-tos-guardian: TOS compliance skill for autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[claude-agent-tos-guardian](https://github.com/cdtodosi-bit/claude-agent-tos-guardian)** | TOS compliance skill for autonomous agents — enforces Anthropic Consumer TOS rules covering human-in-the-loop auth, sanctioned access methods, rate limits, content policy, data privacy, and audit logging. Includes self-check script and graceful degradation. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding claude-agent-tos-guardian to the community skills list.

**What it does:** TOS compliance skill that enforces Anthropic's Consumer Terms of Service for autonomous AI agents. 8 rules covering human-in-the-loop authentication, sanctioned access methods, rate limits, AUP content checks, data privacy, account integrity, graceful degradation, and audit logging.

**Why it matters:** Agents running on remote infrastructure don't inherently know TOS boundaries. This is the first compliance/governance skill in the ecosystem. Helps operators stay legal and reduces enforcement burden.

Repo: https://github.com/cdtodosi-bit/claude-agent-tos-guardian
Independent project, not affiliated with Anthropic.