### PR TITLE
Add one-page-cv skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[one-page-cv](https://github.com/Andy8647/one-page-cv)** | Generate professionally tailored, one-page LaTeX/PDF resumes from any job description — bilingual (CN/EN), cross-platform fonts, STAR method, automatic page fitting |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Add [one-page-cv](https://github.com/Andy8647/one-page-cv) to the Individual Skills table

**one-page-cv** generates professionally tailored, one-page LaTeX/PDF resumes from any job description.

### Features
- Bilingual support (Chinese/English) with proper CJK font handling
- Cross-platform fonts (macOS/Windows/Linux) including Maple Mono
- STAR method bullet points with quantified results
- Automatic page fitting — always exactly one page
- Multi-agent compatible: Claude Code, Codex CLI, OpenClaw, Cursor, Windsurf

Repo: https://github.com/Andy8647/one-page-cv