### PR TITLE
Add tg-send: publish Markdown/Obsidian notes to Telegram channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[tg-send](https://github.com/fulln/tg-send)** | Publish Obsidian/Markdown notes to a Telegram channel — text-only articles sent directly, image articles published via Telegraph with Telegram-hosted images; auto-updates frontmatter after publishing |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skill: tg-send

**Repo**: https://github.com/fulln/tg-send

A Claude Code skill (+ standalone Python script) that publishes Obsidian/Markdown documents to a Telegram channel.

### What it does

- **Text-only articles** → sent directly as Telegram messages (chunked at 3800 chars)
- **Articles with images** → images uploaded to Telegram private chat to get CDN-hosted URLs, then published as a Telegraph article; link + hashtags sent to channel

### Notable features

- Auto-extracts `tags` from frontmatter (both inline and YAML list formats)
- Updates `published.telegram: <date>` in source file after publishing
- Uses Telegram Bot API instead of Application API (more proxy-friendly; no `my.telegram.org` registration needed)
- No third-party image hosting — images hosted on Telegram's own CDN
- Zero dependencies beyond Python stdlib + `curl`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)