### PR TITLE
Add claude-learn to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[claude-learn](https://github.com/OutcomeFocusAi/claude-learn)** | Self-improving behavioral rules plugin with scored rules, automated decay, community playbook sharing, and collective intelligence |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
- Adds [claude-learn](https://github.com/OutcomeFocusAi/claude-learn) to the Individual Skills table
- Self-improving behavioral rules plugin for Claude Code
- Closed feedback loop with scored rules, automated decay, and collective intelligence via community playbook sharing

## Social Proof
- Published as a Claude Code plugin on the marketplace: `claude plugin marketplace add OutcomeFocusAi/claude-learn`
- Active development with v3.1.0 released
- Includes 3 mechanical hooks (language detection, outcome tracking, session init)

🤖 Generated with [Claude Code](https://claude.com/claude-code)