### PR TITLE
Add privacy-mask to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills for working with complex file formats:
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[privacy-mask](https://github.com/fullstackcrew-alpha/privacy-mask)** | Local image privacy masking — detect and redact PII, API keys, and secrets in screenshots via OCR + 47 regex rules. Installs as a Claude Code hook for automatic masking. 100% offline |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |


### PR DESCRIPTION
Adds [privacy-mask](https://github.com/fullstackcrew-alpha/privacy-mask) — a local image privacy masking tool that detects and redacts PII, API keys, and secrets in screenshots via OCR + 47 regex rules. Installs as a Claude Code UserPromptSubmit hook. 100% offline, MIT licensed.