### PR TITLE
Add AKF — The AI Native File Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[AKF — The AI Native File Format](https://github.com/HMAKT99/AKF)** | EXIF for AI. Stamps every file with trust scores, source provenance, and compliance metadata (~15 tokens of JSON). Embeds into 20+ formats. MCP server, shell hook, EU AI Act auditing. [akf.dev](https://akf.dev) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
AKF is the AI native file format — EXIF for AI. Stamps every file with trust scores, source provenance, and compliance metadata.

- ~15 tokens of JSON, embeds into 20+ formats
- MCP server with 9 tools
- Shell hook auto-stamps AI outputs
- EU AI Act, SOX, HIPAA compliance auditing
- `pip install akf` | https://akf.dev