### PR TITLE
Add ADHX to Individual Skills — X/Twitter post reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[adhx](https://github.com/itsmemeworks/adhx)** | Fetch any X/Twitter post as clean LLM-friendly JSON via a public API — no browser, no scraping. Supports regular tweets and full X Articles. Install: `/plugin marketplace add itsmemeworks/adhx` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds ADHX (https://github.com/itsmemeworks/adhx) to the Individual Skills table.

ADHX is an open-source Claude Code skill that fetches any X/Twitter post as clean LLM-friendly JSON via a public API — no browser, no scraping. Works with regular tweets and full X Articles.

Install options:
- /plugin marketplace add itsmemeworks/adhx
- Manual: curl -sL https://raw.githubusercontent.com/itsmemeworks/adhx/main/skills/adhx/SKILL.md -o ~/.claude/skills/adhx/SKILL.md