### PR TITLE
Add skill-loader: on-demand skill management

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[skill-loader](https://github.com/eppicservices/claude-skill-loader)** | On-demand skill management — move inactive skills to `~/.claude/skills-inactive/`, auto-loads them when needed via keyword detection, zero context cost when dormant |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [skill-loader](https://github.com/eppicservices/claude-skill-loader) to the Individual Skills table.

It's a meta-skill that manages inactive skills on demand. You move skills you don't need every session to ~/.claude/skills-inactive/, and a small loader skill auto-detects when you need one (keyword matching), reads it from disk mid-session, and promotes it to active for next time.

Solves the problem described in anthropics/claude-code#7336, #15964, and #18497 (all locked). Went from 95 skills loading per session to 21, with all 95 still available on demand.