### PR TITLE
Add openclaw-persona-forge skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[openclaw-persona-forge](https://github.com/eamanc-lab/openclaw-persona-forge)** | Forge a complete lobster soul for OpenClaw AI Agents — outputs identity, SOUL.md, boundary rules, name, and avatar prompt via gacha or guided mode |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds **openclaw-persona-forge** to the Individual Skills table.

## Skill Overview

- **Name:** openclaw-persona-forge
- **GitHub:** https://github.com/eamanc-lab/openclaw-persona-forge
- **ClawHub:** https://clawhub.ai/eamanc-lab/openclaw-persona-forge
- **License:** MIT

Forge a complete lobster soul for OpenClaw AI Agents. Outputs identity, SOUL.md, boundary rules, name, and avatar prompt via gacha or guided mode.

The skill provides two modes:
- **Gacha mode** — random soul generation with personality traits, speech patterns, and backstory
- **Guided mode** — step-by-step soul crafting with user input at each stage

Outputs include a structured `SOUL.md` file, boundary rules, a unique name, and an image-generation prompt for the agent's avatar.

## Checklist

- [x] Follows the existing table format
- [x] Description is concise and accurate
- [x] Link is valid and points to the correct repository
- [x] Skill has documentation (README + SKILL.md)
- [x] Skill is functional and tested