### PR TITLE
Add framecraft skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[framecraft](https://github.com/vaddisrinivas/framecraft)** | Generate polished demo videos from a single prompt — orchestrates Playwright, FFmpeg, and Edge TTS MCP servers for 1920x1080 videos with voiceover, transitions, and CSS animations |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [framecraft](https://github.com/vaddisrinivas/framecraft) to the **Individual Skills** table.

| Skill | Description |
| --- | --- |
| **[framecraft](https://github.com/vaddisrinivas/framecraft)** | Generate polished demo videos from a single prompt — orchestrates Playwright, FFmpeg, and Edge TTS MCP servers for 1920x1080 videos with voiceover, transitions, and CSS animations |

**Install:** `claude plugin install framecraft` or `npx skills add vaddisrinivas/framecraft`

- Full pipeline: Python CLI + MCP server + HTML scene templates
- MIT licensed