### PR TITLE
Add Production Grade plugin — 14-agent autonomous pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[production-grade](https://github.com/nagisanzenin/claude-code-production-grade-plugin)** | 14-agent autonomous pipeline — PM, Architect, Backend, Frontend, QA, Security, Code Review, DevOps, SRE, Data Scientist, Technical Writer, Skill Maker, Polymath co-pilot. Two-wave parallel execution, brownfield-safe. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds **[production-grade](https://github.com/nagisanzenin/claude-code-production-grade-plugin)** to the Community Skills table.
- 14-agent autonomous pipeline (PM, Architect, Backend, Frontend, QA, Security, Code Review, DevOps, SRE, Data Scientist, Technical Writer, Skill Maker, Polymath co-pilot) with two-wave parallel execution, brownfield-safe.

## Test plan

- [x] Entry follows existing table format (`| **[name](url)** | description |`)
- [x] Link points to valid GitHub repository
- [x] Description is concise and informative