### PR TITLE
Add claude-for-safari Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[claude-for-safari](https://github.com/SDLLL/claude-for-safari)** | Control Safari on macOS via AppleScript — read pages, execute JS, fill forms, take screenshots, all using the user's real browser session |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds Claude for Safari to the community individual skills table.
                                                                                                                               
  It lets Claude control the user's real Safari browser on macOS through native AppleScript and screencapture — no extensions, 
  no separate browser instance. Supports reading pages, executing JS, clicking elements, filling forms, taking screenshots, and
   more.                                                                                                                       
                                                                                                     
  Repo: https://github.com/SDLLL/claude-for-safari                                                                             
  
  - Has clear documentation (README + SKILL.md + Chinese README)                                                               
  - MIT licensed                                                                                     
  - Functional and tested on macOS                                                                                             
  - I have read and followed the contribution guidelines