### PR TITLE
Add typst-claude-skill: Professional document/PDF generation with Typst

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[typst-claude-skill](https://github.com/ChanMeng666/typst-claude-skill)** | Professional document and PDF generation using the Typst typesetting system, with complete language/CLI reference and 9 templates |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[typst-claude-skill](https://github.com/ChanMeng666/typst-claude-skill)** to the Individual Skills table.

Professional document and PDF generation using the [Typst](https://typst.app/) typesetting system — a modern, fast alternative to LaTeX. Includes complete language reference, CLI reference for Typst v0.14.2, and 9 ready-to-use templates (academic papers, resumes with theme system, technical reports, presentation slides, invoices, CJK documents). Features advanced patterns like cascading theme defaults, scope-based show rules, and modular component functions.

**Repository:** https://github.com/ChanMeng666/typst-claude-skill  
**License:** MIT