### PR TITLE
Add cybersecurity-claude-skills: web hacking, pentest recon, code review, CTF solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[cybersecurity-claude-skills](https://github.com/mahmutka/cybersecurity-claude-skills)** | 4-skill cybersecurity suite: web hacking (OWASP Top 10, XSS, SQLi, SSRF), pentest recon (OSINT, Nmap, Shodan), secure code review (Python/JS/Go/Java + CWE mapping), and CTF solver (crypto, pwn, rev, forensics) |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 


### PR DESCRIPTION
## New Skill Submission

**Repository:** https://github.com/mahmutka/cybersecurity-claude-skills

A suite of 4 cybersecurity-focused Claude Code skills for penetration testers, security engineers, and CTF competitors.

### Skills Included

| Skill | Description |
|-------|-------------|
| `web-hacking` | OWASP Top 10 (2025), XSS, SQLi, SSRF, WAF bypass techniques, payload crafting |
| `pentest-recon` | OSINT, DNS enum, Shodan, subdomain discovery, Nmap, attack surface mapping |
| `secure-code-review` | Python/JS/Go/Java security patterns, CWE mapping, Semgrep integration, remediation guidance |
| `ctf-solver` | Crypto (RSA attacks, classical ciphers), Web, Pwn (BoF, ROP), Rev (Ghidra, angr), Forensics |

### Checklist
- [x] Skill follows the `skill.md` format with valid YAML frontmatter
- [x] Publicly available on GitHub with MIT license
- [x] Includes ethics/authorization notices
- [x] Release assets (ZIP files) available for direct download
- [x] Placed next to the existing Trail of Bits Security Skills entry