### PR TITLE
Add doc-harness: document-based project control skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[doc-harness](https://github.com/cilidinezy-commits/doc-harness)** | Document-based project control — keeps projects organized, principles enforced, and information persistent across AI context resets. Init creates 5 status docs; check audits health and reflects on working principles |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skill: doc-harness

**Repository**: https://github.com/cilidinezy-commits/doc-harness

**What it does**: Doc Harness is a document-based project control system for AI-human collaboration. It creates and maintains 5 structured documents per project (CLAUDE.md, CURRENT_STATUS.md, FILE_INDEX.md, WORKLOG.md, DOC_HARNESS_SPEC.md) that keep projects organized, enforce working principles, and persist important information across AI context resets.

**Two commands**:
- `/doc-harness init` — Set up status documentation for a new or existing project
- `/doc-harness check` — Audit documentation health + reflect on working principles

**Key features**:
- "Moving car" metaphor for CURRENT_STATUS (tire tracks / car body / headlights / driving manual)
- "Write It Down or Lose It" principle — ensures important info is persisted, not lost in context
- Phase transition protocol with interrupt safety
- Works for any project type (research, software, data analysis, writing)
- English and Chinese versions included

**License**: MIT