### PR TITLE
Add A.S.K. — Agent Skills Kernel to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Skills for working with complex file formats:
   - Install from `superpowers-marketplace` plugin
 
 
+- **[A.S.K. — Agent Skills Kernel](https://github.com/srmbsrg/ask-kernel)** - Versioned, composable skill library for AI agents. Define capabilities once in SKILL.md files, invoke by name across sessions. Ships as a plugin with 65+ cross-domain skills (finance, engineering, marketing, ops, data).
+
 ### Individual Skills
 
 > These will be broken down into categories once there are enough community skills available to list


### PR DESCRIPTION
## What is A.S.K.?

[A.S.K. — Agent Skills Kernel](https://github.com/srmbsrg/ask-kernel) is a versioned, composable skill library for AI agents.

**Why it belongs in Collections & Libraries:**
- Ships as a plugin with 65+ cross-domain skills (finance, engineering, marketing, ops, data, design, product)
- Built with the skill-creator meta-skill for creating new skills within a session
- MIT licensed
- Designed specifically for Claude Skills architecture

**Addition:** One entry added to `### Collections & Libraries` section.