### PR TITLE
Add OpenPaw to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills for working with complex file formats:
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
+| **[OpenPaw](https://github.com/daxaur/openpaw)** | Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 built-in skills including Telegram, Discord, Obsidian memory, daily briefings, and more |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |


### PR DESCRIPTION
Adding OpenPaw to the Collections section — it's a setup wizard I built that installs 38 skills for Claude Code. Handles email, calendar, Spotify, smart home, GitHub, plus a Telegram bridge, task dashboard, and scheduling with cost caps. MIT licensed.