### PR TITLE
Add Agent Cards skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[agent-cards-skill](https://github.com/agent-cards/skill)** | Manage prepaid virtual Visa cards for AI agents. Create cards, check balances, view credentials, close cards, and get support via MCP tools. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [agent-cards/skill](https://github.com/agent-cards/skill) to the list.

**Agent Cards** lets AI agents create and spend prepaid virtual Visa cards — each with a fixed budget, real card credentials, and full MCP integration. The skill teaches agents how to:

- **Create cards** — set a dollar amount, complete Stripe Checkout, get a card back
- **Check balances** — quick balance lookup
- **View card credentials** — full card number, CVV, expiry (with email approval)
- **Close cards** — permanent closure with user confirmation
- **Get support** — open and manage support conversations

Works with Claude Code, Codex, and any agent that supports SKILL.md.

- **Repo:** https://github.com/agent-cards/skill
- **Product:** https://agentcard.sh
- **Install:** `npx skills add agent-cards/skill`