### PR TITLE
Add LinkedIn automation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[linkedin-skills](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** | LinkedIn automation via CLI — fetch profiles, search people/companies, send messages, manage connections, create posts, and Sales Navigator |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [Linked-API/linkedin-skills](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin) to the Individual Skills table.

**What it does:** LinkedIn automation via CLI — fetch profiles, search people/companies, send messages, manage connections, create posts, and Sales Navigator.

**Skill format:** Standard SKILL.md  
**Dependency:** `@linkedapi/linkedin-cli` npm package  
**License:** MIT