### PR TITLE
Add thinking-partner to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[thinking-partner](https://github.com/mattnowdev/thinking-partner)** | 150+ mental models with orientation detection for structured reasoning and decision-making |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Proposing my `thinking-partner` skill. It's an agent skill for structured reasoning that addresses issues with [sycophancy problem](https://github.com/anthropics/claude-code/issues/3382), and genuinely helps with thinking through the problems by utilizing 150+ mental models (inspired by Munger's latticework, Parrish's Great Mental Models, Taleb's Antifragile, Kahneman's Thinking Fast and Slow).

And most importantly it detects first when you're not actually thinking clearly before picking up the right models to use. 

It received *95+* stars in one day and positive reception from the community: [https://www.reddit.com/r/ClaudeAI/comments/1rz40f5/i_gave_claude_150_mental_models_and_a_framework](https://www.reddit.com/r/ClaudeAI/comments/1rz40f5/i_gave_claude_150_mental_models_and_a_framework)

## What Makes It Different

| Feature | This Skill | Others |
|---|---|---|
| **Orientation Detection** | Diagnoses 6 thinking states with targeted interventions | Generic questioning |
| **150+ Mental Models** | Full catalog organized by discipline with key questions | Handful of models |
| **Cognitive Operations** | 7 complementary operation pairs (Decouple/Re-couple, Hold/Resolve, etc.) | None |
| **Structured Workflow** | 6-step deterministic process from diagnosis to synthesis | Freeform |
| **Anti-Patterns** | Explicit guidance on what NOT to do | None |
   