### PR TITLE
Add Prism Scanner — security scanner for agent skills/plugins/MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[Prism Scanner](https://github.com/aidongise-cell/prism-scanner)** | Security scanner for AI Agent skills, plugins, and MCP servers — 39+ detection rules, AST taint tracking, A-F grading, post-uninstall residue cleanup |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |


### PR DESCRIPTION
## Summary

Adds [Prism Scanner](https://github.com/aidongise-cell/prism-scanner) to the skills table alongside Trail of Bits Security Skills.

**Prism Scanner** is an open-source (Apache 2.0) security scanner for AI Agent skills, plugins, and MCP servers:
- **39+ detection rules**: AST taint tracking, malicious signatures, metadata analysis, system residue
- **A-F grading** with actionable recommendations
- **Full lifecycle**: pre-install + post-uninstall cleanup

Install: `pip install prism-scanner` or `npx skills add aidongise-cell/prism-scanner`