### PR TITLE
feat: add session-letter to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[session-letter](https://github.com/catcam/session-letter)** | Continuity across AI sessions — Claude writes a letter to its future self at session end, reads it at session start. Addresses the gap between compact summaries (data) and actual continuity (voice, context) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## session-letter

**https://github.com/catcam/session-letter**

Continuity across AI sessions — Claude writes a letter to its future self at session end, reads it at session start.

### What it is

- `/session-letter` skill — Claude writes in its own voice, first person, to the next instance
- `hooks/session-start.sh` — injects last letter into session context via SessionStart hook
- `hooks/pre-compact.sh` — reminds before auto-compact if not written yet

### Why letters, not summaries

A changelog says: *"Fixed orderbook indexing bug."*

A letter says: *"The bug was elegant in its stupidity — `asks[0]` returns the worst ask, not the best. One character: `[0]` → `[-1]`. Gamma API was telling the truth the whole time."*

Next session, Claude referenced the specific framing unprompted when a similar issue appeared. That doesn't happen from a changelog.

### Related work

Complements Auto-Dream (memory consolidation) and Claude Diary (learning capture) — different layer, same goal. See [Related Work](https://github.com/catcam/session-letter#related-work) section in README for full comparison.

MIT license. Reviewed by Claude Opus 4.6.