### PR TITLE
Add skill: CN Content Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
+| **[cn-content-matrix](https://github.com/fullstackcrew-alpha/skill-cn-content-matrix)** | Chinese multi-platform content generator for Xiaohongshu, WeChat, Douyin, and Bilibili with true style transfer, compliance review, and sensitive word detection |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
## New Skill: CN Content Matrix

**CN Content Matrix** — Chinese multi-platform content generator for Xiaohongshu, WeChat, Douyin, and Bilibili with true style transfer, compliance review, and sensitive word detection

- **GitHub**: https://github.com/fullstackcrew-alpha/skill-cn-content-matrix
- **ClawHub**: https://clawhub.ai/s/cn-content-matrix
- **Install**: `clawhub install cn-content-matrix`
- **License**: MIT

Published by [FullStackCrew](https://github.com/fullstackcrew-alpha).