### PR TITLE
Add translate-image skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[translate-image](https://github.com/translateimage/translate-image-skills)** | AI-powered image translation (130+ languages), OCR with bounding boxes, text removal via inpainting, and Gemini-powered extraction with multi-language translation |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [translate-image](https://github.com/translateimage/translate-image-skills) to the Individual Skills table.

AI-powered image translation, OCR, and text removal via the [TranslateImage](https://translateimage.io) API.

**4 tools:**
- Translate Image — 130+ languages, preserves layout
- Extract Text (OCR) — bounding boxes, language detection, confidence scores
- Remove Text — AI inpainting
- Image to Text — Gemini-powered extraction + multi-language translation

**Install:** `npx skills add translateimage/translate-image-skills`
**License:** MIT