### PR TITLE
Add oh-my-claude statusline framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Skills for working with complex file formats:
 
 _More community skills coming soon! Submit a PR to add your skill._
 
+### Statusline
+
+- **[npow/oh-my-claude](https://github.com/npow/oh-my-claude)** - Like oh-my-zsh but for Claude Code. Extensible statusline framework with themes (tamagotchi, boss-battle, RPG, narrator, and more), dozens of mix-and-match segments, and a plugin system. Zero npm dependencies.
+
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills


### PR DESCRIPTION
Adds [oh-my-claude](https://github.com/npow/oh-my-claude) to the Tools section.

**oh-my-claude** is like oh-my-zsh but for Claude Code — an extensible statusline framework with themes, dozens of mix-and-match segments, and a plugin system for custom segments. Zero npm dependencies.

### Themes

**tamagotchi** — virtual pet, growing garden, draining coffee
![tamagotchi](https://raw.githubusercontent.com/npow/oh-my-claude/main/screenshots/tamagotchi.png)

**boss-battle** — dungeon crawl with weather and battle music
![boss-battle](https://raw.githubusercontent.com/npow/oh-my-claude/main/screenshots/boss-battle.png)

**rpg** — D&D character sheet, speedrun timer, cat companion
![rpg](https://raw.githubusercontent.com/npow/oh-my-claude/main/screenshots/rpg-developer.png)

**danger-zone** — 3 hours in, $18 spent, everything on fire
![danger-zone](https://raw.githubusercontent.com/npow/oh-my-claude/main/screenshots/danger-zone.png)

**narrator** — third-person text adventure with vibes
![narrator](https://raw.githubusercontent.com/npow/oh-my-claude/main/screenshots/narrator.png)

**coworker** — fake Slack messages and fortune cookie wisdom
![coworker](https://raw.githubusercontent.com/npow/oh-my-claude/main/screenshots/coworker.png)