### PR TITLE
Add boutique-resume-agency skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[boutique-resume-agency](https://github.com/stevesolun/CV_Boutique_Agency)** | Top-tier boutique resume agency — builds, critiques, rewrites, and QC-controls resumes to 8.5+ quality with an 8-expert panel and zero hallucinations. Outputs a send-ready `.docx`. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add `boutique-resume-agency` skill

**Skill:** boutique-resume-agency
**Repo:** https://github.com/stevesolun/CV_Boutique_Agency
**Category:** Career / Resume

### What it does

Acts as a top-tier boutique resume agency with a panel of eight expert reviewers (AI veteran, HR specialist, founder, business operator, devil's advocate, creative reframer, QC lead, hallucination detector). 

- Builds resumes from scratch, critiques uploaded resumes, rewrites, and tailors to specific roles
- Enforces strict hallucination controls — no unsupported metrics, no inflated claims
- Scores using a weighted multi-expert model with per-section tracking
- Stops only when score ≥ 8.5, no critical blocker flags, user accepts
- Final output includes a send-ready `.docx`

### Score targets
- 8.5+ = send-ready (minimum to stop)
- 9.0+ = must-call quality
- 9.5+ = exceptional (rare)

### Install
```
/plugin marketplace add stevesolun/CV_Boutique_Agency
/plugin install boutique-resume-agency@cv-boutique-agency
```

### Trigger phrases
`build my resume`, `critique my resume`, `rewrite my resume`, `tailor my resume`, `fast mode resume`, `boutique resume agency`