### PR TITLE
Add claude-cortex / ShieldCortex

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[claude-cortex / ShieldCortex](https://github.com/mkdelta221/claude-cortex)** | Brain-like persistent memory with temporal decay, knowledge graphs, and a 6-layer defence pipeline that blocks memory poisoning attacks. Works with Claude Code, Cursor, and VS Code. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding claude-cortex (now ShieldCortex) to the individual skills table.

Persistent memory system for Claude Code with knowledge graphs and security scanning. Been around since late January 2026, 46 stars on the original repo.

- GitHub: https://github.com/mkdelta221/claude-cortex (46 ⭐)
- npm: shieldcortex (2,300+ downloads)
- License: MIT
- Not a SaaS wrapper — runs entirely locally, free forever

Resubmitting after the previous PR was closed for not meeting the star threshold. This repo has 46 stars.

I've read the contribution guidelines and acknowledge the social proof and AI submission requirements.