### PR TITLE
Add EUrouter Integration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[EUrouter Integration](https://github.com/EUrouter/eurouter-skill)** | Integrate EUrouter, an OpenAI-compatible AI gateway for EU/GDPR compliance. Covers drop-in migration from OpenAI/OpenRouter, EU data residency, streaming, tool calling, and multi-model fallback |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [EUrouter Integration](https://github.com/EUrouter/eurouter-skill) to the Individual Skills table.

EUrouter is an OpenAI-compatible AI gateway for EU/GDPR compliance. This skill covers drop-in migration from OpenAI/OpenRouter, EU data residency, streaming, tool calling, and multi-model fallback.

**Install:** `npx skills add eurouter/eurouter-skill`