### PR TITLE
Add social-listening-tagger: sentiment, topic & emotion analysis for social listening

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
-
+| **[social-listening-tagger](https://github.com/gmr-inc/social-listening-tagger)** | Pre-tag social media posts with sentiment analysis, topic detection (with disambiguation), and emotion analysis using Claude Haiku. Built for social listening pipelines. By [@gmr-inc](https://github.com/gmr-inc) |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
Adding [social-listening-tagger](https://github.com/gmr-inc/social-listening-tagger) to the Individual Skills table.

A Claude Skill for pre-tagging social media posts with:
- **Sentiment analysis** (score, confidence, sarcasm detection)
- - **Topic detection with disambiguation** (11-category taxonomy, handles ambiguous terms like "Apple")
- - **Emotion analysis** (Plutchik's wheel: joy, anger, sadness, fear, surprise, disgust, trust, anticipation)
- - **Entity extraction** with per-entity sentiment
- - **Intent classification** (complaint, praise, question, opinion, etc.)
Optimized for Claude Haiku batch processing (~$0.001/post). Includes TypeScript implementation example.

Built by [GMR Inc](https://github.com/gmr-inc).