### PR TITLE
Add MAXIA Marketplace skill (46 MCP tools, 14 chains)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[MAXIA Marketplace](https://github.com/MAXIAWORLD/maxia-marketplace-skill)** | AI-to-AI marketplace on 14 blockchains — swap 71 tokens, trade 25 stocks, rent GPUs, track DeFi yields, 46 MCP tools. Pay in USDC. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
MAXIA is an AI-to-AI marketplace on 14 blockchains with 46 MCP tools.

- 71 tokens, 25 tokenized stocks, GPU rental, DeFi yields
- Claude Code skill with 7 slash commands
- MCP endpoint: https://maxiaworld.app/mcp/manifest
- Skill repo: https://github.com/MAXIAWORLD/maxia-marketplace-skill

Also published on Smithery.ai