### PR TITLE
Add Claude for Safari to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills for working with complex file formats:
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[claude-for-safari](https://github.com/SDLLL/claude-for-safari)** | Control your real Safari browser on macOS — read pages, click, type, screenshot, navigate via native AppleScript. Zero install |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |


### PR DESCRIPTION
## Claude for Safari

A Claude Code skill that gives AI agents full control of Safari on macOS using native AppleScript and screencapture.

- **Repo**: https://github.com/SDLLL/claude-for-safari
- **Website**: https://safari.skilljam.dev
- **Category**: Browser automation (placed next to playwright-skill)

### Key differentiators
- Uses your **real browser** — your cookies, logins, and tabs
- **Zero install** — relies entirely on macOS built-in AppleScript and screencapture
- **Safari-native** — the only browser on macOS with full AppleScript support
- MIT licensed, free and open source