### PR TITLE
Add career-ops skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[career-ops](https://github.com/poferraz/career-ops)** | A research-backed career coaching skill that surfaces achievements and generates zero-slop resumes, cover letters, and outreach materials |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Description
Adding [career-ops](https://github.com/poferraz/career-ops) to the Individual Skills table.

This is a comprehensive, multi-module orchestrator skill (not a simple one-file prompt). It turns Claude Code into a research-backed career coach using Motivational Interviewing frameworks to surface achievements before generating zero-slop materials.

**Value Add to Community:**
*   **Anti-Slop Quality Gate:** Every output passes through a 5-dimension scoring rubric to eliminate AI-tells (generic specificity, banned phrases) before reaching the user.
*   **Research Backed:** Built on 5 rounds of verified hiring data (e.g., eye-tracking studies, 7,712-resume callback experiments).
*   **Session Persistence:** Includes a template for cross-session learning about the user's background.
*   **Multi-Platform Ready:** Includes conversion scripts making it adaptable beyond Claude Code.

*Note on AI Generation:* This PR was generated via the gh CLI, but the skill itself is a hand-architected framework built on empirical research data, completely adhering to the non-promotional and high-value tenets of this repository's CONTRIBUTING.md.