### PR TITLE
Add skill: Digidai/pm-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Skills for working with complex file formats:
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
+| **[pm-agent](https://github.com/Digidai/product-manager-skills)** | AI-native PM agent — PRD, user stories, roadmaps, SaaS metrics, positioning, discovery, career coaching, AI product strategy |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 
 _More community skills coming soon! Submit a PR to add your skill._


### PR DESCRIPTION
## Add PM Agent Skill

- **Skill:** [pm-agent](https://github.com/Digidai/product-manager-skills)
- **Description:** AI-native PM agent — PRD, user stories, roadmaps, SaaS metrics, positioning, discovery interviews, career coaching, and AI product strategy
- **Install:** `clawhub install pm-agent` or `npx skills add Digidai/product-manager-skills`
- **Published on:** ClawHub, skills.sh, npm