### PR TITLE
Add claude-code-plugins to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[claude-code-plugins](https://github.com/jeremylongshore/claude-code-plugins)** - Open-source collection of 340+ plugins and 1,800+ skills across 29 categories including DevOps, security, AI/ML, crypto, and SaaS integrations
+  - Searchable web marketplace at [tonsofskills.com](https://tonsofskills.com)
+  - CLI installer: `ccpi` ([npm](https://www.npmjs.com/package/@intentsolutionsio/ccpi))
+  - Includes 116 custom agents and CI-validated plugin quality checks
+  - Installation: `/plugin marketplace add jeremylongshore/claude-code-plugins`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## What

Adds [claude-code-plugins](https://github.com/jeremylongshore/claude-code-plugins) to the **Collections & Libraries** section.

## About the project

- **340+ open-source plugins** and **1,800+ agent skills** across 29 categories (DevOps, security, AI/ML, crypto, SaaS, and more)
- **116 custom agents** for specialized workflows
- Searchable web marketplace at [tonsofskills.com](https://tonsofskills.com)
- CLI installer `ccpi` published on [npm](https://www.npmjs.com/package/@intentsolutionsio/ccpi)
- CI-validated plugin quality checks on every PR (JSON schema, frontmatter, secret scanning)
- MIT licensed, community contributions welcome

## Checklist

- [x] Relates to Claude Skills
- [x] Provides clear user value (largest open-source Claude plugin collection)
- [x] Not promotional — free, open source, MIT licensed
- [x] Has 200+ GitHub stars (exceeds 10-star minimum)
- [x] One item per PR
- [x] All links tested and working
- [x] Follows existing formatting conventions