### PR TITLE
Add openclaw-soul-forge skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[openclaw-soul-forge](https://github.com/eamanc-lab/openclaw-persona-forge/tree/main/skills/openclaw-soul-forge)** | English-first soul forging for OpenClaw lobster agents — choose direction or pull gacha to get identity, SOUL.md, rules, name, and avatar |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds **openclaw-soul-forge** to the Individual Skills table.

## Skill Overview

- **Name:** openclaw-soul-forge
- **GitHub:** https://github.com/eamanc-lab/openclaw-persona-forge/tree/main/skills/openclaw-soul-forge
- **ClawHub:** https://clawhub.ai/eamanc-lab/openclaw-soul-forge
- **License:** MIT

English-first soul forging for OpenClaw lobster agents. Choose direction or pull gacha — get identity, SOUL.md, rules, name, and avatar.

This is the English-first variant of the persona forge skill, designed for international users and English-speaking OpenClaw communities. It supports:
- **Gacha mode** — randomized soul generation
- **Directed mode** — user chooses a direction and the skill crafts a soul around it

All outputs (identity card, SOUL.md, boundary rules, name, avatar prompt) are generated in English.

## Checklist

- [x] Follows the existing table format
- [x] Description is concise and accurate
- [x] Link is valid and points to the correct repository/subfolder
- [x] Skill has documentation (README + SKILL.md)
- [x] Skill is functional and tested