### PR TITLE
Add Twitter/X skills (claude-skill-twitter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[claude-skill-twitter](https://github.com/PHY041/claude-skill-twitter)** | 3 Twitter/X skills for account growth, keyword search, and content strategy. Uses rnet to bypass Cloudflare — no API key needed, just browser cookies |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds [claude-skill-twitter](https://github.com/PHY041/claude-skill-twitter) to the Community Skills > Individual Skills table
- 3 skills for Twitter/X: account growth (TweepCred scoring, shadowban check), keyword search (200+ tweets), and content strategy (hook formulas, thread templates)
- Core tech: `rnet_twitter.py` — async GraphQL client using rnet (bypasses Cloudflare TLS fingerprinting)
- No API key needed — uses browser cookies only
- More than just a SKILL.md: includes Python scripts (rnet_twitter.py, async GraphQL client), cookie management, and rate limiting logic

## Test plan

- [ ] Table row format matches existing entries
- [ ] Link resolves to valid GitHub repo
- [ ] Description is concise and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)