### PR TITLE
Add hand-drawn-diagrams: Excalidraw diagram skill with animation and hosted edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Skills for working with complex file formats:
 
 - **[algorithmic-art](https://github.com/anthropics/skills/tree/main/skills/algorithmic-art)** - Create generative art using p5.js with seeded randomness, flow fields, and particle systems
 - **[canvas-design](https://github.com/anthropics/skills/tree/main/skills/canvas-design)** - Design beautiful visual art in .png and .pdf formats using design philosophies
+- **[hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams)** - Generate hand-drawn Excalidraw diagrams from a prompt — animated SVG, hosted edit link, and PNG export. Works with Claude Code, Codex, and any agent supporting standard skill paths
 - **[slack-gif-creator](https://github.com/anthropics/skills/tree/main/skills/slack-gif-creator)** - Create animated GIFs optimized for Slack's size constraints
 
 ### Development


### PR DESCRIPTION
## Add hand-drawn-diagrams

**Repo:** https://github.com/muthuishere/hand-drawn-diagrams
**Author:** Muthukumaran Navaneethakrishnan ([@muthuishere](https://github.com/muthuishere))

### What it does

An agent skill that generates hand-drawn Excalidraw diagrams from a natural language prompt — picks the right diagram type (architecture, UX flows, teaching explainers, funnels, wireframes), lays out elements without overlap, and delivers:

- A hosted edit link — browser opens directly to the Excalidraw editor, no app install needed
- An animated SVG that draws itself stroke by stroke
- PNG export on request

Works with Claude Code, Codex, and any agent supporting standard skill paths.

### Placement

Added to **Design & Creative** alongside canvas-design and slack-gif-creator.