### PR TITLE
feat: add telegram-bridge Claude Code skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[telegram-bridge](https://github.com/Zzxmh/telegram-bridge)** | Claude Code skill that scaffolds a Telegram bot bridging your local Claude Code instance to any Telegram chat, enabling remote chat, filesystem navigation, shell execution, session management, and task monitoring via hooks |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Description

Adds [telegram-bridge](https://github.com/Zzxmh/telegram-bridge) to the Individual Skills table.

**telegram-bridge** is a Claude Code skill () that scaffolds a full-featured Telegram bot bridging your local Claude Code instance to any Telegram chat.

### What it does
- Chat with Claude Code from Telegram with live-streaming responses
- Filesystem navigation (, , , )
- Shell execution (, , )
- Session management (, , , )
- Model switching ()
- Task monitoring via Claude Code hooks (PreToolUse/Stop notifications pushed to Telegram)

### Installation
Copy the skill file to , then invoke  in any Claude Code session to scaffold the bridge.

### Links
- Repo: https://github.com/Zzxmh/telegram-bridge
- License: MIT
