### PR TITLE
Add windows-screenshot-paste skill by @sharooncs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[claude-windows-screenshot-paste](https://github.com/sharooncs/claude-windows-screenshot-paste)** | Enables Ctrl+V screenshot pasting in Claude Code on Windows — intercepts clipboard images, saves as PNG, and types the file path into the terminal by [@sharooncs](https://github.com/sharooncs) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New skill: windows-screenshot-paste

Adds [@sharooncs](https://github.com/sharooncs)'s [`claude-windows-screenshot-paste`](https://github.com/sharooncs/claude-windows-screenshot-paste) skill to the Individual Skills list.

### What it does

Enables `Ctrl+V` screenshot pasting in Claude Code on Windows Terminal. Windows Terminal cannot natively paste images — this skill installs an AutoHotkey v2 script that:

- Detects clipboard images via Win32 `IsClipboardFormatAvailable`
- Saves them as timestamped PNGs to `%USERPROFILE%\Pictures\Claude_Screenshots\`
- Types the file path into the terminal so Claude can read them directly

### Install

```bash
/plugin marketplace add sharooncs/claude-windows-screenshot-paste
```

### Usage

`Win+Shift+S` → snip → `Ctrl+V` in terminal → file path typed automatically