### PR TITLE
Add ShellWard Security Guide skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[ShellWard Security Guide](https://github.com/jnMetaCode/shellward/tree/main/skills/security-guide)** | AI agent security middleware — 8-layer defense with prompt injection detection (32 rules), DLP data flow tracking, dangerous command blocking, PII scanning. Install: `npx clawhub install shellward-security-guide` |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |


### PR DESCRIPTION
Adding ShellWard's security-guide skill next to Trail of Bits Security Skills.

ShellWard is an AI agent security middleware with 8-layer defense:
- Prompt injection detection (32 rules, EN + ZH)
- DLP-style data flow tracking
- Dangerous command blocking
- PII/API key detection

Install: `npx clawhub install shellward-security-guide`
GitHub: https://github.com/jnMetaCode/shellward