### PR TITLE
Add kipi-skills: 8 founder OS skills for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[kipi-skills](https://github.com/assafkip/kipi-skills)** | Founder OS skills for Claude Code -- 8 skills covering AUDHD executive function, neurodivergent interaction rules, founder voice, post-conversation debrief, session handoff, evening wrap, customer fit review, and gated plan building. Apache-2.0. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding [kipi-skills](https://github.com/assafkip/kipi-skills) -- a marketplace of 8 Claude Code skills for founders.

**Skills included:**
- audhd-executive-function -- ADHD/AUDHD-aware task design and daily schedule structuring
- neurodivergent-founder -- Behavioral rules and task patterns for ND founders
- founder-voice -- Voice matching with anti-AI detection
- founder-debrief -- Post-conversation extraction with canonical routing
- session-handoff -- Session continuity notes for next-session resume
- evening-wrap -- End-of-day health check and open loop closure
- customer-fit-review -- Expert persona reviews against customer deployment reality
- gated-plan-builder -- Review findings to gated engineering plans with pytest gates

**Install:** `/install github:assafkip/kipi-skills`
**License:** Apache-2.0
**Repo:** https://github.com/assafkip/kipi-skills