### PR TITLE
Add translate-book project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[translate-book](https://github.com/deusyu/translate-book)** | Translate entire books (PDF/DOCX/EPUB) into any language using parallel sub-agents with chunk-level resume and multi-format output |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Book translation skill that converts PDF/DOCX/EPUB to markdown chunks, translates in parallel with sub-agents (8 concurrent), validates with SHA-256 manifest, and builds HTML/DOCX/EPUB/PDF output. 400+ GitHub stars.