### PR TITLE
Add the-council: multi-model advisory board skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[the-council](https://github.com/DantesPeak85/the-council)** | Multi-model advisory board — invokes Codex and Gemini CLIs in parallel for second opinions on code reviews, architecture, and debugging |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [the-council](https://github.com/DantesPeak85/the-council) to the Individual Skills table.

**What it does:** Invokes OpenAI Codex CLI and Google Gemini CLI in parallel as an advisory board for code reviews, architecture evaluation, debugging, and general engineering decisions. Both advisors run in read-only sandboxes with full codebase access, and Claude synthesizes their responses into a unified recommendation.

**Key features:**
- Parallel CLI invocation with read-only sandboxes
- Startup preflight check with graceful single-advisor degradation
- Prompt templates for code review, architecture, debugging, and general advisory
- Session-cached CLI detection (no repeated checks)