### PR TITLE
Add Parallel Code to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 
+- **[johannesjo/parallel-code](https://github.com/johannesjo/parallel-code)** - Desktop app for orchestrating multiple Claude Code agents simultaneously in isolated git worktrees, with support for Codex CLI and Gemini CLI
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
 
 ## ✏️ Creating Your First Skill


### PR DESCRIPTION
Adds [Parallel Code](https://github.com/johannesjo/parallel-code) to the Tools section.

Parallel Code is an MIT-licensed desktop app (~376 GitHub stars) for orchestrating multiple Claude Code agents simultaneously in isolated git worktrees. It also supports Codex CLI and Gemini CLI.

- Repo: https://github.com/johannesjo/parallel-code
- Website: https://parallelcode.app
- License: MIT