### PR TITLE
Add claude-workspace-snapshot to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[REMvisual/claude-workspace-snapshot](https://github.com/REMvisual/claude-workspace-snapshot)** - Snapshot and restore live Claude Code sessions as named, color-coded Windows Terminal tabs. Detects running sessions via process inspection and .jsonl file activity. Windows only.
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
## Summary
- Adds [claude-workspace-snapshot](https://github.com/REMvisual/claude-workspace-snapshot) to the Tools section under Community Skills

## Description
Snapshot and restore live Claude Code sessions as named, color-coded Windows Terminal tabs. Detects running sessions via process inspection and .jsonl file activity. Restores tab layout after any restart. Windows only.