### PR TITLE
Add PM Skills — 82 product management skills for Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[PM Skills](https://github.com/DipakMajhi/product-management-skills)** | 82 expert skills for the full PM lifecycle — strategy, discovery, PRD writing, roadmapping, prioritization, growth, analytics, design, career prep, and legal |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
 _More community skills coming soon! Submit a PR to add your skill._


### PR DESCRIPTION
## What this adds

**[PM Skills](https://github.com/DipakMajhi/product-management-skills)** by [Dipak Majhi](https://github.com/DipakMajhi)

82 expert skills for the full PM lifecycle — strategy, discovery, user research, PRD writing, roadmapping, prioritization, sprint planning, growth, analytics, design, career development, and legal.

## Why it fits here

- Uses the `skills/*/SKILL.md` format, fully compatible with Claude Code and Claude.ai
- 82 skills, each with named frameworks (Teresa Torres, Geoffrey Moore, Reforge, Nielsen), worked examples, anti-patterns, and structured output templates
- Skills range from 150 to 800+ lines of expert content
- Covers a domain (product management) not yet represented in the community skills list

Added to the **Individual Skills** table under Community Skills.