### PR TITLE
Add rails-llm-integration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[rails-llm-integration](https://github.com/rubyonai/rails-llm-integration)** | Rails conventions for LLM calls — service objects, async jobs, model routing, cost tracking, eval pipelines, and testing patterns. Covers ruby_llm, langchain-rb, ruby-openai, and anthropic-rb |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
  Adds [rails-llm-integration](https://github.com/rubyonai/rails-llm-integration) to the Individual Skills list.

  A Claude Skill that teaches Claude Code Rails conventions for LLM calls — service objects, async jobs, model routing, cost
  tracking, eval pipelines, and testing. Covers ruby_llm, langchain-rb, ruby-openai, and anthropic-rb.