### PR TITLE
Add extract-design-soul-website

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Skills for working with complex file formats:
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
+| **[extract-design-soul-website](https://github.com/yigitkonur/extract-design-soul-website)** | Extract the complete visual DNA from any website, landing page, or marketing site codebase. Section-by-section documentation of typography, colors, animations, backgrounds, and responsive behavior. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds extract-design-soul-website — forensic visual DNA extraction for websites, landing pages, and marketing sites. The section-centric sibling of extract-design-soul-dashboard (already listed). Produces pixel-perfect section-by-section documentation of typography, colors, scroll animations, backgrounds, and responsive behavior. GitHub: https://github.com/yigitkonur/extract-design-soul-website