### PR TITLE
Add PM Skills — 24 product management skills library

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills)** - 24 product management skills covering the full PM lifecycle from discovery to delivery, following the [agentskills.io](https://agentskills.io/specification) specification
+  - Organized across 6 Triple Diamond phases with templates and workflow bundles
+  - [pm-skills-mcp](https://github.com/product-on-purpose/pm-skills-mcp) - MCP server for instant access to all 24 skills
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## What

Adds [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) to the
**Community Skills > Collections & Libraries** section.

## Why

- **24 production-ready PM skills** covering discovery, definition, design, development,
  delivery, and iteration — the only product-management-focused skills library in the list
- Follows the open [agentskills.io specification](https://agentskills.io/specification)
  with proper SKILL.md frontmatter, progressive disclosure, and bundled resources
- Includes templates, workflow bundles, and a companion
  [MCP server](https://github.com/product-on-purpose/pm-skills-mcp)
- Apache 2.0 licensed, actively maintained (v2.3.0)

## Details

- **Repository**: https://github.com/product-on-purpose/pm-skills
- **License**: Apache 2.0
- **Skills count**: 24
- **Section**: Collections & Libraries (parallel to obra/superpowers)