### PR TITLE
Add Graphify.md skills: infographic-engine, learn-engine, context-extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
+| **[graphify-infographic-engine](https://graphifymd.com)** | Generate interactive HTML infographics for textbooks and courses — 8 layout types (process flow, comparison, timeline, concept map, etc.), dark theme, self-contained, D3.js when needed. Built for the YODA educational pipeline. |
+| **[graphify-learn-engine](https://graphifymd.com)** | Conversational learning engine with 5-layer answer architecture: one-liner → analogy → mechanism → relationship map → comprehension check. Adapts to learner domain, supports voice mode, outputs as dialogue, textbook sections, FAQ, or flashcards. |
+| **[graphify-context-extractor](https://graphifymd.com)** | Transforms any source — transcripts, PDFs, web pages, voice memos, raw text — into a portable knowledge graph compressed to .md. 170x token density, 93% compression. Output works in Claude, ChatGPT, Cursor, MCP, or any AI environment. |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
## Summary
- Adds 3 community skills from [Graphify.md](https://graphifymd.com) to the Individual Skills table
- **infographic-engine** — interactive HTML infographic generation for educational content (8 layout types, D3.js, dark theme, self-contained)
- **learn-engine** — conversational learning engine with 5-layer answer architecture (one-liner → analogy → mechanism → relationship map → comprehension check)
- **context-extractor** — transforms any source (transcripts, PDFs, web pages, voice memos) into knowledge graphs compressed to portable .md at 170x token density

## Context
These skills are built around knowledge graph → .md compression — structuring domain intelligence as traversable entity-relationship graphs, then compressing to ~12KB markdown files that work across Claude, ChatGPT, Cursor, MCP, or any AI environment.

Live demos:
- [Healthcare KG Demo](https://graphifymd.com/healthcare-kg-demo.html) — 200 clinical concepts, drug interactions, care pathways
- [March Madness KG](https://graphifymd.com/march-madness.html) — 68 teams, 350+ relationships, real-time scores
- [Industry Verticals](https://graphifymd.com/verticals.html) — 12 industries where KG → .md solves real problems

Related discussion: [Proposal: Knowledge Graph → .md Compression as a Skill Content Pattern](https://github.com/agentskills/agentskills/discussions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)