### PR TITLE
Add SAP-SKILLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[efeumutaslan/SAP-SKILLS](https://github.com/efeumutaslan/SAP-SKILLS)** - 23 SAP development skills for Claude Code covering ABAP, RAP, CDS, CAP, Fiori, BTP, HANA, S/4HANA extensibility, Integration Suite, and more — with references, templates, validation scripts, and MCP server configs
 
 ### Individual Skills
 


### PR DESCRIPTION
## Add SAP-SKILLS to Collections & Libraries

**[efeumutaslan/SAP-SKILLS](https://github.com/efeumutaslan/SAP-SKILLS)** — A comprehensive collection of 23 SAP development skills for Claude Code.

### What's included

- **23 skills** covering ABAP, RAP, CDS, CAP, Fiori, BTP, HANA Cloud, S/4HANA extensibility, Integration Suite, Security, DevOps, and more
- **33 reference documents** — syntax guides, API references, checklists
- **19 templates** — copy-paste ready code and config templates
- **4 validation scripts** — ABAP Cloud compliance, Clean Core, CAP project structure, RAP BO completeness
- **4 MCP server configs** — pre-configured SAP MCP server setups
- **4 agents** and **5 slash commands**

### Why it belongs here

- First SAP/ERP skills collection for Claude Code — no existing SAP coverage in this list
- Follows the Agent Skills Specification (agentskills.io)
- MIT licensed
- All skills include: Quick Start, Core Concepts, Common Patterns, Error Catalog, and Performance Tips
- Cross-referenced skills with progressive disclosure (metadata → instructions → resources)

### Checklist

- [x] Public repository
- [x] Not a SaaS wrapper or commercial product
- [x] One entry per PR
- [x] Clear, concise description
- [x] MIT license