### PR TITLE
Add 3 China quant trading skills (CTP API, RiceQuant, NautilusTrader)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[CTP API](https://github.com/algoderiv/skills/tree/main/ctp-api)** | CTP 6.7.8 API documentation for Chinese futures/options trading — trading interfaces, market data subscription, order execution, and position management (53 reference files from 2466-page official PDF) |
+| **[RiceQuant RQData Guide](https://github.com/algoderiv/skills/tree/main/rice-quant-dev-guide)** | RiceQuant RQData Python API for Chinese financial data — A-shares, futures, options, funds, bonds, and macro data |
+| **[NautilusTrader Dev Guide](https://github.com/algoderiv/skills/tree/main/nautilus-trader-dev-guide)** | NautilusTrader developer guide — building from source, Rust/Python integration, testing practices, and contribution guidelines |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
-| **[CTP API](https://github.com/algoderiv/skills/tree/main/ctp-api)** | CTP 6.7.8 API documentation for Chinese futures/options trading — trading interfaces, market data subscription, order execution, and position management (53 reference files from 2466-page official PDF) |
-| **[RiceQuant RQData Guide](https://github.com/algoderiv/skills/tree/main/rice-quant-dev-guide)** | RiceQuant RQData Python API for Chinese financial data — A-shares, futures, options, funds, bonds, and macro data |
-| **[NautilusTrader Dev Guide](https://github.com/algoderiv/skills/tree/main/nautilus-trader-dev-guide)** | NautilusTrader developer guide — building from source, Rust/Python integration, testing practices, and contribution guidelines |
+| **[CTP API](https://github.com/algoderiv/agent-skills/tree/main/skills/ctp-api)** | CTP 6.7.8 API documentation for Chinese futures/options trading — trading interfaces, market data subscription, order execution, and position management (53 reference files from 2466-page official PDF) |
+| **[RiceQuant RQData Guide](https://github.com/algoderiv/agent-skills/tree/main/skills/rice-quant-dev-guide)** | RiceQuant RQData Python API for Chinese financial data — A-shares, futures, options, funds, bonds, and macro data |
+| **[NautilusTrader Dev Guide](https://github.com/algoderiv/agent-skills/tree/main/skills/nautilus-trader-dev-guide)** | NautilusTrader developer guide — building from source, Rust/Python integration, testing practices, and contribution guidelines |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skills

Adding 3 skills for Chinese quantitative trading development:

| Skill | Description |
|-------|-------------|
| **[CTP API](https://github.com/algoderiv/agent-skills/tree/main/skills/ctp-api)** | CTP 6.7.8 complete API documentation — 53 reference files extracted from the official 2466-page PDF. Covers trading interfaces, market data, order execution, position management, and error handling for Chinese futures/options. |
| **[RiceQuant RQData Guide](https://github.com/algoderiv/agent-skills/tree/main/skills/rice-quant-dev-guide)** | RiceQuant RQData Python API for accessing Chinese financial market data — A-shares, futures, options, funds, bonds, and macro data. |
| **[NautilusTrader Dev Guide](https://github.com/algoderiv/agent-skills/tree/main/skills/nautilus-trader-dev-guide)** | Developer guide for NautilusTrader, a high-performance algorithmic trading platform — building from source, Rust/Python integration, testing. |

### Install

```bash
npx skills add https://github.com/algoderiv/agent-skills --skill ctp-api
npx skills add https://github.com/algoderiv/agent-skills --skill "*"
```

All skills are hosted at https://github.com/algoderiv/agent-skills following the Agent Skills format.