### PR TITLE
Add session-wizard to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[session-wizard](https://github.com/non4me/session-wizard)** | Full session lifecycle management — analyzes sessions, routes knowledge to memory/skills, and hands off context to the next session via SessionStart hook |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [session-wizard](https://github.com/non4me/session-wizard) to the Individual Skills table.                                            
  Session Wizard provides full session lifecycle management for Claude Code:
  - Analyzes sessions on close via `/es` slash command                                                                                    
  - Routes knowledge to classified memory files (user/feedback/project/reference)
  - Detects reusable patterns and updates skills
  - Writes structured handoff (`last-session.md`) consumed by a SessionStart hook
  - Next session starts warm with full context

  Works alongside Auto-dream and Auto-memory — they complement each other.