### PR TITLE
Add PM AI Partner: 12 PM-specific agent skills + 6 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[PM AI Partner](https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework)** | 12 PM-specific agent skills (thought partner, devil's advocate, technical analyst, writer, builder, data analyst, product brief, meeting prep, stakeholder update, strategic clarity, hypothesis tester, competitor analyst), 6 workflow commands, 3 hooks. Install: `npx pm-ai-partner@latest` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [PM AI Partner](https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework) to the Community Skills > Individual Skills table.

**PM AI Partner** is a Claude Code plugin built for Product Managers, providing:

- **12 agent skills**: thought partner, devil's advocate, technical analyst, writer, builder, data analyst, product brief, meeting prep, stakeholder update, strategic clarity, hypothesis tester, competitor analyst
- **6 workflow commands** for structured PM workflows
- **3 hooks** for automation

### Install

```bash
npx pm-ai-partner@latest
```

### Links

- GitHub: https://github.com/ahmedkhaledmohamed/PM-AI-Partner-Framework
- npm: https://www.npmjs.com/package/pm-ai-partner