### PR TITLE
Add format-thesis: Chinese thesis auto-formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[format-thesis](https://github.com/Lang-Li-1/format-thesis)** | Auto-format Chinese academic thesis (.docx) — configurable page setup, heading styles, body text, figure/table captions, TOC generation, and GB/T 7714-2015 references |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add format-thesis

Adds [format-thesis](https://github.com/Lang-Li-1/format-thesis) to the Individual Skills table.

**format-thesis** is a Chinese academic thesis (.docx) auto-formatter skill for Claude Code. Features:

- 4 modules: body formatting, TOC generation, GB/T 7714-2015 references, TOC indent fixing
- All formatting parameters configurable via JSON config
- References loaded from external JSON files
- Auto-detects TOC insertion point and style IDs
- Includes ready-to-use `/format-thesis` Claude Code skill

Built with python-docx and lxml. MIT licensed.