### PR TITLE
Add Silicon Friendly - AI agent-friendliness checker MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 
+- **[Silicon Friendly](https://github.com/unlikefraction/silicon-friendly)** - MCP server that searches and rates websites on AI-agent friendliness using a 30-criteria L0-L5 taxonomy. Check if any site has llms.txt, agent-friendly APIs, or structured data. *By [@unlikefraction](https://github.com/unlikefraction)*
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
 
 ## ✏️ Creating Your First Skill


### PR DESCRIPTION
## Summary
Adding [Silicon Friendly](https://github.com/unlikefraction/silicon-friendly) to the Tools section.

Silicon Friendly is an MCP server + directory that rates websites on AI-agent friendliness using a 30-criteria L0-L5 taxonomy. It's available on the official MCP registry as `com.siliconfriendly/directory`.

**Features:**
- 8 MCP tools for searching and verifying website AI-friendliness
- Checks for llms.txt, agent-friendly APIs, structured data, and more
- L0-L5 scoring scale across 30 criteria
- Website: [siliconfriendly.com](https://siliconfriendly.com)
- SKILL.md: [siliconfriendly.com/.well-known/skill.md](https://siliconfriendly.com/.well-known/skill.md)