### PR TITLE
Add Manifest — cost observability skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills for working with complex file formats:
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
+| **[Manifest](https://github.com/mnfst/manifest)** ([website](https://manifest.build)) | Real-time cost observability for OpenClaw agents — track tokens, costs, messages, and model usage. [Skill](https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md) for guided plugin setup and configuration |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 
 _More community skills coming soon! Submit a PR to add your skill._


### PR DESCRIPTION
## Summary
- Adds [Manifest](https://manifest.build) ([GitHub](https://github.com/mnfst/manifest)) to the list
- Manifest provides a Claude Code skill for installing and configuring cost observability on OpenClaw agents
- Skill: https://github.com/mnfst/manifest/blob/main/skills/manifest/SKILL.md
- 3.3k GitHub stars, MIT licensed

## Why it belongs here
Manifest ships with a dedicated SKILL.md for Claude Code, guiding users through the full setup flow — from plugin installation to API key configuration and verification.