### PR TITLE
Add dna-claude-analysis to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Skills for working with complex file formats:
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
+| **[dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis)** | Personal genome analysis toolkit with Python scripts analyzing raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, psychology, etc.) and generating a terminal-style single-page HTML visualization |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |


### PR DESCRIPTION
## Summary

Adds [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the Individual Skills table under Community Skills.

**What it does**: Personal genome analysis toolkit with Python scripts that analyze raw DNA data across 17 categories — including health risks, ancestry, pharmacogenomics, nutrition, sports/fitness, psychology, longevity, sleep, immunity, skin, vision, and more — and generate a terminal-style single-page HTML visualization report.

**Why it belongs here**: It uses Claude Code as the analysis engine and CLAUDE.md-driven workflow, making it a practical example of Claude Skills applied to bioinformatics / personal genomics data.

The entry was placed alphabetically by skill name in the existing table (after `claude-scientific-skills`, before `web-asset-generator`).