### PR TITLE
Add jolt-atlas zkML skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[jolt-atlas](https://github.com/hshadab/zkmlskill)** | Zero-knowledge machine learning (zkML) — generate cryptographic SNARK proofs of ONNX model inference using the JOLT proving system, with reference docs and Rust templates |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [jolt-atlas](https://github.com/hshadab/zkmlskill) to the Individual Skills table.

**What it does:** A skill for zero-knowledge machine learning (zkML) — teaches Claude how to generate cryptographic SNARK proofs of ONNX model inference using the JOLT proving system from a16z Crypto. Includes YAML frontmatter, reference docs (architecture, supported ONNX ops, troubleshooting), and two Rust templates.

**Source framework:** [ICME-Lab/jolt-atlas](https://github.com/ICME-Lab/jolt-atlas)