### PR TITLE
Add AuraKit — all-in-one 33-mode Claude Code skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
-| **[AuraKit](https://github.com/smorky850612/Aurakit)** | All-in-one Claude Code skill: 33 modes, 6-layer security, 23 hooks, 8 languages, 75% token savings. One `/aura` command for build, fix, review, deploy. Cross-platform (Codex, Cursor, Manus, Windsurf) |
+
+| **[AuraKit](https://github.com/smorky850612/Aurakit)** | Full-lifecycle Claude Code skill framework: 46 modes (BUILD/FIX/DEPLOY/REVIEW/TDD/QA/DEBUG/PAYMENT), 23 sub-agents, 6-layer OWASP+ security, ~55% token savings via Haiku/Sonnet routing |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[AuraKit](https://github.com/smorky850612/Aurakit)** | All-in-one Claude Code skill: 33 modes, 6-layer security, 23 hooks, 8 languages, 75% token savings. One `/aura` command for build, fix, review, deploy. Cross-platform (Codex, Cursor, Manus, Windsurf) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
- Adds [AuraKit](https://github.com/smorky850612/Aurakit) v6.3.1
- All-in-one Claude Code skill: **36 modes**, 6-layer security, 23 hooks, 8 languages, ~55% token savings
- Cross-platform: Claude Code · OpenAI Codex CLI · Cursor · Manus · Windsurf
- Install: `npx @smorky85/aurakit` or `bash install.sh`

## What's New in v6.3.1
- **36 modes**: BUILD · FIX · CLEAN · DEPLOY · REVIEW · TDD · DEBUG · QA:E2E · ORCHESTRATE · STATUS:HEALTH + 26 more
- **install.sh v2.0**: Auto-installs jq (winget/scoop/choco/brew/apt/dnf/yum/apk/pacman), cross-platform OS detection
- **23 hooks / 16 Claude Code events**: Full automation pipeline (pre-session → build-verify → instinct-auto-save → compact/restore)
- **DNA Identity**: 8 core principles — FAST · FLASHY · SECURE · THRIFTY · IMMORTAL · EVOLVING · UNIVERSAL · TOP-TIER

## Why AuraKit

| Feature | Detail |
|---------|--------|
| Security | 6-layer (L1 roles → L6 npm audit), SEC-01~15 OWASP rules |
| Token savings | ~55% via Tiered Model (haiku Scout + sonnet Builder) |
| Memory | Instinct engine learns patterns per project — gets smarter every session |
| Recovery | Compact-proof — snapshots survive context loss |
| Languages | TypeScript · Python · Go · Java · Rust · Kotlin · C++ · Swift (10 reviewers) |