### PR TITLE
Add claude-handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Skills for working with complex file formats:
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
+| **[claude-handoff](https://github.com/REMvisual/claude-handoff)** | Cross-session handoff system with chain tracking, context summaries, and beads integration for structured work continuity |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |


### PR DESCRIPTION
## [claude-handoff](https://github.com/REMvisual/claude-handoff)

Session handoff skills for Claude Code that capture decisions, failed approaches, measurements, and next steps — so your next session picks up exactly where you left off.

### Why it exists

Claude already tries to hand off context between sessions — generating summaries with "What's broken" and "Next session paste-prompt." It looks like a handoff. It isn't one. We ran a controlled A/B test (same bug, same codebase, three fresh sessions) and found:

| | Session summary (no skill) | `/handoff` skill |
|---|---|---|
| User had to intervene | Yes | No — self-gated |
| Root cause precision | Surface-level | Precise call chain |
| Fix correctness | Correct but unjustified | Correct and justified |
| Chain awareness | Zero | Referenced prior session's analysis |

Full comparison data: [docs/COMPARISON](https://github.com/REMvisual/claude-handoff/blob/master/docs/COMPARISON_skill-vs-internal-handoff.md)

### Features (v1.5.0)

- **Deep context mining** — 12-item extraction checklist with tiered strategy for large contexts (map-reduce at 500K+ tokens)
- **Chain tracking** — handoffs link across sessions via task IDs, with sequence numbers and parent references
- **Self-validation** — enforces line minimums and data completeness; re-mines if too thin
- **Anti-shadowing guard** — prevents Claude from generating inferior freeform handoffs without the skill
- **Onboarding protocol** — next session must prove comprehension before executing
- **PreCompact hook** — safety net before context compression
- **Works standalone** — optional integrations with Beads (task tracking) and OpenViking (AI memory)

### Install

```bash
git clone https://github.com/REMvisual/claude-handoff.git
cp -r claude-handoff/skills/handoff ~/.claude/skills/
cp -r claude-handoff/skills/handoffplan ~/.claude/skills/
```