### PR TITLE
Add affiliate-skills — 45 AI agent skills for affiliate marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[affiliate-skills](https://github.com/Affitor/affiliate-skills)** | 45 AI-powered affiliate marketing skills covering the full funnel: research, content, SEO, landing pages, distribution, analytics, automation. Works with Claude Code and 6+ other AI agents |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add affiliate-skills

**Repository:** https://github.com/Affitor/affiliate-skills
**License:** MIT
**Skills:** 45
**Standard:** [agentskills.io](https://agentskills.io)

### What it is

45 open-source AI agent skills for affiliate marketing. Full funnel: research, content, SEO, landing pages, distribution, analytics, automation. Works with Claude Code, ChatGPT, Gemini, Cursor, Windsurf.

### Compatibility

Claude Code, ChatGPT, Gemini CLI, Cursor, Windsurf, OpenClaw, any AI agent.

### Install

```bash
npx skills add Affitor/affiliate-skills
```

### Why include it

- Largest open-source affiliate marketing skill collection (45 skills)
- Follows agentskills.io standard
- Full funnel coverage (8 stages with closed-loop flywheel)
- Works across all major AI coding agents
- Active development, MIT licensed