### PR TITLE
Add BGPT MCP to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[bgpt-mcp](https://github.com/connerlambden/bgpt-mcp)** | Search scientific papers via remote MCP server. Returns structured experimental data from full-text studies: methods, results, sample sizes, quality scores, and 25+ fields per paper. Free tier (50 searches), no API key needed. |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) to the Individual Skills table.

BGPT is a remote MCP server for searching scientific papers that returns structured experimental data from full-text studies — methods, results, sample sizes, quality scores, and 25+ metadata fields per paper. Free tier with 50 searches, no API key needed.

Listed in the [Official MCP Registry](https://registry.modelcontextprotocol.io).