### PR TITLE
Add AgentShield as recommended security scanning tool for skill vetting

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ _Video tutorials coming soon! Have a good video about Claude Skills? Submit a PR
 - **Review SKILL.md and all scripts** before enabling a skill
 - **Be cautious of skills** that request sensitive data access
 - **Audit carefully** before deploying to production or enterprise environments
+- **Use automated scanning** — [AgentShield](https://github.com/elliotllliu/agent-shield) can scan skills for prompt injection, data exfiltration, and backdoors before installation (`npx @elliotllliu/agent-shield scan ./skill/`)
 
 ### Security Concerns
 


### PR DESCRIPTION
Adds a recommendation for [AgentShield](https://github.com/elliotllliu/agent-shield) in the Security & Best Practices → Vetting Skills section.

Given the security concerns highlighted in this README (malicious skills, prompt injection, data exfiltration), having an automated scanning tool is a natural complement to the manual review guidelines already listed.

AgentShield can scan Claude skills before installation:

```bash
npx @elliotllliu/agent-shield scan ./skill/
```

It detects:
- Prompt injection (55+ patterns in 8 languages)
- Data exfiltration (read sensitive files + HTTP exfil)
- Backdoors (eval, exec, reverse shells)
- Hidden HTML comments with injected instructions
- Tool poisoning and cross-file attack chains

Free, offline, zero-config, MIT licensed.