### PR TITLE
Add oiloil-ui-ux-guide skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills for working with complex file formats:
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
+| **[oiloil-ui-ux-guide](https://github.com/oil-oil/oiloil-ui-ux-guide)** | Modern UI/UX guidance and review skill. Two modes: `guide` for actionable do/don't rules, `review` for prioritized P0/P1/P2 fix lists. Covers CRAP, task-first UX, HCI laws, and interaction psychology. |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 
 _More community skills coming soon! Submit a PR to add your skill._


### PR DESCRIPTION
Adds [oiloil-ui-ux-guide](https://github.com/oil-oil/oiloil-ui-ux-guide) — a modern UI/UX guidance and review skill.

**What it does:**
- `guide` mode: actionable do/don't rules for modern clean UI/UX
- `review` mode: prioritized P0/P1/P2 fix lists with design psychology diagnosis

**Covers:** CRAP, task-first UX, cognitive load, HCI laws (Fitts/Hick/Miller), interaction psychology, and modern minimal style.

Installable via `npx skills add oil-oil/oiloil-ui-ux-guide`.