### PR TITLE
Add debug-skill: interactive debugger for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills for working with complex file formats:
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
+| **[debug-skill](https://github.com/AlmogBaku/debug-skill)** | Interactive debugger for AI agents — breakpoints, stepping, variable inspection, and stack traces via the `dap` CLI. Supports Python, Go, Node.js/TypeScript, Rust, and C/C++ |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |


### PR DESCRIPTION
## What is this?

[`debugging-code`](https://github.com/AlmogBaku/debug-skill) is a skill that gives AI agents access to a real interactive debugger via the `dap` CLI.

Instead of print-statement debugging, the agent can:
- Set breakpoints and step through code line by line
- Inspect live variable values and the call stack
- Evaluate expressions against the running process

**Supported languages:** Python · Go · Node.js/TypeScript · Rust · C/C++

**GitHub:** https://github.com/AlmogBaku/debug-skill