### PR TITLE
Add claude-config to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[claude-config](https://gitlab.com/oldmission/claude-config)** by [Greg Smethells](https://github.com/gsmethells) - Complete skills library for Claude Code with 12 production-ready skills (`/boot`, `/design`, `/review`, `/ship`, `/goal`, and more), automated hooks for linting and test enforcement, and team coding standards. One-command install, automatic updates.
 
 ### Individual Skills
 


### PR DESCRIPTION
## Summary
- Adds [claude-config](https://gitlab.com/oldmission/claude-config) to Collections & Libraries
- 12 production-ready skills (`/boot`, `/design`, `/review`, `/ship`, `/goal`, and more)
- Automated hooks for linting and test enforcement
- Team coding standards with language-specific files (Python, Java, C++, JS, Bash)
- One-command install, automatic updates, three-tier config hierarchy

## Checklist
- [x] Link is working and points to an active project
- [x] Description is concise and accurate
- [x] Placed in the Collections & Libraries section
- [x] Provides standalone value beyond a single SKILL.md file