### PR TITLE
Add ShieldCortex — persistent memory & security for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[shieldcortex](https://github.com/Drakon-Systems-Ltd/ShieldCortex/tree/main/skills/shieldcortex)** | Persistent memory with knowledge graphs, decay, contradiction detection, and a 6-layer defence pipeline against memory poisoning. MCP server with 19 tools |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [ShieldCortex](https://github.com/Drakon-Systems-Ltd/ShieldCortex) to the **Individual Skills** table.

ShieldCortex gives AI agents persistent memory with knowledge graphs, decay-based forgetting, contradiction detection, and a 6-layer defence pipeline that blocks memory poisoning attacks.

- **npm:** [shieldcortex](https://www.npmjs.com/package/shieldcortex) (2,300+ downloads)
- **License:** MIT
- **MCP server** with 19 tools for memory, knowledge graph, security, and audit
- **Skill:** [skills/shieldcortex/SKILL.md](https://github.com/Drakon-Systems-Ltd/ShieldCortex/tree/main/skills/shieldcortex)