### PR TITLE
Add commune skill to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[commune](https://github.com/shanjairaj7/commune-skill)** | Agent-native email inbox — gives any AI agent a permanent `@commune.ai` address with full send/receive, semantic search, triage, and webhooks |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add commune — agent-native email skill

**commune** gives AI agents their own permanent email address at `@commune.ai`, purpose-built for autonomous agents using Claude Code and the Claude API.

### What it does
- Gives any agent a persistent inbox at `orgname@commune.ai`
- Full send/receive via REST API with Ed25519 agent authentication (no human login required)
- Semantic search across emails, smart triage/labeling, and webhook support
- Agentless registration — agents self-register with a public key, no human approval needed

### Added to
**Individual Skills** table (end of list)

### Links
- Skill: https://github.com/shanjairaj7/commune-skill
- Homepage: https://commune.email