### PR TITLE
Add skill: wondelai/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Skills for working with complex file formats:
   - Install from `superpowers-marketplace` plugin
 
 
+
+- **[wondelai/skills](https://github.com/wondelai/skills)** - 25 business skills for UX, marketing, sales, and strategy
+
 ### Individual Skills
 
 > These will be broken down into categories once there are enough community skills available to list


### PR DESCRIPTION
## What's being added
[wondelai/skills](https://github.com/wondelai/skills) — 25 agent skills covering UX design (Refactoring UI, iOS HIG, web typography), marketing/CRO (StoryBrand, Scorecard Marketing), sales psychology (Cialdini's Influence, $100M Offers), product innovation (Lean Startup, Design Sprint), and business strategy (Blue Ocean, Crossing the Chasm, EOS/Traction).

## Installation
```bash
npx skills add wondelai/skills
```

## License
MIT