### PR TITLE
Add visual-theme — design theme gallery + extraction skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[visual-theme](https://github.com/kenehong/visual-theme)** | Design theme gallery + extraction skill — translates real-world visual references (photos, moodboards) into complete design systems with oklch tokens. 16 themed previews included |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skill: visual-theme

**Repo**: https://github.com/kenehong/visual-theme
**Gallery**: https://kenehong.github.io/visual-theme/

### What it does
A gallery of 16 design themes inspired by real-world visual references (90s sneaker stores, Windows 95, manga, brutalist print, etc.) + a Claude Code skill to create new themes from any reference image.

Each theme is a JSON file with oklch color tokens, typography, spacing, shadows, and motion values.

### Why it's useful
AI coding tools generate generic-looking UIs. This gives developers visual direction through image references instead of text prompts — "Stop letting AI pick your theme."

### Features
- 16 themed live previews with demo sites + component showcases
- Copy CSS / Copy JSON export
- Claude Code extraction skill (image → design tokens)
- Theme format spec (THEME_FORMAT.md)
- oklch-native, Tailwind/Figma export utilities

MIT licensed.