### PR TITLE
Add AutoSearch — self-evolving deep research (32 channels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[AutoSearch](https://github.com/0xmariowu/Autosearch)** | Self-evolving deep research — searches 32 channels (GitHub, arXiv, Reddit, zhihu, bilibili, etc.), evaluates with LLM scoring, synthesizes cited reports, and learns from every session. Zero API keys. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
 ## AutoSearch — Self-evolving deep research for Claude Code

  **Repo**: https://github.com/0xmariowu/Autosearch

  A Claude Code plugin that searches 32 channels in parallel and gets smarter every session.

  **What it does:**
  - Searches GitHub, arXiv, Reddit, HN, zhihu, bilibili, and 26 more channels — zero API keys
  - Only searches what Claude doesn't already know (gap-driven)
  - Evaluates results with LLM scoring, synthesizes cited reports
  - Learns from every session: tracks which queries work, evolves its own search strategy

  **Benchmark:** +20% over native Claude across 5 topic categories (92% vs 72%)

  **Install:**
  curl -fsSL https://raw.githubusercontent.com/0xmariowu/autosearch/main/scripts/install.sh | bash