### PR TITLE
Add Context Mode — sandbox large outputs, return only summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Skills for working with complex file formats:
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
+| **[context-mode](https://github.com/mksglu/claude-context-mode)** | Process large outputs in sandboxed subprocesses, keeping only summaries in the context window. 98% context savings. |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |


### PR DESCRIPTION
## Context Mode

A Claude Code plugin that processes large outputs in sandboxed subprocesses instead of dumping raw data into the context window.

**Without Context Mode:** 315 KB of raw data burns ~80K tokens per session  
**With Context Mode:** 5.4 KB of clean summaries — same analysis, 98% less context

| Operation | Raw Output | With Context Mode | Savings |
|---|---|---|---|
| Playwright snapshot | 56.2 KB | 299 B | 99% |
| GitHub Issues (20) | 58.9 KB | 1.1 KB | 98% |
| Access log (500 req) | 45.1 KB | 155 B | 100% |
| Git log (153 commits) | 11.6 KB | 107 B | 99% |

## Install

```bash
claude mcp add context-mode -- npx -y context-mode
```

- GitHub: https://github.com/mksglu/claude-context-mode
- npm: https://www.npmjs.com/package/context-mode