### PR TITLE
Add Claude Code Wrapped to skills list

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
-
+| **[Claude Code Wrapped](https://github.com/natedemoss/claude-skills)** | Spotify Wrapped but for Claude Code! |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
This pull request adds a new entry to the list of community skills in the `README.md`. The new skill, "Claude Code Wrapped," is now included alongside other notable community skills.

Community skills update:

* Added "Claude Code Wrapped" to the community skills table in `README.md`.