### PR TITLE
Add uxuiprinciples/agent-skills to Design & Creative

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Skills for working with complex file formats:
 - **[algorithmic-art](https://github.com/anthropics/skills/tree/main/skills/algorithmic-art)** - Create generative art using p5.js with seeded randomness, flow fields, and particle systems
 - **[canvas-design](https://github.com/anthropics/skills/tree/main/skills/canvas-design)** - Design beautiful visual art in .png and .pdf formats using design philosophies
 - **[slack-gif-creator](https://github.com/anthropics/skills/tree/main/skills/slack-gif-creator)** - Create animated GIFs optimized for Slack's size constraints
+- **[uxuiprinciples/agent-skills](https://github.com/uxuiprinciples/agent-skills)** - 5 research-backed UX/UI skills: evaluate interfaces against 168 principles, detect antipatterns, and inject UX context into AI coding sessions
 
 ### Development
 


### PR DESCRIPTION
## Summary

Adds [uxuiprinciples/agent-skills](https://github.com/uxuiprinciples/agent-skills) to the **Design & Creative** section.

This is a collection of 5 research-backed UX/UI skills:

- **uxui-evaluator** - Evaluate interfaces against 168 UX/UI principles
- **interface-auditor** - Detect antipatterns using the UX smells taxonomy
- **ai-interface-reviewer** - Audit AI-powered interfaces (trust, transparency, human override)
- **flow-checker** - Check user flows against decision and feedback principles
- **vibe-coding-advisor** - Inject UX context into AI coding sessions

Install: `npx skills add uxuiprinciples/agent-skills`