### PR TITLE
Add adversarial-reviewer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[adversarial-reviewer](https://github.com/ekreloff/adversarial-reviewer)** | Adversarial code review with three hostile personas (Saboteur, New Hire, Security Auditor) that breaks the self-review monoculture — each persona must find at least one real issue |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add adversarial-reviewer skill

Adds [adversarial-reviewer](https://github.com/ekreloff/adversarial-reviewer) to the Individual Skills table.

### What it does

Forces genuinely critical code reviews by adopting three adversarial personas:

- **The Saboteur** — tries to break the code in production (null derefs, race conditions, resource leaks)
- **The New Hire** — evaluates readability with zero context from the original author
- **The Security Auditor** — OWASP-informed vulnerability scan across trust boundaries

Each persona MUST find at least one real issue. No "LGTM" escapes.

### Why it's useful

Addresses the self-review monoculture problem — when AI reviews code it wrote, it shares the same blind spots as the author. This skill forces a genuine perspective shift with structured output (BLOCK/CONCERNS/CLEAN verdict).

### Installation

```bash
npx skills add ekreloff/adversarial-reviewer
```

Or:

```bash
git clone https://github.com/ekreloff/adversarial-reviewer.git ~/.claude/skills/adversarial-reviewer
```

### License

MIT