### PR TITLE
Add web-architect: 4-agent design-to-code pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Skills for working with complex file formats:
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
+| **[web-architect](https://github.com/choppawave-beep/web-architect)** | 4-agent orchestrator for design-to-code pipelines — Constrained Generation, 8 project profiles, 5-dimension quality scoring, self-learning. Bans Inter/Roboto/Arial. |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |


### PR DESCRIPTION
## New Skill

**[web-architect](https://github.com/choppawave-beep/web-architect)** — 4-agent orchestrator for full design-to-code pipelines

### Highlights

- 🎨 Constrained Generation — unique palettes, banned generic fonts (Inter/Roboto/Arial), WCAG 4.5:1
- 📊 5-dimension quality scoring with auto-fix loop
- 🗂️ 8 project profiles (landing, saas, dashboard, ecommerce, crm, portfolio, blog, desktop)
- 🧠 Self-learning from user feedback
- 🌍 README in 6 languages

### Install

```bash
npx skills add choppawave-beep/web-architect
```

Works with Claude Code, Cursor, Amp, Codex CLI, Gemini CLI, and more.