### PR TITLE
Add skill: meshy-dev/meshy-3d-agent (3D generation via Meshy AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[meshy-3d-agent](https://github.com/meshy-dev/meshy-3d-agent)** | Generate 3D models from text or images, retexture, rig, animate, and prepare for 3D printing using Meshy AI — no MCP server required |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## meshy-3d-agent

AI agent skill for the [Meshy AI](https://www.meshy.ai) 3D generation platform — the leading AI-powered 3D asset creation tool.

**Capabilities:**
- Text to 3D / Image to 3D (single and multi-image)
- Retexture, Remesh, Auto-Rig, Animate
- 3D printing workflow (OBJ download + Bambu Studio integration)
- No MCP server required — pure Markdown skill

**Install:**
```bash
npx skills add meshy-dev/meshy-3d-agent
```

→ https://github.com/meshy-dev/meshy-3d-agent