### PR TITLE
Add github-optimization-skill and humanise-text-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Skills for working with complex file formats:
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
+| **[github-optimization-skill](https://github.com/199-biotechnologies/github-optimization-skill)** | Turn any GitHub repo into a star-magnet landing page — README optimization, SEO, and repo marketing |
+| **[humanise-text-skill](https://github.com/199-biotechnologies/humanise-text-skill)** | Strip AI writing patterns from any text with a 507-entry banned word list, structural pattern detection, and 12-check validation |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 


### PR DESCRIPTION
## What

Adds two community skills from [199 Biotechnologies](https://github.com/199-biotechnologies) to the Individual Skills table:

- **[github-optimization-skill](https://github.com/199-biotechnologies/github-optimization-skill)** — Turn any GitHub repo into a star-magnet landing page — README optimization, SEO, and repo marketing
- **[humanise-text-skill](https://github.com/199-biotechnologies/humanise-text-skill)** — Strip AI writing patterns from any text with a 507-entry banned word list, structural pattern detection, and 12-check validation

## Why these are useful

**github-optimization-skill** goes beyond a basic README rewrite. It analyzes repo structure, generates shields.io badges, optimizes headers for search engines, and adds star/follow CTAs — treating the README as a conversion-focused landing page rather than just documentation.

**humanise-text-skill** solves a real problem for anyone producing content with AI assistance. It maintains a curated 507-entry banned word list of common AI tells (e.g., "delve", "leverage", "streamline"), runs structural pattern detection (sentence starters, paragraph cadence, hedging density), and validates output through 12 independent checks before passing.

Both skills include more than a single SKILL.md — they ship with scripts, word lists, and multi-step validation logic.

## Checklist

- [x] Follows table format of existing entries
- [x] Descriptions are concise (single sentence each)
- [x] Links are correct and repositories are public
- [x] Placed in alphabetical order within the table
- [x] Both repos have README documentation and are functional