### PR TITLE
Add skill: DevOps Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
+| **[devops-agent](https://github.com/fullstackcrew-alpha/skill-devops-agent)** | One-click deploy, monitoring setup (Prometheus+Grafana), scheduled backups, and fault diagnosis with safety-first design including confirmation prompts, dry-run, and snapshot rollback |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
## New Skill: DevOps Agent

**DevOps Agent** — One-click deploy, monitoring setup (Prometheus+Grafana), scheduled backups, and fault diagnosis with safety-first design including confirmation prompts, dry-run, and snapshot rollback

- **GitHub**: https://github.com/fullstackcrew-alpha/skill-devops-agent
- **ClawHub**: https://clawhub.ai/s/devops-agent
- **Install**: `clawhub install devops-agent`
- **License**: MIT

Published by [FullStackCrew](https://github.com/fullstackcrew-alpha).