### PR TITLE
Add gee-python-skill for Google Earth Engine Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[gee-python-skill](https://github.com/Zhihong-KE/gee-python-skill)** | Google Earth Engine Python API — batch task submission, task monitoring, Google Drive download via EE OAuth credentials, GEE asset management and upload |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds **gee-python-skill** to the Individual Skills list — a Claude Code skill for Google Earth Engine Python API operations.

## What it does

- Batch task submission (image/table export to Asset or Drive)
- Task monitoring and cancellation
- Google Drive download using EE OAuth credentials (no extra auth required)
- GEE asset management and upload (CLI+GCS, Python API, Google Colab)
- `references/utils.py` for direct import

## Why it's useful

GEE is widely used in remote sensing and geospatial research. This is the first Claude skill covering GEE Python API workflows. The key insight (EE OAuth token already includes Drive scope, use `ee.oauth.CLIENT_ID`) is non-obvious and not documented anywhere in an agent-skill format.

## Checklist

- [x] Not a SaaS wrapper
- [x] Improves DX/UX of Claude Code without routing through external servers
- [x] Open source (MIT) at https://github.com/Zhihong-KE/gee-python-skill
- [x] One item per PR