### PR TITLE
Add Claude Code SDK to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Skills for working with complex file formats:
   - Install from `superpowers-marketplace` plugin
 
 
+- **[Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk)** - Open-source single-file CLIs (Node.js, Python, Go, Rust) that replace the 190MB Claude Code binary. Provider-agnostic: works with Anthropic, OpenAI, Google, DeepSeek, Mistral, Groq, Ollama, and LM Studio. Zero dependencies, built-in tool loop with permissions and session persistence. *By [@SeifBenayed](https://github.com/SeifBenayed)*
+
 ### Individual Skills
 
 > These will be broken down into categories once there are enough community skills available to list

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Skills for working with complex file formats:
   - Install from `superpowers-marketplace` plugin
 
 
-- **[Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk)** - Open-source single-file CLIs (Node.js, Python, Go, Rust) that replace the 190MB Claude Code binary. Provider-agnostic: works with Anthropic, OpenAI, Google, DeepSeek, Mistral, Groq, Ollama, and LM Studio. Zero dependencies, built-in tool loop with permissions and session persistence. *By [@SeifBenayed](https://github.com/SeifBenayed)*
+- **[Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk)** - Open-source, provider-agnostic SDK implementing the Claude Code tool loop in 4 languages (Node.js, Python, Go, Rust): works with Anthropic, OpenAI, Google, DeepSeek, Mistral, Groq, Ollama, and LM Studio. Zero dependencies, built-in tool loop with permissions and session persistence. *By [@SeifBenayed](https://github.com/SeifBenayed)*
 
 ### Individual Skills
 


### PR DESCRIPTION
## Summary

Adds [Claude Code SDK](https://github.com/SeifBenayed/claude-code-sdk) to the **Collections & Libraries** section.

**What it is:** An open-source, provider-agnostic SDK that implements the Claude Code tool loop in 4 languages (Node.js, Python, Go, Rust).

- **Fully open source** (MIT) — single-file, zero dependencies
- **Provider agnostic:** Anthropic, OpenAI, Google, DeepSeek, Mistral, Groq, Ollama, LM Studio
- Built-in tools, permissions, and session persistence
- Loads and runs Claude Skills natively on any backend

Happy to adjust the description or section placement.