### PR TITLE
Add cozempic — context weight-loss for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[/cozempic:treat](https://github.com/Ruya-AI/cozempic)** | ✨ v1.2.x — Self-updating now, atomic writes, strict session guard, zero false positives on team detection. Context weight-loss for Claude Code — 13 pruning strategies, Agent Team protection, MCP tools. |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
✨ v1.2.x — Self-updating now, atomic writes, strict session guard, zero false positives on team detection.

**[cozempic](https://github.com/Ruya-AI/cozempic)** is a context weight-loss CLI + plugin for Claude Code. Prunes bloated JSONL sessions with 13 strategies, protects Agent Teams from compaction loss with schema-first detection, ships a 5-tool MCP server, and auto-updates on startup.

- Zero external dependencies
- `pip install cozempic` + `/plugin marketplace add Ruya-AI/cozempic`