### PR TITLE
Add openai-image-skill to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Skills for working with complex file formats:
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
+| **[openai-image-skill](https://github.com/dkarski/openai-image-skill)** | Generate images with DALL-E 2/3 and gpt-image-1. Quality control (`--quality=low\|standard\|hd`), multiple variants (`--count=N`), self-updating via GitHub Releases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |


### PR DESCRIPTION
## Description

Adds [openai-image-skill](https://github.com/dkarski/openai-image-skill) to the Community Skills table.

A Claude Code skill for AI image generation using OpenAI's API:
- Supports DALL-E 2/3, gpt-image-1, gpt-image-1.5
- `--quality=low|standard|hd` — cost vs. quality control
- `--count=N` — generate multiple variants in one command
- Self-updating via `generate-image.mjs update` (uses GitHub Releases API)
- MIT license, Node.js 18+

## Checklist

- [x] Entry added to existing Community Skills table
- [x] Format matches existing table rows
- [x] Repository is public with clear README and install instructions