### PR TITLE
Add Human Pages MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Skills for working with complex file formats:
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
+| **[humanpages](https://github.com/human-pages-ai/humanpages)** | MCP server that gives AI agents access to real-world people who listed themselves to be hired by agents. 31 tools including search by skill/location/equipment, job offers, in-job messaging, and streaming payments |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 
 _More community skills coming soon! Submit a PR to add your skill._


### PR DESCRIPTION
Adds [humanpages](https://github.com/human-pages-ai/humanpages) — MCP server that gives AI agents access to real-world people who listed themselves to be hired by agents. 31 tools including search by skill/location/equipment, job offers, in-job messaging, and streaming payments.

- Website: https://humanpages.ai
- GitHub: https://github.com/human-pages-ai/humanpages