### PR TITLE
Add apple-bridges: native macOS app access for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[apple-bridges](https://github.com/more-io/claude-apple-bridges)** | Native macOS app access from Claude Code — manage Reminders, Calendar, Contacts, Notes, Mail, and tmux sessions via Swift CLI bridges |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds [apple-bridges](https://github.com/more-io/claude-apple-bridges) to the Individual Skills table
- Swift CLI bridges that give Claude Code native access to Apple apps on macOS: Reminders, Calendar, Contacts, Notes, Mail, and tmux
- Installable as a skill via `npx skills add more-io/claude-apple-bridges --skill apple-bridges`

## What it does

Six CLI bridges (compiled Swift binaries) that let Claude Code interact with native Apple apps:

| Bridge | Purpose |
|--------|---------|
| reminders-bridge | Manage Apple Reminders — lists, items, due dates, search |
| calendar-bridge | Read/write Apple Calendar — events, free slots, scheduling |
| contacts-bridge | Search/manage Apple Contacts — lookup, birthdays |
| notes-bridge | Read/write Apple Notes — create, search, append (with HTML) |
| mail-bridge | Read/send Apple Mail — inbox, unread, compose, attachments |
| tmux-bridge | Read tmux sessions — panes, snapshots for summaries |

🤖 Generated with [Claude Code](https://claude.com/claude-code)