### PR TITLE
Add b12-website-generator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Skills for working with complex file formats:
 
 > [!Warning]
 > Skills can execute arbitrary code in Claude's environment.
-> 
+>
 > See [Security & Best Practices](#-security--best-practices) for more information
 
 ### Collections & Libraries
@@ -103,27 +103,27 @@ Skills for working with complex file formats:
   - [superpowers-skills](https://github.com/obra/superpowers-skills) - Community-editable skills repository
   - [Blog: Superpowers](https://blog.fsck.com/2025/10/09/superpowers/) - Author's overview by Jesse Vincent
   - Installation: `/plugin marketplace add obra/superpowers-marketplace`
- 
+
 - **[obra/superpowers-lab](https://github.com/obra/superpowers-lab)** - Experimental skills for `Claude Code Superpowers` (see above)
   - Uses new techniques that are still being refined and tested (i.e. skills here may change over time)
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
-
 ### Individual Skills
 
 > These will be broken down into categories once there are enough community skills available to list
 
-| Skill | Description |
-| --- | --- |
-| **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
-| **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
-| **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
-| **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
-| **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
-| **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
-| **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
-| **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| Skill                                                                                  | Description                                                                                                                                               |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)**           | iOS app building, navigation, and testing through automation                                                                                              |
+| **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)**                    | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
+| **[playwright-skill](https://github.com/lackeyjb/playwright-skill)**                   | General-purpose browser automation using Playwright                                                                                                       |
+| **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)**        | Visualizations in d3.js                                                                                                                                   |
+| **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases                         |
+| **[web-asset-generator](https://github.com/alonw0/web-asset-generator)**               | Generates web assets like favicons, app icons, and social media images                                                                                    |
+| **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)**                    | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue    |
+| **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)**             | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection                                     |
+| **[b12-website-generator](https://github.com/b12io/b12-claude-plugin)**                | Generates a website from a business name and description, producing a ready-to-publish B12 site link                                                      |
 
 _More community skills coming soon! Submit a PR to add your skill._
 
@@ -178,12 +178,10 @@ The easiest way to create a skill is to use the built-in `skill-creator`:
    ```
 
 3. **Add executable scripts** (optional):
-
    - Python, JavaScript, or other scripts Claude can execute
    - Reference them in your SKILL.md instructions
 
 4. **Test locally**:
-
    - Install the skill in Claude Code or Claude Desktop
    - Test with relevant tasks
    - Iterate and refine
@@ -240,13 +238,13 @@ The easiest way to create a skill is to use the built-in `skill-creator`:
 
 ### Quick Reference: When to Use What
 
-| Tool | Best For |
-|------|----------|
-| **Skills** | Reusable procedural knowledge across conversations |
-| **Prompts** | One-time instructions and immediate context |
-| **Projects** | Persistent background knowledge within workspaces |
+| Tool          | Best For                                             |
+| ------------- | ---------------------------------------------------- |
+| **Skills**    | Reusable procedural knowledge across conversations   |
+| **Prompts**   | One-time instructions and immediate context          |
+| **Projects**  | Persistent background knowledge within workspaces    |
 | **Subagents** | Independent task execution with specific permissions |
-| **MCP** | Connecting Claude to external data sources |
+| **MCP**       | Connecting Claude to external data sources           |
 
 **Use Skills when**: Capabilities should be accessible to any Claude instance. They're portable expertise.
 
@@ -254,7 +252,7 @@ The easiest way to create a skill is to use the built-in `skill-creator`:
 
 **Combined approach**: Subagents can leverage Skills for specialized expertise, merging independence with portable knowledge.
 
-**Key insight**: *If you find yourself typing the same prompt repeatedly across multiple conversations, it's time to create a Skill.*
+**Key insight**: _If you find yourself typing the same prompt repeatedly across multiple conversations, it's time to create a Skill._
 
 ### Skills vs MCP (Model Context Protocol)
 
@@ -350,7 +348,6 @@ _Video tutorials coming soon! Have a good video about Claude Skills? Submit a PR
 ### Known Issues
 
 - **Linux path bug (Oct 18, 2025)**: Agent SDK uses hardcoded macOS paths instead of environment home directory
-
   - [Issue #268](https://github.com/anthropics/claude-agent-sdk-python/issues/268)
   - Workaround: Manually specify skill paths
 


### PR DESCRIPTION
Adds [b12-website-generator](https://github.com/b12io/b12-claude-plugin) — a skill that takes users from idea to a live website draft in a single conversation, without switching tools.

Collects a business name and description from the user, then generates a pre-populated signup link for an instant B12 site draft. No existing account required. Activated by phrases like "Create a website for my consulting firm."

Website: [https://www.b12.io/](https://www.b12.io/)
License: Apache 2.0
