### PR TITLE
Add /cht — Chat Persistence for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[cht-cli](https://github.com/kosoukhov/cht-cli)** | 13 slash commands + hooks for persisting Claude Code conversations as local markdown files — crash-proof auto-save, project-based organization, search, and offline-readable history |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add /cht — Chat Persistence for Claude Code

[/cht](https://github.com/kosoukhov/cht-cli) provides 13 slash commands + hooks for persisting Claude Code conversations as local markdown files.

**Key features:**
- 13 slash commands for chat lifecycle, search, management
- Crash-proof auto-save via hooks
- Project-based organization
- Offline-readable markdown files

**Links:**
- GitHub: https://github.com/kosoukhov/cht-cli
- npm: https://www.npmjs.com/package/@kosoukhov/cht-cli