### PR TITLE
Add PUIUX Pilot to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 
+- **[PUIUX-Cloud/puiux-pilot](https://github.com/PUIUX-Cloud/puiux-pilot)** - Auto-configures Claude Code hooks, MCPs, and skills for any project. Scans 95+ project types and installs the relevant configuration. Includes quality scoring and cross-tool config translation.
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
 
 ## ✏️ Creating Your First Skill


### PR DESCRIPTION
Adds [PUIUX Pilot](https://github.com/PUIUX-Cloud/puiux-pilot) to the Tools section.

Open-source CLI (Apache 2.0) that auto-configures Claude Code hooks, MCPs, and skills for any project. Scans 95+ project types and selects the appropriate configuration automatically. Also includes quality scoring (0-100, A-F) and cross-tool config translation (CLAUDE.md, .cursorrules, .windsurfrules, copilot).

Install: `npm i -g puiux-pilot`