### PR TITLE
Add LobsterDomains to community skills list

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[LobsterDomains](https://clawhub.ai/esokullu/lobsterdomains)** | Register domain names via crypto payments (USDC, USDT, ETH, BTC) across 1000+ TLDs |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Added **LobsterDomains** to the Individual Skills table.

[LobsterDomains](https://clawhub.ai/esokullu/lobsterdomains) is a Claude skill for registering domain names via crypto payments (USDC, USDT, ETH, BTC) across 1000+ TLDs using the [LobsterDomains API](https://lobsterdomains.xyz/skills).

- Published on ClawHub: https://clawhub.ai/esokullu/lobsterdomains
- - Homepage: https://lobsterdomains.xyz