### PR TITLE
Add Claude Code Cheat Sheet to Tutorials & Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ The easiest way to create a skill is to use the built-in `skill-creator`:
 
 - [How to Create Your First Claude Skill](https://skywork.ai/blog/ai-agent/how-to-create-claude-skill-step-by-step-guide/) - Step-by-step tutorial with examples
 - [How to Use Skills in Claude Code](https://skywork.ai/blog/how-to-use-skills-in-claude-code-install-path-project-scoping-testing/) - Installation, project scoping, and testing guide
+- [Claude Code Cheat Sheet](https://cc.storyfox.cz/) - Complete one-page printable reference covering shortcuts, commands, CLI flags, MCP config, memory, skills, and agents. Auto-updated daily. Available in EN, ZH, JA, KO.
 
 ### Video Tutorials
 


### PR DESCRIPTION
Adding [Claude Code Cheat Sheet](https://cc.storyfox.cz/) to Written Tutorials.

- One-page printable reference with all shortcuts, commands, CLI flags, MCP config, memory, skills, and agents
- Auto-updated daily from official docs
- Available in 4 languages: [EN](https://cc.storyfox.cz/), [ZH](https://cc.storyfox.cz/zh/), [JA](https://cc.storyfox.cz/jp/), [KO](https://cc.storyfox.cz/kr/)
- Hit HN frontpage with 130k+ pageviews