### PR TITLE
Add healthcare-agents to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[healthcare-agents](https://github.com/ajhcs/healthcare-agents)** | 51 specialized healthcare administration agents with MHA-level expertise across 10 divisions including revenue cycle, compliance, quality, clinical ops, payer relations, and health IT |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
- Adds [healthcare-agents](https://github.com/ajhcs/healthcare-agents) to the Individual Skills table under Community Skills
- 51 specialized healthcare administration AI agents with MHA-level expertise across 10 divisions (revenue cycle, compliance, quality, clinical ops, payer relations, health IT, and more)
- Modeled after the agency-agents pattern — each agent is a standalone `.md` personality file with deep domain expertise, installable into `~/.claude/agents/`

## Why this belongs here
Healthcare administration is a complex, regulation-heavy domain where repeatable expert guidance is extremely valuable. These agents cover areas like HIPAA compliance, Medicare billing, clinical documentation improvement, EHR optimization, and credentialing — tasks that benefit enormously from structured AI expertise. The project includes 51 agent files plus install scripts, well beyond a single SKILL.md.

## Test plan
- [x] Link to repository is valid and public
- [x] Description matches existing table format
- [x] Entry placed in Individual Skills table alongside other community skills
- [x] No formatting issues introduced