### PR TITLE
Add encode-toolkit genomics skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[encode-toolkit](https://github.com/ammawla/encode-toolkit)** | 48 genomics research skills + 20 MCP tools for the ENCODE Project — search experiments, download files with MD5 verification, run analysis pipelines, and cross-reference 14 databases |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## encode-toolkit

**Link**: https://github.com/ammawla/encode-toolkit

**Description**: 48 genomics research skills + 20 MCP tools for the ENCODE Project — the largest public catalog of functional genomic elements. Search experiments, download files with MD5 verification, run analysis pipelines (ChIP-seq, ATAC-seq, RNA-seq, WGBS, Hi-C, DNase-seq, CUT&RUN), and cross-reference 14 databases (PubMed, GTEx, ClinVar, gnomAD, GWAS Catalog, JASPAR, GEO, Ensembl, UCSC, CELLxGENE, bioRxiv, ClinicalTrials.gov, Open Targets, Consensus).

### Checklist

- [x] Clear name and link to repository
- [x] 1-2 sentence description
- [x] README with installation instructions and usage examples
- [x] Functional and tested (506 tests, 98% coverage)
- [x] More than a single file (48 skill directories, 20 tools, 34 reference documents)
- [x] Licensed (CC-BY-NC-ND-4.0)
- [x] Published on PyPI and npm
- [x] DOI via Zenodo (10.5281/zenodo.18917511)