### PR TITLE
Add notion-pdf-skill: Import PDFs into Notion as PPT-style slideshows

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[notion-pdf-skill](https://github.com/cathyhang0905/notion-pdf-skill)** | Import PDFs into Notion as PPT-style slideshows — each page becomes an image block. Auto cover (Unsplash) + icon (DiceBear). Only Notion API key required. |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
Adds [notion-pdf-skill](https://github.com/cathyhang0905/notion-pdf-skill) to the community skills list.

**What it does:** Import any PDF into Notion as a PPT-style slideshow. Each page becomes a full-width image block. Auto-generates a unique Unsplash cover photo and DiceBear icon per document.

**Why it's useful:** No existing skill combines PDF processing + Notion import. Only requires a Notion API key — no third-party image hosting needed.

**Requirements:** Python 3.9+, `notion-client`, `PyMuPDF`, `python-dotenv`