### PR TITLE
Add marginalia — typographic callout library skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[marginalia](https://github.com/andyed/marginalia)** | Typographic callout library — 15 CSS components (pull quotes, sidebars, margin notes, drop caps, magazine spreads) with a markdown converter for editorial-quality HTML output |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds [marginalia](https://github.com/andyed/marginalia) to the Individual Skills table
- 15 CSS components for editorial-quality HTML output: pull quotes with 3D perspective tilt, sidebars, margin notes, drop caps, lead-ins, magazine two-column spreads, and more
- Includes a markdown converter (`marginalia-md.js`) — GitHub-style alerts, blockquotes, `==highlights==`, `{badges}`, and footnotes convert to styled components
- Zero dependencies, CSS custom properties for theming, dark/light mode
- [Live demo](https://andyed.github.io/marginalia/) | [SKILL.md](https://github.com/andyed/marginalia/blob/main/SKILL.md)