### PR TITLE
Add SidClaw — MCP governance proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[SidClaw](https://github.com/sidclawhq/platform)** | Governance proxy for MCP servers — wraps any upstream server with policy evaluation, human approval workflows, and tamper-proof audit trails. Configure via `.mcp.json` with zero code changes |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |


### PR DESCRIPTION
Adds SidClaw to the community skills table (after Trail of Bits Security Skills).

SidClaw wraps any upstream MCP server with policy evaluation, human approval workflows, and tamper-proof audit trails. Configure via `.mcp.json` — zero code changes to Claude Code or the upstream server.

- Repo: https://github.com/sidclawhq/platform
- Apache 2.0 SDK
- Docs: https://docs.sidclaw.com/docs/integrations/claude-code