### PR TITLE
Add claude-recap session memory skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Skills for working with complex file formats:
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
+| **[claude-recap](https://github.com/hatawong/claude-recap)** | Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |


### PR DESCRIPTION
## What

Adds [claude-recap](https://github.com/hatawong/claude-recap) to the Individual Skills table.

## About claude-recap

A per-topic session memory system for Claude Code. It uses two Shell hooks (SessionStart + Stop) to automatically archive each conversation topic as a separate Markdown summary under `~/.memory/`.

- **How it works**: Stop hook detects topic changes via inline tags, triggers archival. SessionStart hook injects prior memory into new sessions.
- **Stack**: Bash + Node.js, no external services, 100% local
- **Storage**: One `.md` file per topic, organized by project and session
- **License**: MIT

The skill goes beyond a single SKILL.md — it includes hook scripts, a Node.js transcript extractor, cold-summarization pipeline, and an archive-pending background service.

Repository: https://github.com/hatawong/claude-recap