### PR TITLE
Add product-manager-skills to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[product-manager-skills](https://github.com/Digidai/product-manager-skills)** | Senior PM agent with 6 knowledge domains, 30+ frameworks, 10 templates, and 32 SaaS metrics. Covers discovery, strategy, delivery, finance, career coaching, and AI product craft |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Resource

**[product-manager-skills](https://github.com/Digidai/product-manager-skills)** — Senior PM agent skill for Claude Code.

## What it does

A single-install skill that gives Claude 6 PM knowledge domains, 30+ frameworks, 10 templates, and 32 SaaS metrics with exact formulas. Covers the full PM lifecycle:

- **Discovery & Research**: JTBD, Mom Test, Opportunity Solution Tree, PoL Probes
- **Strategy & Positioning**: Geoffrey Moore, PESTEL, TAM/SAM/SOM, RICE/Kano
- **Artifacts & Delivery**: PRD, user stories (Cohn + Gherkin), epics, PRFAQ
- **Finance & Metrics**: 32 SaaS metrics with formulas and benchmarks
- **Career & Leadership**: PM to Director to VP to CPO transitions
- **AI Product Craft**: Context engineering, agent orchestration

## Why it fits this list

- No PM skill currently listed in the community skills section
- Pure Markdown, zero scripts, zero dependencies — fully auditable
- Works with Claude Code, Claude Projects, and any LLM
- Published on ClawHub and GitHub with CC BY-NC-SA 4.0 license