### PR TITLE
Add claude-cortex / ShieldCortex

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[claude-cortex / ShieldCortex](https://github.com/mkdelta221/claude-cortex)** | Brain-like persistent memory with temporal decay, knowledge graphs, and a 6-layer defence pipeline that blocks memory poisoning attacks. Works with Claude Code, Cursor, and VS Code. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Hey Travis — adding claude-cortex (now ShieldCortex) to the individual skills list.

Persistent memory for Claude Code with knowledge graphs and security scanning. Been building it since January, 46 stars on the repo.

- Repo: https://github.com/mkdelta221/claude-cortex (46 stars)
- npm: shieldcortex (2,300+ downloads)
- MIT licensed, runs fully local
- Not a SaaS wrapper — no paid API required, everything works offline

I saw the contribution guidelines about social proof and AI submissions. This is a genuine project I use daily — happy to answer any questions about it.

Cheers