### PR TITLE
Add Apple HIG Skills to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Skills for working with complex file formats:
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 
+| **[apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills)** | Apple Human Interface Guidelines as 14 agent skills covering platforms, foundations, components, patterns, inputs, and technologies for iOS, macOS, visionOS, watchOS, and tvOS |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
Adds [apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills) — 14 agent skills providing Apple Human Interface Guidelines for iOS, macOS, visionOS, watchOS, and tvOS design decisions.

Covers platforms, foundations, components (layout, controls, dialogs, menus, search, status, system, content), patterns, inputs, and technologies. Built on the agentskills.io spec.