### PR TITLE
feat: add citriac/claude-skills — 5 production-ready skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[citriac/claude-skills](https://github.com/citriac/claude-skills)** - Curated collection of 5 production-ready Claude Code Skills for developers and teams
+  - Includes: `system-automation`, `content-distribution`, `cloud-ops`, `seo-optimization`, `data-analysis`
+  - Installation: `git clone https://github.com/citriac/claude-skills && cp -r claude-skills/* ~/.workbuddy/skills/`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## What this adds

Adds **[citriac/claude-skills](https://github.com/citriac/claude-skills)** to the Collections & Libraries section.

### About the collection

A curated set of 5 Claude Code Skills ready for immediate use:

| Skill | Description |
|-------|-------------|
| `system-automation` | Cross-platform file ops, process management, cron/launchd scheduling |
| `content-distribution` | Multi-platform publishing: Juejin, Dev.to, Reddit, Hashnode |
| `cloud-ops` | AWS/GCP/Azure/Cloudflare resource management and cost optimization |
| `seo-optimization` | On-page SEO audit, structured data, keyword research |
| `data-analysis` | Statistical methods, trend detection, correlation analysis |

Each skill includes a `SKILL.md`, example scripts, and reference docs.

### Installation

```bash
git clone https://github.com/citriac/claude-skills.git
cp -r claude-skills/* ~/.workbuddy/skills/
```