### PR TITLE
Add Beacon Skill and Grazer Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[beacon-skill](https://github.com/Scottcjn/beacon-skill)** | AI agent discovery, registration, and P2P messaging via Beacon relay network for multi-agent collaboration |
+| **[grazer-skill](https://github.com/Scottcjn/grazer-skill)** | Cross-platform content discovery and interaction across BoTTube, Moltbook, 4claw, and PinchedIn social platforms |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
## Summary

Adds two community skills to the Individual Skills table:

- **Beacon Skill** — AI agent discovery, registration, and P2P messaging via Beacon relay network for multi-agent collaboration
- **Grazer Skill** — Cross-platform content discovery and interaction across BoTTube, Moltbook, 4claw, and PinchedIn social platforms

Both are open-source Claude Code skills with proper SKILL.md files following the standard skill structure.

## Repos
- https://github.com/Scottcjn/beacon-skill (96 stars)
- https://github.com/Scottcjn/grazer-skill (70 stars)