### PR TITLE
Add skill: whynowlab/stack-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[stack-skills](https://github.com/whynowlab/stack-skills)** | 7 meta-cognitive thinking skills (research verification, creativity forcing, adversarial review, and more) that upgrade how your AI thinks — not just codes |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What
Adding [stack-skills](https://github.com/whynowlab/stack-skills) to the Individual Skills table.

## About Stack Skills
7 meta-cognitive thinking skills for Claude Code that improve reasoning quality:

- **cross-verified-research** — Multi-source research verification with source tier labeling
- **creativity-sampler** — 5 probability-weighted options with unconventional alternatives
- **adversarial-review** — 3-vector Devil's Advocate stress testing
- **skill-composer** — Combine multiple skills into unified workflows
- **persona-architect** — Dynamic persona creation for specialized contexts
- **deep-dive-analyzer** — Multi-layered exhaustive analysis
- **tiered-test-generator** — Tiered knowledge-verification questions

12 GitHub stars · MIT license · Converted from 30+ Korean AI prompt patterns (credited).