### PR TITLE
Add ml-feature-evaluator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[ml-feature-evaluator](https://github.com/wan-huiyan/ml-feature-evaluator)** | Structured go/no-go evaluation for adding features to production ML models. Runs a 6-query diagnostic (distribution, outcome gradient, coverage gaps, entropy), temporal safety checklist, and produces decision-backed implementation plans with mandatory review. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds **[ml-feature-evaluator](https://github.com/wan-huiyan/ml-feature-evaluator)** to the Individual Skills table in the Community Skills section.
- Structured go/no-go evaluation for adding features to production ML models — runs a 6-query diagnostic (distribution, outcome gradient, bucket decomposition, coverage gaps, entropy), temporal safety checklist, and produces decision-backed implementation plans with mandatory review.

## Skill Details

| Field | Value |
|---|---|
| Name | ML Feature Evaluator |
| URL | https://github.com/wan-huiyan/ml-feature-evaluator |
| Category | Individual Skills (Community) |

## Checklist

- [x] Based on a real use case
- [x] No duplicate in existing skills
- [x] Follows the existing table format in Individual Skills section
- [x] Clear, concise description

🤖 Generated with [Claude Code](https://claude.com/claude-code)