### PR TITLE
Add widemem: Claude Code memory skill with semantic search and confidence scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Skills for working with complex file formats:
 
 
 ### Individual Skills
-| **[widemem-ai](https://github.com/remete618/widemem-ai)** | Next-gen AI memory layer with importance scoring, temporal decay, hierarchical memory, and YMYL prioritization |
+| **[widemem](https://github.com/remete618/widemem-skill)** | Claude Code memory skill with semantic search, confidence scoring, and quality gates. Remembers at scale, knows when it doesn't. |
 
 > These will be broken down into categories once there are enough community skills available to list
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Skills for working with complex file formats:
 
 
 ### Individual Skills
+| **[widemem-ai](https://github.com/remete618/widemem-ai)** | Next-gen AI memory layer with importance scoring, temporal decay, hierarchical memory, and YMYL prioritization |
 
 > These will be broken down into categories once there are enough community skills available to list
 


### PR DESCRIPTION
Adding [widemem-skill](https://github.com/remete618/widemem-skill), a Claude Code memory skill powered by [widemem-ai](https://github.com/remete618/widemem-ai).

**What it does:** Persistent AI memory with `/mem` slash commands: search, add, pin, prune, export, reflect.

**Why it's different from other memory skills:**
- Semantic vector search (FAISS/Qdrant), not grep over markdown
- 4-level confidence scoring: says "I don't know" instead of guessing
- Quality gates: classifies facts before storing (SKIP/LOW/MEDIUM/HIGH/CRITICAL)
- LLM-based conflict resolution and dedup
- Self-reflection audit (`/mem reflect`) for duplicates, contradictions, stale entries
- Frustration detection: searches harder when users say "I already told you"

**Install:** `pip install widemem-ai[mcp]` + copy skill or `/plugin install widemem`

- Skill repo: https://github.com/remete618/widemem-skill
- SDK repo: https://github.com/remete618/widemem-ai
- Website: https://widemem.ai
- License: Apache 2.0