### PR TITLE
Add feasibility-study skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[feasibility-study](https://github.com/topcoder1/jz_skills)** | Product feasibility studies with TELOS framework — analyzes technical, economic, market, operational, schedule, and automation feasibility with AI-adjusted effort/cost estimation |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skill: feasibility-study

**Repo:** https://github.com/topcoder1/jz_skills

Comprehensive product feasibility studies using the TELOS framework (Technical, Economic, Legal/Compliance, Operational, Schedule) plus an Automation Feasibility dimension.

### Features
- 6-phase workflow with quality gates and 3 depth modes (quick/standard/deep)
- AI-adjusted effort estimation (COCOMO II, function points, T-shirt sizing)
- Three-dimension output: effort (person-months), calendar time, cash cost
- Automation feasibility analysis with solo-operator viability scoring
- Interactive report presentation with guided discussion
- Python estimation script (stdlib only, no dependencies)
- Plugin-packaged for easy installation

### Usage
```
/feasibility-study BuiltWith.com --depth standard
/feasibility-study "AI-powered code review tool" --depth quick
```

### Install
```bash
claude plugin marketplace add topcoder1/jz_skills
claude plugin install feasibility-study
```