### PR TITLE
Add webapp-uat: Playwright UAT skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills for working with complex file formats:
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[webapp-uat](https://github.com/tsilverberg/webapp-uat)** | Full browser UAT with Playwright: console/network error capture, WCAG 2.2 AA accessibility checks, i18n validation, responsive testing, and bug triage. Read-only by default |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
-| **[webapp-uat](https://github.com/tsilverberg/webapp-uat)** | Full browser UAT skill — Playwright testing with console/network error capture, WCAG 2.2 AA accessibility checks, i18n validation, responsive testing, and bug triage. Read-only by default |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[webapp-uat](https://github.com/tsilverberg/webapp-uat)** | Full browser UAT skill — Playwright testing with console/network error capture, WCAG 2.2 AA accessibility checks, i18n validation, responsive testing, and bug triage. Read-only by default |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[webapp-uat](https://github.com/tsilverberg/webapp-uat)** to the Individual Skills table.

Full browser UAT skill using Playwright — captures console/network errors, runs WCAG 2.2 AA accessibility checks, validates i18n, tests responsive layouts, and generates structured bug reports (P0-P3). Read-only by default (no Edit/Write tools). Works with React, Vue, Angular, Ionic, Next.js, and more.

Listed on [skills.sh](https://skills.sh/tsilverberg/webapp-uat/webapp-uat).