### PR TITLE
Add Frostbyte MCP — remote MCP server with 13+ developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Skills for working with complex file formats:
 
 _More community skills coming soon! Submit a PR to add your skill._
 
+### MCP Servers
+
+| Server | Description |
+| --- | --- |
+| **[frostbyte-mcp](https://github.com/Robocular/frostbyte-mcp)** | Remote MCP server providing 13+ developer tools — crypto prices, DNS/WHOIS lookups, screenshots, web scraping, code execution, PDF generation, and more. Works with Claude Desktop, Claude Code, Cursor, and VS Code via SSE or Streamable HTTP |
+
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills


### PR DESCRIPTION
## What is Frostbyte MCP?

[Frostbyte MCP](https://github.com/Robocular/frostbyte-mcp) is a remote MCP server that gives Claude access to 13+ developer tools through a single connection. It works out of the box with Claude Desktop, Claude Code, Cursor, and VS Code — no local install required.

### Tools included

| Tool | What it does |
|------|-------------|
| `crypto_price` | Live prices for BTC, ETH, SOL, and 40+ tokens |
| `dns_lookup` | DNS records (A, AAAA, MX, TXT, NS, CNAME, SOA) |
| `whois_lookup` | Domain WHOIS/RDAP data |
| `take_screenshot` | Website screenshots in multiple viewports |
| `scrape_url` | Extract text, markdown, or HTML from any URL |
| `run_code` | Execute JavaScript, Python, TypeScript, Bash |
| `search_web` | Web search with structured results |
| `shorten_url` | URL shortener with analytics |
| `generate_pdf` | PDF from HTML, URL, or Markdown |
| `geo_lookup` | IP geolocation |
| `check_domain` | Domain availability across TLDs |
| `create_paste` | Code sharing with syntax highlighting |
| `transform_data` | Convert between JSON, CSV, XML, YAML |

### Why it fits this list

The README already covers MCP as a complement to Skills (the "Skills vs MCP" section). Frostbyte MCP extends what Claude can do in practice — looking up live crypto prices, taking screenshots during development, running code snippets, checking DNS records, etc. I added it under a new "MCP Servers" subsection within Community Skills, since no such section existed yet.

### Checklist

- [x] Public repo with README, Dockerfile, and source code
- [x] Works with Claude Desktop, Claude Code, Cursor, VS Code
- [x] Supports both SSE and Streamable HTTP transport
- [x] Docker image available
- [x] Free to use, no API key required
- [x] One item in this PR