### PR TITLE
Add OpenPaw to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[daxaur/openpaw](https://github.com/daxaur/openpaw)** - Personal assistant skill pack for Claude Code with 38 skills across email, calendar, Spotify, smart home, Slack, GitHub, Obsidian, and more
+  - One-command setup via `npx pawmode` — installs skills, CLI tools, and walks through auth
+  - Includes Telegram bridge, task dashboard, and smart scheduling with cost caps
+  - Installation: `npx pawmode`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adds [OpenPaw](https://github.com/daxaur/openpaw) to the Collections & Libraries section.

OpenPaw (`npx pawmode`) is an open-source personal assistant skill pack for Claude Code with 38 skills across email, calendar, Spotify, smart home, Slack, GitHub, Obsidian, and more. One command sets up all the CLI tools, walks through auth, and configures Claude with an identity and persistent memory.

- **GitHub**: https://github.com/daxaur/openpaw
- **npm**: https://www.npmjs.com/package/pawmode
- **License**: MIT
- **Stars**: 200+