### PR TITLE
Add playwright-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
-
+| **[TestDino Playwright Skill](https://github.com/testdino-hq/playwright-skill)** | 70+ structured Playwright testing skill for AI agents covering end-to-end tests, page object models, CI/CD setup, Cypress or Selenium migration, and CLI automation |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
## Summary
Adds `playwright-skill` to the relevant section.

## Details
- 70+ structured Playwright testing skill for AI agents
- Covers end-to-end tests, page object models, CI/CD setup, Cypress or Selenium migration, and CLI automation

## Notes
Kept the format consistent with the existing list style.