### PR TITLE
Add AWT — AI-powered E2E testing skill (beta, feedback welcome)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Skills for working with complex file formats:
 - **[web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder)** - Build complex claude.ai HTML artifacts using React, Tailwind CSS, and shadcn/ui components
 - **[mcp-builder](https://github.com/anthropics/skills/tree/main/skills/mcp-builder)** - Guide for creating high-quality MCP servers to integrate external APIs and services
 - **[webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing)** - Test local web applications using Playwright for UI verification and debugging
+- **[awt](https://github.com/ksgisang/AI-Watch-Tester)** - E2E testing with visual matching (OpenCV + OCR), platform auto-detection (Flutter/React/Vue), and learning DB. Install: `npx skills add ksgisang/awt-skill --skill awt -g`. Beta — built with AI, designed for AI coding tools. No API key needed in Skill Mode.
 
 ### Communication
 


### PR DESCRIPTION
## Add AWT to Development / Testing section

```
npx skills add ksgisang/awt-skill --skill awt -g
```

**[AWT (AI Watch Tester)](https://github.com/ksgisang/AI-Watch-Tester)** — Eyes and hands for your AI coding tool. E2E web testing with declarative YAML scenarios, executed in a real browser via Playwright.

### What works now (beta)
- YAML scenarios → Playwright execution with human-like mouse/typing
- Visual matching: OpenCV template matching + OCR (pytesseract) — works on Canvas/Flutter
- Platform auto-detection: Flutter CanvasKit, React, Next.js, Vue, Angular, Svelte
- Structured failure diagnosis (AI-independent) + investigation checklists
- Learning DB: failure patterns stored in SQLite, gets smarter over time
- 5 AI providers: Claude, OpenAI, Gemini, DeepSeek, Ollama
- Skill Mode: no extra AI API key needed — your AI coding tool designs tests, AWT runs them

### What's in development
- VisionAI matcher (multi-modal LLM-based element detection)
- GitHub Actions CI integration
- npm package distribution

Built with the help of AI coding tools — and designed to help AI coding tools test better.

Actively developed by a solo developer at [AILoopLab](https://github.com/ksgisang). Feedback, issues, and contributions are very welcome!