### PR TITLE
Add Pear — iCloud Calendar, Reminders & Contacts skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Skills for working with complex file formats:
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 
+| **[pear](https://github.com/AshtonAU/pear-plugin)** | iCloud Calendar, Reminders & Contacts integration. 27 MCP tools via CalDAV/CardDAV for managing events, scheduling, contacts, and daily briefings. Cross-platform — no macOS required. |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
Adds [Pear](https://github.com/AshtonAU/pear-plugin) to the Individual Skills section.

**What it does:** iCloud Calendar, Reminders & Contacts integration via 27 MCP tools. Uses CalDAV/CardDAV protocols — works cross-platform (no macOS required).

**Features:**
- 8 calendar tools (CRUD events, find free slots, check availability)
- 4 reminder tools (CRUD with priorities and due dates)
- 9 contact tools (CRUD, groups, photo management, search)
- Daily briefing with contact-enriched attendees
- AI-scored optimal meeting time scheduling
- Batch operations (up to 50 items per call)

**Repo:** https://github.com/AshtonAU/pear-plugin
**Homepage:** https://pearmcp.com