### PR TITLE
Add claude-chat-dashboard to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[claude-chat-dashboard](https://github.com/tusharika-rastogi/claude-chat-dashboard)** | Fetches your full Claude chat history and renders a searchable, tagged dashboard inside claude.ai |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
A claude.ai skill that fetches your full chat history, generates tags from the content, and renders an interactive filterable dashboard. Works inside claude.ai using the recent_chats tool. MIT licensed.