### PR TITLE
Add agent-skill-bus to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[agent-skill-bus](https://github.com/ShunsukeHayashi/agent-skill-bus)** | Self-improving task orchestration for AI agent systems — framework-agnostic (Claude Code, Codex, LangGraph, CrewAI, OpenClaw), published on npm, zero dependencies |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds **[agent-skill-bus](https://github.com/ShunsukeHayashi/agent-skill-bus)** to the Individual Skills table.

## About the skill

- **What it does**: Self-improving task orchestration for AI agent systems. Enables agents to discover, load, and chain skills dynamically with a feedback loop that refines execution over time.
- **Framework-agnostic**: Works with Claude Code, Codex, LangGraph, CrewAI, and OpenClaw — no vendor lock-in.
- **Published on npm**: Available as a package, zero runtime dependencies.
- **MIT licensed**.
- **35+ GitHub stars** in the first 3 days after launch (organic growth).

## Checklist

- [x] The skill has a clear purpose and use case
- [x] Includes documentation (README + SKILL.md)
- [x] Follows Claude Skills best practices
- [x] More than a single SKILL.md file (full npm package with tests, examples, and tooling)
- [x] 35+ stars (exceeds the 10-star minimum threshold)
- [x] No SaaS dependency — fully standalone, zero external service requirements
- [x] MIT license

## Format

Entry follows the exact table row format from CONTRIBUTING.md:
```
| **[name](link)** | Description |
```