### PR TITLE
Add claude-obsidian-reporter: auto daily Git reports in Obsidian

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[claude-obsidian-reporter](https://github.com/sinaayyy/claude-obsidian-reporter)** | Auto-generates daily, weekly, and monthly Git activity reports into your Obsidian vault. Smart backfill, Dataview dashboard, multi-language, Windows/macOS/Linux |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
## What is this skill?

**[claude-obsidian-reporter](https://github.com/sinaayyy/claude-obsidian-reporter)** is a Claude Code skill that automatically generates daily, weekly, and monthly Git activity reports and saves them directly into your Obsidian vault.

## Why add it?

- Type `/report-orchestrator` at end of day — Claude reads your Git commits and writes structured reports instantly
- Smart backfill: generates all missing reports from day one (`backfill=all`) or from a chosen date
- Dataview dashboard auto-generated on first run
- Graph view with color-coded nodes and hierarchy (daily → weekly → monthly → project index)
- Multi-language support, Windows/macOS/Linux compatible
- Install in 2 minutes

## Links

- Repo: https://github.com/sinaayyy/claude-obsidian-reporter
- License: MIT