### PR TITLE
Add Shield security orchestrator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[Shield](https://github.com/alissonlinneker/shield-claude-skill)** | Security orchestrator — runs Shannon pentester, Semgrep SAST (34 rules), gitleaks secrets scanning, and npm/pip/composer audits from a single command. Risk scoring, fix proposals, OWASP/CWE compliance mapping, SARIF output, and dependency freshness checks |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **Shield** to the Individual Skills table — a security orchestrator that runs autonomous pentests, SAST, secrets scanning, and dependency audits from a single `/shield` command.

**Repo:** https://github.com/alissonlinneker/shield-claude-skill

- Wraps Shannon pentester + Semgrep (34 custom rules) + gitleaks + npm/pip/composer audit
- 0-100 risk score with OWASP/CWE/SOC2/PCI-DSS/HIPAA compliance mapping
- SARIF 2.1.0 output, fix proposals with diffs, dependency freshness checks
- 189 unit tests, MIT licensed