### PR TITLE
feat: add bulkgen skill for bulk AI image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[bulkgen](https://github.com/oil-oil/bulkgen-skill)** | Bulk AI image generation — generate 9 AI images for the cost of 1 via the BulkGen API. One grid request, auto-split into separate assets, ~89% cost savings vs individual generations |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [bulkgen](https://github.com/oil-oil/bulkgen-skill) to the Individual Skills table.

**What it does:** Bulk AI image generation — calls the BulkGen API to generate one grid image and auto-splits it into N separate assets. This means 9 images cost the same as 1 generation (~89% cost savings).

**Modes:** solo, batch (different prompt per cell), variation (one prompt, multiple creative variants)

**Bundled scripts:** `generate.js`, `download_images.js`, `build_preview.js` — no extra setup beyond an API key.