### PR TITLE
Add deploy-verify skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[deploy-verify](https://github.com/Web3ok/deploy-verify-skill)** | 7-step production deployment closed-loop: pre-checks, backup, deploy with .env protection, SHA-256 file verification, functional testing, log monitoring with secret redaction, and team notification. Covers database migrations, cross-OS permission fixes, and rollback with security review. Born from 5 real incidents. |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |


### PR DESCRIPTION
## Add deploy-verify skill to Individual Skills

**Skill**: [deploy-verify](https://github.com/Web3ok/deploy-verify-skill)

A 7-step production deployment closed-loop skill born from real incidents. Fills a gap in the ecosystem — most skills cover code writing (TDD, review, debugging) but not "did the files actually arrive on the server?"

### Key features
- SHA-256 file integrity verification (local vs remote checksum diff)
- Sensitive file protection (.env, private keys auto-excluded)
- Cross-OS permission fix (macOS `501:staff` → Linux `www:www`)
- Database migration coordination (migration order by change type)
- Rollback with security review (warns about re-introducing fixed vulnerabilities)
- Log monitoring with secret redaction (strips passwords/tokens from output)
- Multi-server canary deployment strategy
- CI/CD integration mapping
- 10 anti-patterns with correct alternatives
- 5 real-world incident case studies

### Works with
Any web stack (PHP, Node.js, Python, Go) and any deployment method (tar, rsync, scp, CI/CD).