### PR TITLE
Add skill_miner to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[liaoandi/skill_miner](https://github.com/liaoandi/skill_miner)** - Mine reusable skills from your AI agent session history. Scans Claude Code, Codex, OpenClaw, and Gemini CLI sessions to find recurring workflows and generate SKILL.md files
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
## What

Adds [skill_miner](https://github.com/liaoandi/skill_miner) to the **Tools** section.

## About skill_miner

- Scans AI agent session history (Claude Code, Codex, OpenClaw, Gemini CLI) to discover recurring workflows
- Uses LLM to extract, classify, and deduplicate skill candidates
- Generates ready-to-use SKILL.md files from accepted candidates
- Available on [PyPI](https://pypi.org/project/skill-miner/): `pip install skill-miner[anthropic]`

Complements Skill_Seekers (docs → skills) by mining skills from **usage history** instead.