### PR TITLE
Add VPN skill for Cisco Secure Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[vpn](https://github.com/matuspavliscak/claude-code-kit/tree/main/.claude/skills/vpn)** | Connect/disconnect Cisco Secure Client (AnyConnect) VPN via openconnect CLI — certificate auth, macOS Keychain, no GUI needed |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
- Adds a VPN skill for connecting/disconnecting Cisco Secure Client (AnyConnect) VPN from Claude Code
- Uses `openconnect` CLI with certificate auth and macOS Keychain — no GUI automation needed
- Repo: https://github.com/matuspavliscak/claude-code-kit

## Why
Cisco Secure Client is the dominant corporate VPN. There's no existing Claude Code skill for it — only a Tailscale one. Many developers struggle with automating AnyConnect (TLS handshake stalls with Cisco CLI, GUI can't be scripted reliably). This skill solves it with openconnect.