### PR TITLE
Add Multisage skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[multisage-skill](https://github.com/cluesmith/multisage-skill)** | Query Claude, GPT, and Gemini simultaneously and get a synthesized multi-expert answer. Supports standard queries (1 credit, 30-90s) and deep research mode (5 credits, 5-25 min). |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [multisage-skill](https://github.com/cluesmith/multisage-skill) to the Community Skills > Individual Skills table.

**What it does:** A Claude Code skill that queries Claude, GPT, and Gemini simultaneously and returns a synthesized multi-expert answer. It supports two modes:

- **Standard queries** (1 credit, 30-90s) — ask all three frontier models and get a unified synthesis
- **Deep research mode** (5 credits, 5-25 min) — each model performs web research with extended thinking before synthesis