### PR TITLE
Add obey — rule enforcement plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[obey](https://github.com/Lexxes-Projects/obey)** | Rule enforcement plugin with /remember, /rules, /forget skills. Save rules in natural language, enforced with 17 lifecycle hooks across three scopes (global, stack-specific, project-local). Active blocking, completion checklists, audit trail |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [obey](https://github.com/Lexxes-Projects/obey) to the community skills table.

**Skills:** `/remember`, `/rules`, `/forget`
**What it does:** Claude Code plugin that makes Claude follow user rules with natural language. Uses all 17 Claude Code lifecycle hooks for enforcement.
**License:** MIT
**Social proof:** Solves the #1 user frustration — Claude agreeing to rules then breaking them minutes later.