### PR TITLE
Add iris-eval/mcp-server to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Skills for working with complex file formats:
 - **[web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder)** - Build complex claude.ai HTML artifacts using React, Tailwind CSS, and shadcn/ui components
 - **[mcp-builder](https://github.com/anthropics/skills/tree/main/skills/mcp-builder)** - Guide for creating high-quality MCP servers to integrate external APIs and services
 - **[webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing)** - Test local web applications using Playwright for UI verification and debugging
+- **[iris-eval](https://github.com/iris-eval/mcp-server)** - MCP-native agent eval & observability. Trace agent executions, evaluate output quality, and track costs — agents discover it automatically via MCP
 
 ### Communication
 


### PR DESCRIPTION
Adding [Iris](https://github.com/iris-eval/mcp-server) — MCP-native eval and observability for AI agents. MIT licensed.