### PR TITLE
Add ai-video-remix skill to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 
-_More community skills coming soon! Submit a PR to add your skill._
+| **[ai-video-remix](https://github.com/abu-ShotAI/ai-video-remix)** | AI-driven video remix generator using ShotAI semantic search + LLM planning + Remotion rendering to produce styled video compositions from a local video library |  _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 


### PR DESCRIPTION
## Add ai-video-remix skill

Adds the [ai-video-remix](https://github.com/abu-ShotAI/ai-video-remix) skill to the Community Skills > Individual Skills table.

**What this skill does:**
AI-driven video remix generator that uses ShotAI semantic search + LLM planning + Remotion rendering to produce styled video compositions from a user's local video library. Supports compositions like TravelVlog, CyberpunkCity, SportsHighlight, NatureWild and more.

**Key features:**
- 8-step pipeline: intent parsing → query refinement → shot selection → music → clip extraction → annotation → rendering
- 6 built-in Remotion compositions
- Bilingual output support (zh/en)
- Probe mode for unknown libraries
- Works with any OpenAI-compatible LLM API or heuristic fallback

**Prerequisites:** ShotAI (local MCP server), ffmpeg, Node.js, yt-dlp (optional for auto music)