### PR TITLE
Add ffmpeg-render-pro to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
-| **[ffmpeg-render-pro](https://github.com/beeswaxpat/ffmpeg-render-pro)** | Parallel video rendering with live dashboard, GPU auto-detection, checkpoint system, color grading, audio merge, and YouTube-optimized output |
+| **[ffmpeg-render-pro](https://github.com/beeswaxpat/ffmpeg-render-pro)** | Render video with ffmpeg from Claude: parallel rendering, live dashboard, GPU auto-detection, checkpoints, color grading, and audio merge. Ships a skill, an MCP server (6 tools), and a CLI. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[ffmpeg-render-pro](https://github.com/beeswaxpat/ffmpeg-render-pro)** | Parallel video rendering with live dashboard, GPU auto-detection, checkpoint system, color grading, audio merge, and YouTube-optimized output |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds ffmpeg-render-pro — parallel video rendering with live dashboard, GPU auto-detection, checkpoint system, color grading, audio merge, and YouTube-optimized output.

- Repo: https://github.com/beeswaxpat/ffmpeg-render-pro
- npm: https://www.npmjs.com/package/ffmpeg-render-pro
- License: MIT
- Cross-platform (Win/Mac/Linux), zero dependencies