### PR TITLE
Add Claudebase to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[claudebase](https://github.com/rohithzr/claudebase)** | Back up, restore, and sync your Claude Code config (settings, skills, agents, hooks, rules, memory) to a private GitHub repo with named profiles and secret scanning |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [Claudebase](https://github.com/rohithzr/claudebase) - a Claude Code plugin that backs up, restores, and syncs your entire Claude Code environment to a private GitHub repo.

Features:
- 6 skills: setup, push, pull, status, profiles, config
- Named profiles for switching between work/personal/team setups
- Secret scanning (API keys, PEM files, tokens)
- Multi-machine conflict detection
- Automatic backups before every pull
- 158 BATS tests, CI on macOS/Linux/Windows
- MIT licensed