### PR TITLE
Add Deep Thinking Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[Deep Thinking Skills](https://github.com/amankr-novo/deep-thinking)** | Deep-reasoning framework for complex tasks. Auto-applies to multi-step problems, ambiguous requirements, architecture, debugging, and anything needing careful analysis. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Add Deep Thinking skill

This PR adds the **Deep Thinking** community skill to the Awesome Claude Skills list. The skill provides a structured, deep reasoning framework for complex, multi-step tasks, with a clear protocol for problem decomposition, hypothesis generation, verification, and knowledge synthesis. [github](https://github.com/amankr-novo/deep-thinking)

Why is this skill valuable?  
- Offers a reusable reasoning protocol inspired by Claude God Mode, emphasising careful analysis over superficial answers for complex scenarios such as architecture decisions, debugging, and multi-system investigations. 
- Provides a clearly documented framework via `README.md`, `SKILL.md`, and `reference.md`, making it easy for others to adopt and adapt the thinking patterns in their own workflows. 