### PR TITLE
Add ClawSec and ClawSearch security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Skills for working with complex file formats:
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
+| **[ClawSec](https://clawsec.cc)** | Security audit platform for AI agent skills — 5-tier analysis with static analysis, pattern matching, LLM semantic review, and Firecracker sandbox execution |
+| **[ClawSearch](https://clawsearch.cc)** | Security-focused search engine for discovering and evaluating AI agent skills, MCP servers, and Claude Code extensions |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |


### PR DESCRIPTION
## What are ClawSec and ClawSearch?

- **[ClawSec](https://clawsec.cc)** - Security audit platform for AI agent skills with 5-tier analysis (static analysis, pattern matching, LLM semantic review, Firecracker sandbox execution)
- **[ClawSearch](https://clawsearch.cc)** - Security-focused search engine for discovering and evaluating AI agent skills, MCP servers, and Claude Code extensions

## Changes

Added both tools to the Individual Skills table in the Community Skills section, in alphabetical order.