### PR TITLE
Add claude-pipe to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Skills for working with complex file formats:
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 
+| **[claude-pipe](https://github.com/bluzir/claude-pipe)** | Pipeline conventions for Claude Code: file-based YAML state, flat orchestration, data layer contracts, and resume-from-failure. Ships with research and batch classifier examples |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
Adding [claude-pipe](https://github.com/bluzir/claude-pipe) to the Individual Skills table.

**When I need multi-step Claude Code pipelines that don't fall apart mid-run.** State persists to YAML files. ROOT orchestrates flat — no nested spawns. You can resume from the exact failure point instead of starting over.

Ships with research pipeline and batch classifier examples.