### PR TITLE
Add claude-code-btw: persistent conversation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[claude-code-btw](https://github.com/Softwaremania/claude-code-btw)** | Persistent conversation notes — auto-captures "btw" asides via hook, survives context compaction, project-scoped |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## /btw — Persistent Conversation Notes for Claude Code

**First-of-its-kind** — checked 200+ existing skills, nothing like this exists.

### Problem
You say "btw check on flowcode patents" mid-conversation. Two messages later, Claude has no memory of it. Context compaction erases it.

### Solution
Two lightweight bash hooks:
- **btw-capture.sh** — auto-detects "btw" or "by the way" in messages, saves to project-scoped scratchpad
- **btw-inject.sh** — injects saved notes back into Claude's context via `additionalContext`

Plus a `/btw` slash command for manual save/view/clear.

### Features
- Auto-detect from natural conversation (no slash command needed)
- Project-scoped (each project gets its own notes)
- Max 15 notes, FIFO, 24hr auto-expire
- Works standalone — no plugins required
- 20/20 tests passing
- Windows + Mac/Linux compatible

### Repo
https://github.com/Softwaremania/claude-code-btw