### PR TITLE
Add community skill: presentation-chef

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills for working with complex file formats:
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[presentation-chef](https://github.com/sacredvoid/presentation-chef)** | Converts any content into cinematic Apple Keynote-style HTML presentations with 5 themes, 13 slide types, speaker notes, and PDF export — single self-contained `.html` file |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |


### PR DESCRIPTION
Adds **[presentation-chef](https://github.com/sacredvoid/presentation-chef)** to the Individual Skills table.

Presentation Chef converts any content into cinematic Apple Keynote-style HTML presentations as a single self-contained `.html` file with zero dependencies. Features 5 theme presets, 13 slide types, speaker notes sidebar (Press T), and PDF export (Press P).

- Repository: https://github.com/sacredvoid/presentation-chef
- License: MIT
- Complete SKILL.md with design system, slide templates, JS engine spec
- Works with Claude Code, Cursor, Windsurf, GitHub Copilot, Cline, and more