### PR TITLE
Add skill: CosmoBlk/email-marketing-bible

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[email-marketing-bible](https://github.com/CosmoBlk/email-marketing-bible)** | 55K-word data-backed email marketing guide as a Claude skill — audits, sequences, benchmarks, 908 sources |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds [CosmoBlk/email-marketing-bible](https://github.com/CosmoBlk/email-marketing-bible) to the Community Skills — Individual Skills table.

## About the skill

The Email Marketing Bible is a 55,000-word, data-backed email marketing guide (908 sources, 16 chapters) packaged as a Claude Code skill. Install it with one command and Claude becomes an email marketing co-pilot — audits setups, drafts sequences, pulls industry benchmarks, and gives sourced recommendations.

- **Install:** `claude install-skill https://github.com/CosmoBlk/email-marketing-bible`
- **Website:** https://emailmarketingskill.com
- **License:** MIT