### PR TITLE
Add AgenTopology skill — multi-agent topology designer

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[AgenTopology](https://github.com/agentopology/agentopology)** | Design multi-agent teams with a Claude Code skill. Type `/agentopology`, describe your team in plain English, get a full topology with agents, flows, gates, hooks. Visualize as interactive graph. Scaffold to 7 platforms |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
- Adds AgenTopology to the Community Skills > Individual Skills table
- AgenTopology is a Claude Code skill for designing multi-agent teams: describe your team in plain English, get a full topology with agents, flows, gates, and hooks, visualize as an interactive graph, and scaffold to 7 platforms

## Link
https://github.com/agentopology/agentopology

🤖 Generated with [Claude Code](https://claude.com/claude-code)