### PR TITLE
Add Den to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Skills for working with complex file formats:
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
+| **[den](https://github.com/us/den)** | Self-hosted sandbox runtime for AI agents — MCP server for secure code execution in Docker containers |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |


### PR DESCRIPTION
Add [Den](https://github.com/us/den) — a self-hosted sandbox runtime for AI agents. MCP server for secure code execution in Docker containers.