### PR TITLE
Add thinking-skills: 20 structured thinking framework commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[thinking-skills](https://github.com/wanikua/thinking-skills)** | 20 structured thinking framework commands — Critical Thinking, First Principles, Red Team, Bayesian, Six Thinking Hats, Premortem, and more |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [thinking-skills](https://github.com/wanikua/thinking-skills) to the Individual Skills table.

20 human thinking framework slash commands for Claude Code:
- Critical Thinking, First Principles, Red Team, Bayesian Thinking, Six Thinking Hats, Premortem, Second-Order Thinking, Inversion, Steelman, Mental Models, Systems Thinking, Design Thinking, Dialectical, Analogical Reasoning, and more.

Each command provides a structured multi-step analytical workflow. Copy `.claude/commands/` into any project and use e.g. `/red-team Our launch plan`.