### PR TITLE
Add openclaw-user-profiler skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[openclaw-user-profiler](https://github.com/eamanc-lab/openclaw-persona-forge/tree/main/skills/openclaw-user-profiler)** | Build user.md profiles through conversation and recommend Claude Code Skills based on 42 roles across 11 categories |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds **openclaw-user-profiler** to the Individual Skills table.

## Skill Overview

- **Name:** openclaw-user-profiler
- **GitHub:** https://github.com/eamanc-lab/openclaw-persona-forge/tree/main/skills/openclaw-user-profiler
- **ClawHub:** https://clawhub.ai/eamanc-lab/openclaw-user-profiler
- **License:** MIT

Build user.md profiles through conversation and recommend Claude Code Skills based on 42 roles across 11 categories.

The skill conducts a structured conversation to understand the user's background, workflows, and needs, then:
- Generates a `user.md` profile summarizing the user's role, tools, and preferences
- Recommends relevant Claude Code Skills from a catalog of 42 roles spanning 11 categories (engineering, design, data, DevOps, security, etc.)

This helps new Claude Code users discover skills that match their actual workflow rather than browsing a flat list.

## Checklist

- [x] Follows the existing table format
- [x] Description is concise and accurate
- [x] Link is valid and points to the correct repository/subfolder
- [x] Skill has documentation (README + SKILL.md)
- [x] Skill is functional and tested