### PR TITLE
Add ru-text: Russian text quality skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[ru-text](https://github.com/talkstream/ru-text)** | Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence. Cross-platform: Claude Code, Codex CLI, Gemini CLI, Cursor. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
A skill for Russian text quality — typography rules (guillemets, em dashes, non-breaking spaces), information style (stop-words, reader-first structure), editorial punctuation, UX writing patterns, and business correspondence.

~1,040 rules across 7 domains. Not a single SKILL.md — the repo includes separate rule files, a scoring rubric, and configs for Claude Code, Codex CLI, Gemini CLI, and Cursor.

MIT license, 10 stars. Babushka tier. I'm not a bot or AI 🥺