### PR TITLE
Add autoevolve — evolve strategies through automated self-play

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[autoevolve](https://github.com/MrTsepa/autoevolve)** | Iteratively improve code, strategies, or prompts through mutation, evaluation, and selection via automated self-play |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [autoevolve](https://github.com/MrTsepa/autoevolve) to the Individual Skills table.

  **autoevolve** lets an AI coding agent improve strategies through automated self-play: mutate a candidate, benchmark it head-to-head against previous versions, rate with Bradley-Terry MLE, and branch from the Pareto front.

  Good fits: game bots, prompt optimization, heuristic policies, trading strategies, adversarial co-evolution.

  Available via:
  - `npx skills add MrTsepa/autoevolve`
  - `claude skill add https://github.com/MrTsepa/autoevolve@v0.1.0`