### PR TITLE
Add bitcoin-companies-skills to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[bitcoin-companies-skills](https://github.com/sbounmy/bitcoin-companies-skills)** | Query Bitcoin company treasury data — search, leaderboard, and reports |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [bitcoin-companies-skills](https://github.com/sbounmy/bitcoin-companies-skills) to the Individual Skills table.

**What it does:** Claude Code skill to query Bitcoin company treasury data from the [Bitcoin Companies API](https://bitcoincompanies.co/api-docs).

- `/bitcoin strategy.com` — company detail card
- `/bitcoin top 10 mining` — filtered leaderboard
- `/bitcoin report etf` — aggregate treasury report

Free API, no auth required, 629 companies tracked.