### PR TITLE
Add rails-conventions (Rails 8 conventions skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Skills for working with complex file formats:
 
 ### Development
 
+- [rails-conventions](https://github.com/ethos-link/rails-conventions) — Rails 8 conventions + production review guidance (GoodJob/Solid Queue aware).
+
 - **[frontend-design](https://github.com/anthropics/skills/blob/main/skills/frontend-design)** - Instructs Claude to avoid "AI slop" or generic aesthetics and to make bold design decisions. Works very well for React & Tailwind.
 - **[web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder)** - Build complex claude.ai HTML artifacts using React, Tailwind CSS, and shadcn/ui components
 - **[mcp-builder](https://github.com/anthropics/skills/tree/main/skills/mcp-builder)** - Guide for creating high-quality MCP servers to integrate external APIs and services


### PR DESCRIPTION
Adds a new Claude Skill:

- Name: rails-conventions
- Link: https://github.com/ethos-link/rails-conventions
- Description: Rails 8.x architecture, implementation, and review guidance for production codebases; matches existing app conventions; includes queue adapter detection (GoodJob/Solid Queue), security/perf/testing checklists.

Notes:
- Open-source (MIT)
- Contains SKILL.md + references/
- Focused on repeatable Rails development/review workflow