### PR TITLE
Add CLI-Anything-Web to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[CLI-Anything-Web](https://github.com/ItamarZand88/CLI-Anything-WEB)** | Generate Python CLIs for any web app by capturing HTTP traffic. Plugin with 4-phase pipeline, 10 reference CLIs (Reddit, Booking.com, Stitch, etc.), 434 tests |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding **CLI-Anything-Web** to the Individual Skills table.

A Claude Code plugin that generates production-grade Python CLIs for any web application by capturing HTTP traffic via Playwright. Features a 4-phase automated pipeline (capture → analyze → generate → test) and ships with 10 fully-tested reference CLIs.

**GitHub:** https://github.com/ItamarZand88/CLI-Anything-WEB
**License:** MIT