### PR TITLE
Add powerpoint.md — curated directory of 33 AI PowerPoint & Excel skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,10 @@ A: For skills from git repositories, pull the latest changes. For manually insta
 
 </details>
 
+## 🌐 Directories & Aggregators
+
+- [powerpoint.md](https://powerpoint.md) — Curated directory of 33 AI PowerPoint & Excel skills for Claude Code agents. Includes install commands, ratings, and detail pages for every skill. Agent-friendly with [/llms.txt](https://powerpoint.md/llms.txt).
+
 ## 🤝 Contributing
 
 Contributions welcome! See [contribution guidelines](CONTRIBUTING.md) for details. To add a skill or resource: fork, add to appropriate section, submit PR.


### PR DESCRIPTION
Hi! I'd like to add [powerpoint.md](https://powerpoint.md) to the directories section.

**What it is**: A curated directory of 33 AI PowerPoint & Excel skills for Claude Code agents. Each skill has:
- Tested install commands (we actually run each skill and verify)
- Quality ratings and ease-of-use scores  
- Dedicated detail page with feature breakdown
- Agent-friendly `/llms.txt` for programmatic discovery

**Why it's relevant**: It's specifically focused on Claude Code skills (PPT/Excel category), which seems like a natural fit for this awesome list.

Thanks for maintaining this resource!