### PR TITLE
Add OpenDivination

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[OpenDivination](https://github.com/amenti-labs/opendivination)** | Tarot and I Ching SDK plus installable divination skill with auditable entropy provenance, QRNG support, guided setup, and optional resonance mode |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
- add OpenDivination to the individual community skills table

## Why
OpenDivination is a public skill + SDK for tarot and I Ching that emphasizes provenance and explicit entropy sources. It fits the list's focus on reusable Claude-compatible skills while being distinct from the existing coding-heavy entries.
