### PR TITLE
Add AgentWard to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
-| **[AgentWard](https://github.com/agentward-ai/agentward)** | Open-source permission control plane for AI agents — scans, enforces, and audits every tool call in code, not prompts |
+| **[AgentWard](https://github.com/agentward-ai/agentward)** | Open-source runtime & compile-time enforcement layer for AI agents — scans, enforces, and audits every tool call in code, not prompts |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[AgentWard](https://github.com/agentward-ai/agentward)** | Open-source permission control plane for AI agents — scans, enforces, and audits every tool call in code, not prompts |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 


### PR DESCRIPTION
Adds [AgentWard](https://github.com/agentward-ai/agentward) — open-source permission control plane for AI agents.

Scans MCP servers, OpenClaw skills, and Python SDK tools, then enforces least-privilege policies at runtime in code (not prompts). Apache 2.0.

- `pip install agentward`
- [GitHub repo](https://github.com/agentward-ai/agentward)