### PR TITLE
Add claude-code-inventory-skill to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[claude-code-inventory-skill](https://github.com/marbaji/claude-code-inventory-skill)** | Display complete inventory of all installed Claude Code components including MCP servers (with status), plugin marketplaces, available skills, and global CLI tools |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
## Summary

This PR adds the **claude-code-inventory-skill** to the community skills list.

## What This Skill Does

The inventory-checker skill displays a complete inventory of all installed Claude Code components including:
- MCP servers with connection status (✅ Connected, ⚠️ Needs Auth, ❌ Failed)
- Plugin marketplaces and their sources
- Available skills organized by category
- Global CLI tools
- Summary statistics

## Installation

```bash
claude plugin marketplace add marbaji/claude-code-inventory-skill
claude plugin install inventory-checker
```

## Repository

https://github.com/marbaji/claude-code-inventory-skill

## Testing

The skill has been tested and is working correctly. It's already published and installable via the Claude Code plugin system.

---

Thanks for maintaining this awesome list! 🙏
