### PR TITLE
Add Council 2.0 — multi-model advisory skill with adversarial role-based framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[Council 2.0](https://github.com/deashidle-stack/claude-skills)** | Multi-model advisory with adversarial role-based framing — GPT-5.4 (Skeptiker) vs Gemini 3.1 Pro (Konstruktør) in parallel, with divergence-first synthesis and explicit confidence scoring |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
 _More community skills coming soon! Submit a PR to add your skill._


### PR DESCRIPTION
## New skill: Council 2.0

**Repo:** https://github.com/deashidle-stack/claude-skills  
**License:** MIT  
**Author:** Andreas Hidle / Deveras

### What it does

Council 2.0 is a Claude Code skill for multi-model advisory with structured adversarial reasoning.

Instead of asking two models the same neutral question, it assigns roles that **guarantee** genuine divergence:

- **Skeptiker** (GPT-5.4 via Codex CLI) — Assumes failure. Finds risks, gaps, fatal flaws.
- **Konstruktør** (Gemini 3.1 Pro) — Assumes success. Finds underestimated strengths and opportunities.

Claude acts as **Chair** and synthesizes with a divergence-first approach — never flattening disagreement into false consensus.

### Key features

- Phase 0 question-sharpening before dispatch
- Evidence citations + confidence level (HIGH/MEDIUM/LOW) per finding
- Same-answer test — flags when advisors converge (strong consensus OR shared blind spot)
- Case A/B/C classification: Strong Consensus / Live Disagreement / Partial Overlap
- Steel-man requirement per advisor ("what would change my assessment")
- Three modes: `debug`, `design`, `council`

### Installation

```
/plugin marketplace add deashidle-stack/claude-skills
/plugin install council@deveras-skills
```

Inspired by Perplexity's Model Council and adversarial sparring patterns from multi-agent systems.