### PR TITLE
Add launch-swarm to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Skills for working with complex file formats:
 | Skill | Description |
 | --- | --- |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
+| **[launch-swarm](https://github.com/harshmoney123/launch-swarm)** | 6-agent Claude Code swarm with strict role separation, dual-gate merge pipeline, and prompt health anti-rot for autonomous plan-code-review-document-deploy workflows |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |


### PR DESCRIPTION
Adds [launch-swarm](https://github.com/harshmoney123/launch-swarm) to the **Community Skills > Individual Skills** table.

**launch-swarm** is a 6-agent Claude Code swarm with strict role separation, dual-gate merge pipeline, and prompt health anti-rot for autonomous plan-code-review-document-deploy workflows.

- Placed in alphabetical order in the Individual Skills table
- Matches existing table entry format