### PR TITLE
Add kastell server security skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Skills for working with complex file formats:
 | Skill | Description |
 | --- | --- |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
+| **[kastell](https://github.com/kastelldev/kastell)** | Server security auditing, hardening, and fleet management. 413 security checks across 29 categories, CIS/PCI-DSS/HIPAA compliance, 19-step production hardening. Supports Hetzner, DigitalOcean, Vultr, Linode |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |


### PR DESCRIPTION
Adds [kastell](https://github.com/kastelldev/kastell) to the Individual Skills table.

Kastell is a CLI toolkit and Claude Code plugin for server security auditing, hardening, and fleet management. It runs 468+ security checks across 31 categories (SSH, Firewall, Docker, TLS, HTTP Headers, Kernel, DDoS, Edge/WAF, etc.) with CIS/PCI-DSS/HIPAA compliance mapping. It also provides 24-step production hardening, safe auto-fix with TypeScript-enforced FORBIDDEN tiers, and supports Hetzner, DigitalOcean, Vultr, and Linode.

**Checklist:**
- [x] Skill has a clear purpose and use case
- [x] Includes documentation (README + SKILL.md + 7 skills + scripts/)
- [x] Follows Claude Skills best practices (progressive disclosure, frontmatter)
- [x] Functional and tested (9,611 tests across 208 suites, 90%+ coverage)
- [x] Non-trivial (37,000+ lines of TypeScript, 14 MCP tools, 34 CLI commands)
- [x] 37 GitHub stars (above the 10-star threshold)
- [x] Not a SaaS wrapper — fully open-source, runs locally, no external service required
- [x] Licensed under MIT
