### PR TITLE
Add skills-janitor - skill hygiene plugin (7 commands, zero deps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Skills for working with complex file formats:
 
 
 ### Individual Skills
+| **[skills-janitor](https://github.com/khendzel/skills-janitor)** | Audit, deduplicate, check, fix, and track usage of your Claude Code skills — 9 actions, zero dependencies |
 
 > These will be broken down into categories once there are enough community skills available to list
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ Skills for working with complex file formats:
 
 
 ### Individual Skills
-| **[skills-janitor](https://github.com/khendzel/skills-janitor)** | Audit, deduplicate, check, fix, and track usage of your Claude Code skills — 9 actions, zero dependencies |
 
 > These will be broken down into categories once there are enough community skills available to list
 
@@ -128,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[skills-janitor](https://github.com/khendzel/skills-janitor)** | Audit, deduplicate, check, fix, and track usage of your Claude Code skills — 9 actions, zero dependencies |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
-| **[skills-janitor](https://github.com/khendzel/skills-janitor)** | Audit, deduplicate, check, fix, and track usage of your Claude Code skills — 9 actions, zero dependencies |
+| **[skills-janitor](https://github.com/khendzel/skills-janitor)** | Audit, track usage, and manage your Claude Code skills — 7 slash commands, zero dependencies |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## [skills-janitor](https://github.com/khendzel/skills-janitor)

Audit, track usage, and manage your Claude Code skills. 7 slash commands, zero dependencies.

Cross-platform: supports both Claude Code and OpenAI Codex.

**Install:**
```
/plugin marketplace add khendzel/skills-janitor
/plugin install skills-janitor
```

![demo](https://raw.githubusercontent.com/khendzel/skills-janitor/main/demo.gif)