### PR TITLE
Add Claude Code Minoan skill collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[Claude Code Minoan](https://github.com/tdimino/claude-code-minoan)** - 60+ skills covering local RAG (RLAMA + Ollama), cross-model visual dialogue (Gemini + Claude), neural web search (Exa), image generation (Gemini 3 Pro), SMS/Slack/email, LLM eval pipelines, Codex CLI orchestration, and multi-agent team coordination. Pairs with [Claudicle](https://github.com/tdimino/claudicle) for persistent soul identity across sessions.
+
 
 ### Individual Skills
 


### PR DESCRIPTION
I've built 60+ Claude Code skills over the last 6 months while working on cognitive AI
at Subquadratic. Got tired of rewriting the same RAG setup, the same SMS routing,
the same eval harness—so I turned each into a reusable skill.

A few I reach for regularly:

- rlama — local RAG with Ollama, retrieve-only so Claude synthesizes (not Qwen)
- codex-orchestrator — 10 Codex CLI profiles: reviewer, debugger, architect, etc.
- minoan-swarm — multi-agent teams with named roles
- nano-banana-pro — image gen via Gemini 3 Pro
- sms — 8 phone numbers across Telnyx + Twilio, auto-detection
- exa-search — neural web search with 5 specialized scripts
- gemini-claude-resonance — cross-model visual dialogue between Gemini and Claude
- minoan-frontend-design — frontend design skill with 70% blind eval win rate

All SKILL.md format with scripts, references, and assets bundled.
Pairs with [Claudicle](https://github.com/tdimino/claudicle) for persistent soul identity across sessions.

https://github.com/tdimino/claude-code-minoan
MIT licensed, 12 stars.