### PR TITLE
Add lean skill for token-optimal model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Skills for working with complex file formats:
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
+| **[lean](https://github.com/civillizard/claude-lean-skill)** | Plan tasks with optimal model routing (Haiku/Sonnet/Opus) to minimize token usage. Decomposes work, assigns cheapest capable model per step, adds quality gates, and reports savings |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |


### PR DESCRIPTION
## What problem does this skill solve?

Claude Code defaults to Opus for everything — including file reads, test runs, and mechanical refactoring that Haiku or Sonnet handle fine. On a 10-step task, that's 5-10x more expensive than necessary.

## Who uses it?

Developers using Claude Code who want to reduce token costs without sacrificing quality.

## What it does

- `/lean <task>` decomposes work into steps and assigns the cheapest capable model per step
- 12 task types mapped to Haiku/Sonnet/Opus with rationale
- Quality gates between stages (Haiku validates before scaling)
- Staged execution: test on one item, validate, then expand
- Plan persistence to `.lean-plan.md` (survives context compaction)
- Savings report after execution with per-step cost breakdown
- Optional companion hook (`task-model-guard.py`) for always-on model suggestions

## Usage example

```
/lean migrate 8 API endpoints to v2
```

Produces a plan table with model assignments, then executes with quality gates between stages. Typical savings: 70-85% vs all-Opus.

## Attribution

Created by [@civillizard](https://github.com/civillizard). License: MIT.