### PR TITLE
Add screencli-skill: AI-driven browser demo recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[screencli-skill](https://github.com/usefulagents/screencli-skill)** | Record AI-driven browser demos — one command creates polished screen recordings with gradient backgrounds, auto-zoom, click highlights, and shareable links |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [screencli-skill](https://github.com/usefulagents/screencli-skill) to the Individual Skills table.

**What it does:** Gives Claude Code the ability to record AI-driven browser demos. One command creates polished screen recordings with gradient backgrounds, auto-zoom, click highlights, and shareable links.

**Install:** `npx skills add usefulagents/screencli-skill`

**Repo:** https://github.com/usefulagents/screencli-skill