### PR TITLE
Add Blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[Blueprint](https://github.com/JuliusBrussee/blueprint)** | Turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds **[Blueprint](https://github.com/JuliusBrussee/blueprint)** by [@JuliusBrussee](https://github.com/JuliusBrussee) to the Individual Skills table.

Blueprint is a Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software — with automated iteration, validation, and cross-model peer review.

## Changes

- Added Blueprint to the **Community Skills > Individual Skills** table, following the existing `| **[name](URL)** | Description |` format.