### PR TITLE
Add propel-code-skills to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills for working with complex file formats:
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
+| **[propel-code-skills](https://github.com/propel-gtm/propel-code-skills)** | Propel Review API skills for async diff review, PR comment triage, and continuous fix loops |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 
 _More community skills coming soon! Submit a PR to add your skill._


### PR DESCRIPTION
Adds a new Individual Skills entry for [propel-gtm/propel-code-skills](https://github.com/propel-gtm/propel-code-skills).

Summary:
- Adds one row in the Community Skills table.
- Skill focuses on async diff review via Propel Review API, PR comment triage, and continuous fix loops.

Thanks for considering it.