### PR TITLE
Add a-share-skill and feishu-send-file to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
+| **[a-share-skill](https://github.com/shouldnotappearcalm/a-share-skill)** | China A-share market data analysis with real-time quotes, historical K-line data, and 12 technical indicators (MA/EMA/MACD/KDJ/RSI/BOLL/ATR). Built for OpenClaw/Claude Code |
+| **[feishu-send-file](https://github.com/shouldnotappearcalm/feishu-skills)** | Send files and images to Feishu/Lark chats and groups via API. Supports private chats and group chats. Built for OpenClaw/Claude Code |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
## Added Skills

### a-share-skill
- **Repo:** https://github.com/shouldnotappearcalm/a-share-skill
- **ClawHub:** https://clawhub.ai/shouldnotappearcalm/a-share-trading
- **Description:** China A-share market data analysis skill with real-time quotes, historical K-line data, and 12 technical indicators (MA/EMA/MACD/KDJ/RSI/BOLL/ATR/WR/BIAS/CCI/DMI/TAQ). Built for OpenClaw/Claude Code.

### feishu-send-file
- **Repo:** https://github.com/shouldnotappearcalm/feishu-skills
- **ClawHub:** https://clawhub.ai/shouldnotappearcalm/feishu-chatfile-skill
- **Description:** Send files and images to Feishu/Lark chats and groups via API. Supports private chats (ou_ prefix) and group chats (oc_ prefix). Built for OpenClaw/Claude Code.