### PR TITLE
Add claude-code-skills: parallel session awareness rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[claude-code-skills](https://github.com/Kanevry/claude-code-skills)** | Parallel session awareness rules — prevents work loss when multiple Claude Code sessions share a workspace (always-on rules with PSA-001 to PSA-004) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds [Kanevry/claude-code-skills](https://github.com/Kanevry/claude-code-skills) to the Individual Skills table.

## About the skill

Production-tested Claude Code rules that prevent work loss when multiple sessions operate in the same working directory. Includes four numbered safeguards (PSA-001 to PSA-004):

- **PSA-001** Detect Before Acting — recognize signs of parallel work
- **PSA-002** Ask, Don't Assume — stop and ask the user before acting
- **PSA-003** Never Destroy What You Didn't Create — block destructive git commands
- **PSA-004** Isolate Your Changes — commit discipline for shared workspaces

Tested across 20+ repos in production. MIT licensed.