### PR TITLE
Add SkillHub - Chinese AI Skill Marketplace (50+ skills, 5000+ index)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[SkillHub / 技能宝](https://github.com/kevinaimonster/skill-hub)** | Chinese AI skill marketplace with 50+ curated skills covering Xiaohongshu, Douyin, WeChat, code review, security audit, and more. 5000+ skill index, 12-layer security check, supports 42 agent platforms |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What is SkillHub / 技能宝?

Chinese-first AI skill marketplace with:
- 50+ curated skills (20 Chinese-specific originals like Xiaohongshu, Douyin, WeChat)
- 5,000+ skill index covering 13 categories
- 12-layer security scanning
- Support for 42 agent platforms (Claude Code, Cursor, Windsurf, etc.)

Install: `npx skills add kevinaimonster/skill-hub --full-depth --skill '*' -g -y`

GitHub: https://github.com/kevinaimonster/skill-hub