### PR TITLE
feat: add MinerU-Skill — PDF-to-Markdown with LaTeX and Obsidian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[MinerU-Skill](https://github.com/Nebutra/MinerU-Skill)** | PDF-to-Markdown conversion with LaTeX formula preservation, table extraction, 15x parallel batch processing, and direct Obsidian vault output |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skill Submission: MinerU-Skill

**GitHub**: https://github.com/Nebutra/MinerU-Skill
**Category**: Individual Skills

### What it does

Converts PDF documents to clean Markdown using the MinerU VLM engine. Key capabilities:

- **LaTeX formula preservation** — math formulas survive the conversion intact (critical for academic papers, textbooks, exam materials)
- **Table extraction** — structured table content is preserved
- **Batch parallel processing** — 15x concurrent workers; 33 PDFs processed in ~5 minutes
- **Obsidian vault output** — direct path output, making it ideal for knowledge base workflows
- **Resume support** — `--resume` flag skips already-processed files for interrupted batches
- **Free tier** — MinerU API offers 2000 pages/day free

### Usage

Once installed, trigger via natural language:
> "Parse all PDFs in ./papers/ and save to my Obsidian vault"

### Installation

```bash
git clone https://github.com/Nebutra/MinerU-Skill ~/.claude/skills/mineru/
export MINERU_TOKEN="your-token"  # Free from mineru.net
```

### Social proof

- Listed on Smithery skills directory
- Used in production for processing 考研 (Chinese graduate entrance exam) materials — 40+ PDFs converted in one session