### PR TITLE
Add learn skill for skill discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[learn](https://agentskill.sh/learn)** - Discover and install 44k+ skills for Claude Code, Cursor, Codex with two-layer security scanning
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
## Summary

Adds the `/learn` skill from [agentskill.sh](https://agentskill.sh) to the Tools section.

## What it does

- Search across 44k+ skills for Claude Code, Cursor, Codex
- Two-layer security scanning (server-side + client-side)
- One-command installation: `/learn @owner/skill-name`

## Links

- [Browse skills](https://agentskill.sh)
- [/learn skill](https://agentskill.sh/learn)
- [Security dashboard](https://agentskill.sh/security)