### PR TITLE
Add No Cap skill to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[No Cap](https://github.com/zephyr2800/no-cap)** | Turn your X bookmarks into actionable signals, filtering out the noise |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds **[No Cap](https://github.com/zephyr2800/no-cap)** to the community Individual Skills table
- No Cap is a Claude Code skill that ingests X/Twitter bookmarks, filters noise through 3 layers (account-level, post-level, content-level), and extracts actionable signals — output as structured markdown for agents and HTML email digest for humans

## Test plan

- [ ] Verify table row renders correctly in GitHub markdown preview
- [ ] Confirm link to https://github.com/zephyr2800/no-cap resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)