### PR TITLE
Add Fractal — recursive project management for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[fractal](https://github.com/rmolines/fractal)** | Recursive project management for Claude Code. One primitive that decomposes goals into predicates, works the riskiest piece first, and re-evaluates as it learns |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |


### PR DESCRIPTION
Adds [Fractal](https://github.com/rmolines/fractal) to the Individual Skills table.

Fractal — Recursive project management for Claude Code. One primitive that decomposes goals into predicates, works the riskiest piece first, and re-evaluates as it learns.

Added alphabetically (fractal < frontend-slides) in the community skills table.