### PR TITLE
Add Junshi (research strategist) to skills list

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[Junshi](https://github.com/junshi-research/research-junshi)** | Personalized research strategist for Claude Code that reads your papers, tracks relevant literature, and proposes ranked research ideas with suggested first experiments |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

This PR adds Junshi to the Community Skills -> Individual Skills table.

Junshi is a Claude Code skill for researchers designed to act as a personalized research strategist. It first reads your papers and research context, then reviews relevant new literature, and finally produces a short daily digest with:

1. a small number of research ideas worth considering,
2. a suggested first step for each idea, and
3. the main risk that could make the idea fail.


## Repository
https://github.com/junshi-research/research-junshi

