### PR TITLE
Add cup (ClickUp CLI) to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[cup](https://github.com/krodak/clickup-cli)** | ClickUp CLI for AI agents and humans. Manage tasks, sprints, and time tracking from your terminal |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [cup](https://github.com/krodak/clickup-cli) (`@krodak/clickup-cli`) to the Individual Skills table.

cup is a ClickUp CLI built for AI coding agents (Claude Code, Codex, etc.) and humans. It has 40+ commands covering tasks, comments, sprints, time tracking, custom fields, checklists, tags, and attachments. It ships as a Claude Code plugin with skill files included.

- GitHub: https://github.com/krodak/clickup-cli
- npm: https://www.npmjs.com/package/@krodak/clickup-cli