### PR TITLE
feat: add prism-canvas to the community skills list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[prism-canvas](https://github.com/lakshyakumar/prism-canvas)** | Full-spectrum market intelligence for founders — Lean Canvas extended with competitor analysis, validation, and strategic clarity |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Add prism-canvas to Community Skills

Adds [lakshyakumar/prism-canvas](https://github.com/lakshyakumar/prism-canvas) to the Individual Skills table.

About the skill: Prism is a Claude Code skill (/prism) that takes a startup idea and produces a structured market intelligence report. It covers:

Default mode — 9-section Lean Canvas: Problem, Solution, UVP, Unfair Advantage, Customer Segments, Key Metrics, Channels, Cost Structure, Revenue Streams
Extended mode (--extended) — adds 12 more sections including Why Now, Jobs To Be Done, Riskiest Assumptions, Competitor Analysis, Mom Test Questions, Marketing Hook, and more