### PR TITLE
Add Frihet MCP — AI-native business management skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[frihet-mcp](https://github.com/Frihet-io/frihet-mcp)** | AI-native business management — 31 tools for invoicing, expenses, clients, products, quotes & tax compliance. Install: `npx skills add Frihet-io/frihet-mcp`. npm: [@frihet/mcp-server](https://www.npmjs.com/package/@frihet/mcp-server). MIT licensed. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [Frihet MCP](https://github.com/Frihet-io/frihet-mcp) to the **Individual Skills** table in the Community Skills section.

- **What it does:** AI-native business management — 31 tools for invoicing, expenses, clients, products, quotes & tax compliance
- **Install:** `npx skills add Frihet-io/frihet-mcp`
- **npm:** [@frihet/mcp-server](https://www.npmjs.com/package/@frihet/mcp-server)
- **License:** MIT
- **Repo:** https://github.com/Frihet-io/frihet-mcp

The entry follows the existing table format used by other community skills.