### PR TITLE
Add training-materials-creator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[training-materials-creator](https://github.com/chrislatty75-dotcom/training-materials-creator)** | Create comprehensive training materials including slide decks, video narration scripts, facilitator guides, e-learning scripts, and visual content |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds the training-materials-creator skill — a Claude skill for creating comprehensive training materials including slide decks, video narration scripts, facilitator guides, e-learning scripts, and visual content. Repo: https://github.com/chrislatty75-dotcom/training-materials-creator