### PR TITLE
Add blueprint construction planning skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[blueprint](https://github.com/antbotlab/blueprint)** | Turn a one-line objective into a step-by-step construction plan any agent can execute cold — each step has a self-contained context brief, adversarial review gate, dependency graph, and plan mutation protocol. Pure markdown, zero runtime risk. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [blueprint](https://github.com/antbotlab/blueprint) to the Individual Skills table.

Blueprint turns a one-line objective into a step-by-step construction plan that any coding agent can execute cold. It's designed for multi-session, multi-agent engineering projects where each step must be independently executable by a fresh agent.

**Why it belongs here:**

- Proper Claude Code skill with SKILL.md and `/blueprint` slash command
- Cold-start execution: every step has a self-contained context brief
- Adversarial review gate: strongest-model sub-agent reviews every plan before execution
- Zero runtime risk: pure markdown — no hooks, no scripts, no executable code
- More than a single SKILL.md file: includes structured templates, review checklist, anti-pattern catalog, plan mutation protocol, and worked examples

**Installation:**

```bash
mkdir -p ~/.claude/skills
git clone https://github.com/antbotlab/blueprint.git ~/.claude/skills/blueprint
```

**Demo task:** Run `/blueprint myapp "migrate database to PostgreSQL"` in any multi-module project. Blueprint will generate a plan in `plans/` where each step can be executed by a fresh agent with no prior context.

## Checklist

- [x] Resource is related to Claude Skills
- [x] Provides clear value to users
- [x] Non-promotional (standalone value, not a SaaS funnel)
- [x] Has documentation (README + SKILL.md + examples)
- [x] MIT license
- [x] Proper formatting matching existing table entries
- [x] All links verified