### PR TITLE
Add yorrick/claude-code-plugins to community collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[yorrick/claude-code-plugins](https://github.com/yorrick/claude-code-plugins)** - Collection of Claude Code plugins, including `dev-loop` for automated implementation and review workflows and `self-improve-skill` for session reflection
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adds `yorrick/claude-code-plugins` to the Community Skills collections section.

The repository is a collection of Claude Code plugins, currently including:
  - `dev-loop` for automated implementation and review workflows
  - `self-improve-skill` for session reflection and improvement

The repo has documentation and install instructions in the README.

MIT licensed; install via `claude plugin marketplace add yorrick/claude-code-plugins` 