### PR TITLE
Added android reverse engineering skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[Android Reverse Engineering](https://github.com/SimoneAvogadro/android-reverse-engineering-skill)** | Reverse Engineering skill to decompile/reverse engineer an Android (X)APK and find which APIs it's calling and RE its workflow |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [Android Reverse Engineering skill](https://github.com/SimoneAvogadro/android-reverse-engineering-skill) to the Individual Skills table.

### What it does
Provides a skill to simplify the repetitive decompress/decompile/follow-the-thread-of-APIs activities

### Key features
- Multi-step reverse engineering workflow
- Support for multiple decompile engines
- Bundled with support shell scripts
- Includes specific capability to track API usage and follow-the-thread

### Why it's valuable
Android RE is horribly boring and repetitive, a skill allows to skip/delegate the most routine tasks

### Social proof note
I understand the 10-star requirement (it currently has 104 stars). This PR is submitted for when the skill reaches that threshold. The repo includes a proper marketplace.json for plugin installation and comprehensive documentation.

### Checklist
- [x] Skill has clear purpose and use case
- [x] Includes documentation (README + SKILL.md)
- [x] Follows Claude Skills best practices
- [ ] Contains more than just a single SKILL.md
- [x] APACHE licensed