### PR TITLE
Add code-tour skill to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Skills for working with complex file formats:
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
+| **[code-tour](https://github.com/vaddisrinivas/code-tour)** | AI-generated CodeTour walkthroughs for any codebase. Creates persona-targeted .tour files with step-by-step explanations linked to real files and line numbers. Supports 20 developer personas and all CodeTour step types |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |


### PR DESCRIPTION
Adds [code-tour](https://github.com/vaddisrinivas/code-tour) to the **Individual Skills** table.

**What it does:** AI-generated CodeTour walkthroughs for any codebase. Creates persona-targeted `.tour` files with step-by-step explanations linked to real files and line numbers. Supports 20 developer personas and all CodeTour step types.

**Install:** `npx skills add vaddisrinivas/code-tour`

The skill has more than just a single SKILL.md -- it includes bundled scripts, persona definitions, and CodeTour schema validation.