### PR TITLE
Add mortgage plugin (by LendTrain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 
+| **[LendTrain Mortgage Refinance](https://github.com/lendtrain/mortgage)** | AI-native mortgage refinance plugin with real-time institutional pricing, state-specific closing costs, FHA Streamline/VA IRRRL detection, weighted recommendation scoring, and regulatory compliance. No API key required. |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 
-| **[LendTrain Mortgage Refinance](https://github.com/lendtrain/mortgage)** | AI-native mortgage refinance plugin with real-time institutional pricing, state-specific closing costs, FHA Streamline/VA IRRRL detection, weighted recommendation scoring, and regulatory compliance. No API key required. |
+| **[mortgage](https://github.com/lendtrain/mortgage)** | Mortgage refinance plugin by LendTrain — real-time institutional pricing, state-specific closing costs, FHA Streamline/VA IRRRL detection, recommendation scoring, and regulatory compliance via MCP. No API key required. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skill Submission

Adding **[LendTrain Mortgage Refinance](https://github.com/lendtrain/mortgage)** to the Individual Skills table.

### What it does

LendTrain is an AI-native mortgage refinance plugin for Claude Code that provides:

- **Real-time institutional pricing** via MCP connection to a live rate engine
- **State-specific closing costs** with accurate fee calculations
- **FHA Streamline / VA IRRRL detection** for eligible borrowers
- **Weighted recommendation scoring** across multiple loan scenarios
- **Regulatory compliance** with NMLS licensing and required disclosures

### Installation

```bash
/plugin marketplace add lendtrain/mortgage
/plugin install mortgage@mortgage
```

Then use the `/mortgage:refi-quote` command.

### Details

- **Repo**: https://github.com/lendtrain/mortgage
- **Website**: https://www.lendtrain.com
- **No API key required** — connects to a live pricing engine via MCP
- Published as a Claude Code marketplace plugin