### PR TITLE
Add code-to-prd skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[code-to-prd](https://github.com/lihanglogan/code-to-prd)** | Reverse-engineer any frontend codebase into a complete, detailed Product Requirements Document (PRD) — covering every page's fields, interactions, API specs, and page relationships |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
- Adds **code-to-prd** to the Individual Skills table
- Reverse-engineers any frontend codebase into a complete, detailed Product Requirements Document (PRD)
- Covers page fields, interactions, API specs, enum definitions, and page relationships
- Framework agnostic (React, Vue, Angular, Svelte, Next.js, etc.)

**GitHub**: https://github.com/lihanglogan/code-to-prd

🤖 Generated with [Claude Code](https://claude.com/claude-code)