### PR TITLE
Add agent-review-panel skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[agent-review-panel](https://github.com/wan-huiyan/agent-review-panel)** | Multi-agent adversarial review panel where Claude Code subagents with different perspectives review work, debate, reach consensus, then a supreme judge renders the final verdict. Based on ChatEval (ICLR 2024), AutoGen, MachineSoM (ACL 2024), and DebateLLM research. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds **[Agent Review Panel](https://github.com/wan-huiyan/agent-review-panel)** to the Individual Skills table in the Community Skills section
- Multi-agent adversarial review panel where Claude Code subagents with different perspectives review work, debate, reach consensus, then a supreme judge renders the final verdict
- Based on ChatEval (ICLR 2024), AutoGen, MachineSoM (ACL 2024), and DebateLLM research

🤖 Generated with [Claude Code](https://claude.com/claude-code)