### PR TITLE
Add product-manager-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[product-manager-skills](https://github.com/Digidai/product-manager-skills)** | End-to-end product management skill covering discovery, strategy, PRDs, SaaS metrics, and PM career coaching |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Resubmitting — the repo now has 16 GitHub stars (was under 10 last time).

The skill covers PM workflows end-to-end: discovery, strategy, PRDs, SaaS metrics, career coaching. 26 files, MIT-0 license.