### PR TITLE
Add NEXO Brain — cognitive memory architecture with 100+ MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[NEXO Brain](https://github.com/wazionapps/nexo)** | Cognitive memory architecture — Atkinson-Shiffrin model, Ebbinghaus forgetting, semantic RAG, knowledge graph, trust scoring, metacognitive guard. 100+ MCP tools. `npx nexo-brain init` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds **NEXO Brain** to the Individual Skills table in the Community Skills section.

- **Repo:** https://github.com/wazionapps/nexo
- **What it is:** A persistent cognitive memory architecture for Claude Code, implementing the Atkinson-Shiffrin memory model (Sensory Register → STM → LTM), Ebbinghaus forgetting curves, semantic RAG via fastembed, a knowledge graph, trust scoring, and metacognitive guard. Ships as a fully self-contained MCP server with 100+ tools.
- **Install:** `npx nexo-brain init`

## Why it fits this list

Most skills in this list add task-specific capabilities. NEXO Brain adds a fundamentally different layer — **persistent cognitive memory across sessions** — which makes all other skills and workflows more effective. It is relevant to anyone running Claude Code for extended, multi-session projects.

## Checklist

- [x] Entry added to the correct section (Individual Skills table)
- [x] Format matches existing entries
- [x] Link goes directly to the public GitHub repo
- [x] Description is concise and factual

Generated with Claude Code