### PR TITLE
Add geo-lint — First open-source GEO linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[geo-lint](https://github.com/IJONIS/geo-lint)** | First open-source GEO linter with 92 rules for AI search visibility (SEO, content quality, structured data). Outputs JSON for agent-driven lint-fix loops. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What is geo-lint?

The first open-source linter for **Generative Engine Optimization (GEO)** — validates content for AI search visibility with **92 rules** across:

- SEO (32 rules)
- Content quality (14 rules)
- Technical checks (8 rules)
- GEO optimization (35 rules)
- Internationalization (3 rules)

### Agent-First Design

Outputs structured JSON violations with actionable suggestions, enabling AI agents to autonomously fix issues in a lint-fix loop until violations reach zero.

### Claude Code Integration

Ships with a ready-made Claude Code skill:

```bash
claude skill add --url https://raw.githubusercontent.com/IJONIS/geo-lint/main/.claude/skills/geo-lint/SKILL.md
```

Provides `/geo-lint audit` for comprehensive content sweeps and `/geo-lint fix` for targeted corrections.

### Links

- **Repository:** https://github.com/IJONIS/geo-lint
- **npm:** [@ijonis/geo-lint](https://www.npmjs.com/package/@ijonis/geo-lint)

---

Added to the **Individual Skills** table as it fits the single-skill pattern rather than a collection.