### PR TITLE
Add: Not-muzzyy/expert-builder skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[expert-builder](https://github.com/Not-muzzyy/expert-builder)** | Turns Claude into a senior software engineer — builds projects, debugs code, designs architecture, and generates READMEs |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## expert-builder

Adds the Expert Builder skill to the Individual Skills table.

### What it does
Turns Claude into a senior software engineer + mentor. Handles full
project builds, debugging, architecture design, deployments, and
README generation across 8 domains (AI/ML, cybersecurity, web, backend, and more).

### Links
- Repo: https://github.com/Not-muzzyy/expert-builder
- Author: https://github.com/Not-muzzyy