### PR TITLE
Add skill: philidor — DeFi vault intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[philidor](https://github.com/zkoranges/philidor-io/tree/main/packages/openclaw-skill)** | DeFi vault intelligence with institutional-grade risk scores, yield comparison, and portfolio analysis across Morpho, Yearn, Aave, Beefy, and Spark |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- **Adds [philidor](https://github.com/zkoranges/philidor-io/tree/main/packages/openclaw-skill)** to the Individual Skills table — a DeFi vault intelligence skill that gives Claude institutional-grade risk analysis, yield comparison, and portfolio monitoring across Morpho, Yearn, Aave, Beefy, and Spark.

## What it does

Philidor equips Claude with real-time DeFi vault data and risk scores so users can:

- **Analyze vault risk** — get a 0–10 risk score broken down across asset composition, platform code quality, and governance vectors
- **Compare yields** — side-by-side APR, TVL, and risk tier comparison across protocols
- **Monitor portfolios** — surface the safest vaults for a given asset, chain, or TVL threshold
- **Research protocols** — pull detailed protocol info including audit history, TVL, and security incidents

## Who uses it

- **DeFi users** evaluating where to allocate capital
- **AI agent builders** integrating on-chain risk intelligence into autonomous workflows
- **Yield analysts** comparing opportunities across lending and vault protocols

## Installation

Published on npm as [`@philidorlabs/cli`](https://www.npmjs.com/package/@philidorlabs/cli). No API key required — the CLI connects to the public Philidor API out of the box.

```bash
npx @philidorlabs/cli
```