### PR TITLE
Add Unbrowse — agent-native browser for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
+| **[Unbrowse](https://github.com/unbrowse-ai/unbrowse)** | API-native agent browser — discovers internal website APIs from traffic and replaces browser automation with direct API calls. 3.6x faster than Playwright across 94 domains. `npm install -g unbrowse` |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
Adds Unbrowse. Agent-native browser that discovers internal APIs from browsing traffic. 3.6x faster than Playwright across 94 domains.

- arXiv: https://arxiv.org/abs/2604.00694
- GitHub: https://github.com/unbrowse-ai/unbrowse
- npm: npm install -g unbrowse