### PR TITLE
feat: add wh-skill — Git work hours exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[wh-skill](https://github.com/kingcwt/wh-skill)** | Export work hours from Git commits — supports daily/weekly/monthly filters, project filtering, and grouped time stats (`/wh`) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Export work hours from Git commits — supports daily/weekly/monthly filters, 
project filtering, and grouped time stats.

Install: curl -fsSL https://raw.githubusercontent.com/kingcwt/wh-skill/main/install.sh | sh

GitHub: https://github.com/kingcwt/wh-skill