### PR TITLE
Add Tommy — dog companion persona for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[tommy](https://github.com/deeprpatel2/tommy)** | Dog companion persona for Claude Code / OpenClaw. Pick a breed (8 options), get breed-matched personality for every task + real dog photos fetched mid-session via dog.ceo API. Free. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What's being added

**[tommy](https://github.com/deeprpatel2/tommy)** — Dog companion persona for Claude Code / OpenClaw. Pick a breed (8 options), get breed-matched personality for every task + real dog photos fetched mid-session via dog.ceo API. Free.

## Why it belongs here

Tommy fits the **Individual Skills** table in the Community Skills section — it is a standalone Claude Code skill that modifies Claude's persona and communication style throughout a session based on the selected dog breed. It fetches real dog photos via the dog.ceo API mid-session for a fun, engaging coding experience.

## Checklist

- Added to the Individual Skills table using the exact same format as existing rows
- Link points directly to the GitHub repository
- Description is concise and accurate
- No commercial dependencies or SaaS requirements — fully free