### PR TITLE
Add ContextDocs to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Skills for working with complex file formats:
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
-| **[ContextDocs](https://github.com/littlebearapps/contextdocs)** | Your AI agent maintains its own context files — an AGENTS-first model covering Codex, Copilot, Cursor, Gemini, and 3 more tools. Includes Signal Gate filtering, Context Guard hooks, and 0-100 health scoring |
+| **[ContextDocs](https://github.com/littlebearapps/contextdocs)** | Your AI agent maintains its own context files — a Claude Code plugin with an AGENTS-first model that covers Codex, Copilot, Cursor, Gemini, and 3 more tools |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Skills for working with complex file formats:
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
+| **[ContextDocs](https://github.com/littlebearapps/contextdocs)** | Your AI agent maintains its own context files — an AGENTS-first model covering Codex, Copilot, Cursor, Gemini, and 3 more tools. Includes Signal Gate filtering, Context Guard hooks, and 0-100 health scoring |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |


### PR DESCRIPTION
## Summary

Adds [ContextDocs](https://github.com/littlebearapps/contextdocs) to the Individual Skills table.

Your AI agent maintains its own context files — a Claude Code plugin with an AGENTS-first model that covers Codex, Copilot, Cursor, Gemini, and 3 more tools. Includes Signal Gate filtering, Context Guard hooks for freshness enforcement, and 0-100 health scoring.

- **License:** MIT
- **Dependencies:** Zero runtime dependencies (pure Markdown)
- **Install:** `/plugin add https://github.com/littlebearapps/lba-plugins` or `npx skills add littlebearapps/contextdocs`
- **SKILL.md:** [Root-level SKILL.md](https://github.com/littlebearapps/contextdocs/blob/main/SKILL.md) with standard frontmatter

## Social Proof

- Listed on [skills.sh](https://skills.sh/) (88k+ skill directory)
- Companion plugin [PitchDocs](https://github.com/littlebearapps/pitchdocs) has PRs open on 5 awesome lists
- Extracted from PitchDocs v1.19.3 as a standalone focused tool