### PR TITLE
Add IFRS skill to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[ifrs-skill](https://github.com/ramyatrouny/ifrs-skill)** | IFRS and IAS reference with paragraph-level citations: 43 standards including IFRS 18, IFRS 19 and IFRS S1/S2, disclosure checklists, worked journal entries, and a GAAP-to-IFRS transition guide |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 
 _More community skills coming soon! Submit a PR to add your skill._


### PR DESCRIPTION
Adds **[ifrs-skill](https://github.com/ramyatrouny/ifrs-skill)** to the Individual Skills table.

A comprehensive IFRS skill covering:
- 40 active standards (IFRS 1-17, IAS 1-41)
- 7 step-by-step workflows with journal entries
- 5 compliance templates (disclosure checklist, gap analysis, audit memo, etc.)
- GAAP-to-IFRS transition guide
- Audience adaptation (professional with citations vs. learner mode)

Works with Claude Code, Codex, Gemini CLI, Cursor, and all agents supporting the agentskills.io spec.

Also registered on skills.sh: `npx skills add ramyatrouny/ifrs-skill`