### PR TITLE
Add excalidraw-skill to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[excalidraw-skill](https://github.com/Minara-AI/excalidraw-skill)** | Generate hand-drawn style diagrams from natural language using Excalidraw, rendered to PNG/SVG via headless Playwright |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Add [excalidraw-skill](https://github.com/Minara-AI/excalidraw-skill) to the Individual Skills table

## About the Skill

Generates hand-drawn style diagrams from natural language using Excalidraw, rendered to PNG/SVG via headless Playwright. Includes:

- One-command installer
- 4-step workflow with design review
- Monochrome-first design philosophy
- Bilingual docs (EN + CN)
- MIT licensed, v1.0.0 released