### PR TITLE
Add steel-browser skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[steel-browser](https://github.com/steel-dev/cli/tree/main/skills/steel-browser)** | Session-backed browser automation for navigation, extraction, screenshots, PDFs, and multi-step web flows |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
`steel-browser` is a Claude-compatible skill for session-backed browser automation, extraction, screenshots, PDFs, and multi-step web flows.

It fits the community skills section because it gives Claude a concrete browser workflow for tasks that basic fetch tools or one-off scripts handle poorly.

Links:
- Skill: https://github.com/steel-dev/cli/tree/main/skills/steel-browser
- Repo: https://github.com/steel-dev/cli
- Docs: https://docs.steel.dev/llms-full.txt
- Blog: https://steel.dev/blog/introducing-steel-cli-v0-2-0-browser-automation-built-for-agents

Example use case: browser automation + skill orchestration for login flows, extraction, and screenshots.