### PR TITLE
Add Spartan AI Toolkit to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[spartan-stratos/spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit)** - Engineering discipline layer with 56 slash commands, 12 coding rules, quality gates, and configurable stack profiles for Claude Code
+  - Features `/spartan:build`, `/spartan:review`, `/spartan:debug` workflows and 22 skills
+  - Supports 8 stack profiles: Kotlin, Go, Python, Java, React, Next.js, and more
+  - Installation: `npx @c0x12c/spartan-ai-toolkit@latest --local`
+
 
 ### Individual Skills
 

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
-- **[spartan-stratos/spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit)** - Engineering discipline layer with 56 slash commands, 12 coding rules, quality gates, and configurable stack profiles for Claude Code
-  - Features `/spartan:build`, `/spartan:review`, `/spartan:debug` workflows and 22 skills
+- **[spartan-stratos/spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit)** - Engineering discipline layer with 67 slash commands, 20 coding rules, quality gates, and configurable stack profiles for Claude Code
+  - Features `/spartan:build`, `/spartan:review`, `/spartan:debug` workflows and 27 skills
   - Supports 8 stack profiles: Kotlin, Go, Python, Java, React, Next.js, and more
   - Installation: `npx @c0x12c/spartan-ai-toolkit@latest --local`
 


### PR DESCRIPTION
Adding [Spartan AI Toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) to the Community Skills > Collections & Libraries section.

Spartan is an engineering discipline layer for Claude Code with:
- 56 slash commands (build, debug, review, deploy workflows)
- 12 coding rules, 22 skills, 7 agents
- Quality gates between every step
- 8 stack profiles (Go, Python, Java, Kotlin, React, etc.)
- Agent memory across sessions

Install: `npx @c0x12c/spartan-ai-toolkit@latest --local`

Repo: https://github.com/spartan-stratos/spartan-ai-toolkit