### PR TITLE
Add Unix Conventions skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Skills for working with complex file formats:
 - **[frontend-design](https://github.com/anthropics/skills/blob/main/skills/frontend-design)** - Instructs Claude to avoid "AI slop" or generic aesthetics and to make bold design decisions. Works very well for React & Tailwind.
 - **[web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder)** - Build complex claude.ai HTML artifacts using React, Tailwind CSS, and shadcn/ui components
 - **[mcp-builder](https://github.com/anthropics/skills/tree/main/skills/mcp-builder)** - Guide for creating high-quality MCP servers to integrate external APIs and services
+- **[unix-conventions](https://github.com/agiacalone/unix-conventions)** - Reviews CLI tools, shell scripts, C programs, and man pages against POSIX, GNU Coding Standards, and Unix philosophy; flags violations with exact fixes
 - **[webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing)** - Test local web applications using Playwright for UI verification and debugging
 
 ### Communication

--- a/unix-conventions/SKILL.md
+++ b/unix-conventions/SKILL.md
@@ -7,7 +7,7 @@ description: Use when reviewing or writing CLI tools, shell scripts, C programs,
 
 ## Overview
 
-Enforce code and documentation against three canonical sources: *The Art of Unix Programming* (ESR), POSIX, and the GNU Coding Standards.
+Enforce code and documentation against four canonical sources: *The Art of Unix Programming* (ESR), POSIX, the GNU Coding Standards, and "Worse is Better" (R.P. Gabriel).
 
 ## Task Dispatch
 

--- a/unix-conventions/SKILL.md
+++ b/unix-conventions/SKILL.md
@@ -18,7 +18,8 @@ Enforce code and documentation against four canonical sources: *The Art of Unix 
 | Review C program | `gnu-coding-standards.md`, `cli-conventions.md` |
 | Write or review man page | `man-page-format.md` |
 | Review `--help` / `--version` output | `cli-conventions.md`, `gnu-coding-standards.md` |
-| Unix philosophy / design review | `taoup-principles.md`, `worse-is-better.md` |
+| Unix philosophy / design review | `taoup-principles.md`, `worse-is-better.md`, `jargon-lore.md` |
+| Code/design quality vocabulary review | `jargon-terms.md`, `taoup-principles.md` |
 
 Load only the references needed for the task. All references are in the `references/` subdirectory of this skill.
 
@@ -122,6 +123,26 @@ When applying the lens:
 When a design decision pits interface elegance against implementation simplicity, note it explicitly:
 
 > "DESIGN NOTE: [option A] is simpler to implement; [option B] is cleaner to use. Worse is Better favors [option A]."
+
+### Jargon Lore Review
+
+Loaded for Unix philosophy and design reviews alongside `taoup-principles.md`.
+All references must be drawn from `jargon-lore.md` — never invent folklore.
+
+1. When a design pattern matches a known incident or koan in `jargon-lore.md`, cite it by name
+2. Format citations as: "DESIGN NOTE: This mirrors [entry] — [one-sentence description]."
+3. Use cultural context to explain *why* a pattern is valued or avoided, not just *that* it is
+4. Do not invent or paraphrase entries not present in `jargon-lore.md`
+
+### Jargon Terms Review
+
+Loaded for code/design quality reviews. Use vocabulary from `jargon-terms.md`
+to name design smells precisely. Terms appear at SUGGESTION level only.
+
+1. Apply positive/negative quality terms accurately (elegant, kludge, bletcherous, etc.)
+2. Terms supplement but do not replace VIOLATION/WARNING entries for convention violations
+3. Format as: "SUGGESTION: This design is [term] — [definition]. Consider [alternative]."
+4. Never use a term not defined in `jargon-terms.md`
 
 ## Reporting Format
 

--- a/unix-conventions/SKILL.md
+++ b/unix-conventions/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: unix-conventions
-description: Use when reviewing or writing CLI tools, shell scripts, C programs, man pages, --help output, error messages, or any artifact where Unix/POSIX/GNU conventions apply. Also use when the user asks if something "follows Unix conventions" or "Unix philosophy".
+description: Use when reviewing or writing CLI tools, shell scripts, C programs, man pages, --help output, or error messages. Also use when writing documentation or explanations for a Unix/hacker audience, or when the user asks if something "follows Unix conventions" or "Unix philosophy".
 ---
 
 # Unix Conventions
 
 ## Overview
 
-Enforce code and documentation against four canonical sources: *The Art of Unix Programming* (ESR), POSIX, the GNU Coding Standards, and "Worse is Better" (R.P. Gabriel).
+Honor Unix tradition in code, documentation, and design. Five canonical sources:
+
+- *The Art of Unix Programming* (ESR) — the 17 Rules; the philosophy behind why Unix works
+- POSIX — option syntax, exit codes, streams; the portable baseline every Unix tool must meet
+- GNU Coding Standards — error format, standard options, shell scripting; what GNU tools actually do
+- "Worse is Better" (R.P. Gabriel) — when implementation simplicity beats interface elegance
+- The Jargon File — hacker vocabulary and lore; how to write for an audience that groks the tradition
 
 ## Task Dispatch
 
@@ -18,8 +24,7 @@ Enforce code and documentation against four canonical sources: *The Art of Unix 
 | Review C program | `gnu-coding-standards.md`, `cli-conventions.md` |
 | Write or review man page | `man-page-format.md` |
 | Review `--help` / `--version` output | `cli-conventions.md`, `gnu-coding-standards.md` |
-| Unix philosophy / design review | `taoup-principles.md`, `worse-is-better.md`, `jargon-lore.md` |
-| Code/design quality vocabulary review | `jargon-terms.md`, `taoup-principles.md` |
+| Unix philosophy / design review | `taoup-principles.md`, `worse-is-better.md`, `jargon-lore.md`, `jargon-terms.md` |
 
 Load only the references needed for the task. All references are in the `references/` subdirectory of this skill.
 
@@ -35,7 +40,7 @@ Read whichever files exist and merge them, with higher-precedence files winning.
 
 ## Conflicts Between Standards
 
-The three sources disagree on these points. **Do not assume — ask the user** unless the config file resolves it.
+POSIX, GNU, and TAOUP disagree on these points. **Do not assume — ask the user** unless the config file resolves it.
 
 | Conflict | POSIX | GNU | Resolution |
 |----------|-------|-----|------------|
@@ -50,7 +55,7 @@ The three sources disagree on these points. **Do not assume — ask the user** u
 When a conflict arises during review and no config setting covers it, stop and ask:
 
 > "This touches a conflict between [standard A] and [standard B]: [describe the conflict].
-> Which do you prefer, or should I note it as a warning without enforcing either?"
+> Which do you prefer, or should I note it as a warning without favoring either?"
 
 Do not silently pick one. Do not assume GNU because it is more common.
 
@@ -124,25 +129,23 @@ When a design decision pits interface elegance against implementation simplicity
 
 > "DESIGN NOTE: [option A] is simpler to implement; [option B] is cleaner to use. Worse is Better favors [option A]."
 
-### Jargon Lore Review
+### Jargon File
 
-Loaded for Unix philosophy and design reviews alongside `taoup-principles.md`.
-All references must be drawn from `jargon-lore.md` — never invent folklore.
+The Jargon File is a cultural resource, not a ruleset. Use it for:
 
-1. When a design pattern matches a known incident or koan in `jargon-lore.md`, cite it by name
-2. Format citations as: "DESIGN NOTE: This mirrors [entry] — [one-sentence description]."
-3. Use cultural context to explain *why* a pattern is valued or avoided, not just *that* it is
-4. Do not invent or paraphrase entries not present in `jargon-lore.md`
+- **Vocabulary:** When writing docs, comments, or explanations, reach for the right hacker
+  term. "Crufty", "kludge", "elegant", "hairy" — these carry precise meaning to Unix people
+  and communicate more than a generic description would.
+- **Analogies:** When explaining why a design pattern is good or bad, a Jargon File analogy
+  can make it immediately recognizable. A Unix person who hears "cargo cult programming" or
+  "creeping featurism" understands instantly.
+- **Lore:** When writing for an audience of hackers, cultural touchstones (foo/bar, the Great
+  Worm, ITS, the hacker ethic) create shared context and signal that the author knows the
+  tradition.
 
-### Jargon Terms Review
-
-Loaded for code/design quality reviews. Use vocabulary from `jargon-terms.md`
-to name design smells precisely. Terms appear at SUGGESTION level only.
-
-1. Apply positive/negative quality terms accurately (elegant, kludge, bletcherous, etc.)
-2. Terms supplement but do not replace VIOLATION/WARNING entries for convention violations
-3. Format as: "SUGGESTION: This design is [term] — [definition]. Consider [alternative]."
-4. Never use a term not defined in `jargon-terms.md`
+Use `jargon-terms.md` for design vocabulary and `jargon-lore.md` for cultural references.
+For anything not covered there, `documentation/jargon.md` has the full text. Don't invent
+entries or use terms you're not confident about — the Jargon File is authoritative.
 
 ## Reporting Format
 
@@ -158,4 +161,6 @@ Group by severity: **errors** (must fix) → **warnings** (should fix) → **sug
 
 ## Tone
 
-Direct and technical. Show the corrected form; minimize explanation of why it is wrong.
+Direct and technical. Show the corrected form; don't handwave. The Unix tradition values
+correctness and terseness over diplomacy — a bletcherous interface is bletcherous whether
+or not its author intended it. Name things accurately.

--- a/unix-conventions/SKILL.md
+++ b/unix-conventions/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: unix-conventions
+description: Reviews CLI tools, shell scripts, C programs, and man pages against POSIX, GNU Coding Standards, and Unix philosophy — flags violations with exact fixes.
+---
+
+# Unix Conventions
+
+Enforces code and documentation against three canonical Unix standards: *The Art of Unix Programming* (ESR), POSIX (IEEE Std 1003.1), and the GNU Coding Standards. Covers option syntax, exit codes, stream usage, error message format, shell script hygiene, C program correctness, and man page structure.
+
+> **Claude Code only.** Clone [agiacalone/unix-conventions](https://github.com/agiacalone/unix-conventions) and run `./install.sh`, which copies the skill and reference documents to `~/.claude/skills/unix-conventions/`.
+
+## When to Use This Skill
+
+- Reviewing a CLI tool for option, exit code, or stream convention violations
+- Auditing a shell script for portability and correctness issues
+- Checking a C program's error handling and resource management
+- Writing or reviewing a man page
+- Evaluating a tool's design against Unix philosophy
+
+## What This Skill Does
+
+1. **Loads targeted references** — pulls only the documents relevant to the task (POSIX, GNU, TAOUP, man page conventions) rather than applying everything at once
+2. **Resolves standard conflicts explicitly** — POSIX and GNU disagree on several points (`-h`, long options, shebang, `printf` vs `echo`); the skill asks rather than silently picking one
+3. **Reports violations in a structured format** — every finding includes location, what was found, what was expected, and an exact fix
+4. **Applies the Worse is Better design lens** — flags tradeoffs between implementation simplicity and interface elegance during design reviews
+
+## How to Use
+
+### Basic Usage
+
+```
+Review this shell script against Unix conventions
+```
+
+```
+Does this CLI tool follow POSIX option conventions?
+```
+
+### Advanced Usage
+
+Per-project preferences can be set in a `.unix-conventions` file at the project root to resolve conflicts between standards without being prompted each time:
+
+```
+# .unix-conventions
+standard = gnu          # gnu | posix | ask
+shebang = bash          # bash | sh | ask
+echo_or_printf = printf # printf | echo | ask
+worse_is_better = yes   # yes | no | ask
+```
+
+## Example
+
+**User**: "Review fetch-taoup.sh against Unix conventions"
+
+**Output**:
+```
+WARNINGS
+
+VIOLATION: echo_or_printf = printf
+LOCATION:  fetch-taoup.sh:28
+FOUND:     echo "fetch-taoup: $*" >&2
+EXPECTED:  printf output to stderr with program name prefix
+FIX:       printf 'fetch-taoup: %s\n' "$*" >&2
+
+VIOLATION: echo_or_printf = printf
+LOCATION:  fetch-taoup.sh:43
+FOUND:     echo "fetch-taoup: warning: could not parse..." >&2
+EXPECTED:  printf for all diagnostic output
+FIX:       printf 'fetch-taoup: warning: could not parse chapter order from index.html, falling back to filename order\n' >&2
+```
+
+**Inspired by:** Eric S. Raymond's *The Art of Unix Programming*, the GNU Coding Standards, and Richard P. Gabriel's "Worse is Better"
+
+## Tips
+
+- Set `standard = posix` for tools that must run on macOS, OpenBSD, or musl-based systems; set `gnu` for Linux-only tools
+- Set `worse_is_better = yes` in projects that prioritize implementation simplicity — the skill will flag over-engineered designs
+- The skill only loads references relevant to the task — you won't get man page rules when reviewing a shell script
+
+## Common Use Cases
+
+- Auditing scripts in a new repo before publishing them
+- Reviewing student or junior developer CLI tools against established conventions
+- Ensuring a new tool composes cleanly in pipelines (Rule of Silence, filter pattern)
+- Writing man pages that follow the canonical section order and macro conventions

--- a/unix-conventions/SKILL.md
+++ b/unix-conventions/SKILL.md
@@ -1,85 +1,140 @@
 ---
 name: unix-conventions
-description: Reviews CLI tools, shell scripts, C programs, and man pages against POSIX, GNU Coding Standards, and Unix philosophy — flags violations with exact fixes.
+description: Use when reviewing or writing CLI tools, shell scripts, C programs, man pages, --help output, error messages, or any artifact where Unix/POSIX/GNU conventions apply. Also use when the user asks if something "follows Unix conventions" or "Unix philosophy".
 ---
 
 # Unix Conventions
 
-Enforces code and documentation against three canonical Unix standards: *The Art of Unix Programming* (ESR), POSIX (IEEE Std 1003.1), and the GNU Coding Standards. Covers option syntax, exit codes, stream usage, error message format, shell script hygiene, C program correctness, and man page structure.
+## Overview
 
-> **Claude Code only.** Clone [agiacalone/unix-conventions](https://github.com/agiacalone/unix-conventions) and run `./install.sh`, which copies the skill and reference documents to `~/.claude/skills/unix-conventions/`.
+Enforce code and documentation against three canonical sources: *The Art of Unix Programming* (ESR), POSIX, and the GNU Coding Standards.
 
-## When to Use This Skill
+## Task Dispatch
 
-- Reviewing a CLI tool for option, exit code, or stream convention violations
-- Auditing a shell script for portability and correctness issues
-- Checking a C program's error handling and resource management
-- Writing or reviewing a man page
-- Evaluating a tool's design against Unix philosophy
+| Task | References to load |
+|------|--------------------|
+| Review CLI tool (options, exit codes, streams) | `cli-conventions.md`, `taoup-principles.md` |
+| Review shell script | `cli-conventions.md`, `gnu-coding-standards.md` |
+| Review C program | `gnu-coding-standards.md`, `cli-conventions.md` |
+| Write or review man page | `man-page-format.md` |
+| Review `--help` / `--version` output | `cli-conventions.md`, `gnu-coding-standards.md` |
+| Unix philosophy / design review | `taoup-principles.md`, `worse-is-better.md` |
 
-## What This Skill Does
+Load only the references needed for the task. All references are in the `references/` subdirectory of this skill.
 
-1. **Loads targeted references** — pulls only the documents relevant to the task (POSIX, GNU, TAOUP, man page conventions) rather than applying everything at once
-2. **Resolves standard conflicts explicitly** — POSIX and GNU disagree on several points (`-h`, long options, shebang, `printf` vs `echo`); the skill asks rather than silently picking one
-3. **Reports violations in a structured format** — every finding includes location, what was found, what was expected, and an exact fix
-4. **Applies the Worse is Better design lens** — flags tradeoffs between implementation simplicity and interface elegance during design reviews
+## Configuration
 
-## How to Use
+Load preferences in this order (highest to lowest precedence):
 
-### Basic Usage
+1. `.unix-conventions` in the project root
+2. `~/.config/unix-conventions/config` (user config)
+3. Skill defaults — ask
+
+Read whichever files exist and merge them, with higher-precedence files winning. If a setting is `ask` or absent in all files, follow the conflict rules below.
+
+## Conflicts Between Standards
+
+The three sources disagree on these points. **Do not assume — ask the user** unless the config file resolves it.
+
+| Conflict | POSIX | GNU | Resolution |
+|----------|-------|-----|------------|
+| `-h` option | Not reserved; tools use it for domain purposes (e.g., human-readable) | Reserved strictly for `--help` | Ask: is `-h` for help or domain use? |
+| Long options | Not defined | Required alongside short options | Ask: require long options, optional, or none? |
+| Options after operands | First non-option ends option parsing | Freely permuted | Ask: POSIX strict or GNU permutation? |
+| Shebang | `#!/bin/sh` for portability | `#!/bin/bash` when bash features used | Ask: must it be portable to non-bash? |
+| `printf` vs `echo` | Both defined; `echo` behaviour varies | Prefer `printf` | Ask: portability requirement? |
+| C indentation | Not specified | 2 spaces | Ask: gnu, kr (8-space tabs), or linux? |
+| `error()` function | Not defined | Recommended when on glibc | Ask: glibc-only acceptable? |
+
+When a conflict arises during review and no config setting covers it, stop and ask:
+
+> "This touches a conflict between [standard A] and [standard B]: [describe the conflict].
+> Which do you prefer, or should I note it as a warning without enforcing either?"
+
+Do not silently pick one. Do not assume GNU because it is more common.
+
+## Checklists
+
+### CLI Tool
+
+1. Option syntax: POSIX short (`-x`), GNU long (`--foo`), clustering, `--` terminator
+2. Exit codes: 0=success, 1=error, 2=misuse
+3. Streams: errors → stderr, data → stdout, never reversed
+4. Error format: `progname: description` (lowercase, no period)
+5. `--help`: correct format, exits 0
+6. `--version`: correct format, exits 0
+7. Reserved options: `-h/--help`, `-V/--version`, `-v/--verbose`, `-q/--quiet`, `-n/--dry-run`
+8. Rule of Silence: silent on success by default; no chatty progress output unless `-v`
+9. Unix philosophy: does one thing, composes via stdin/stdout
+
+### Shell Script
+
+1. Shebang: `#!/bin/sh` for portable, `#!/bin/bash` only when bash features are used
+2. `set -euo pipefail` present
+3. All variable expansions quoted: `"$var"`, `"$@"`, `"${var}"`
+4. Command substitution uses `$()` not backticks
+5. Error messages go to stderr, include script name
+6. Temp files via `mktemp`, cleaned up with `trap ... EXIT`
+7. No parsing of `ls` output; use globs
+8. Exit codes correct
+
+### C Program
+
+1. All system call return values checked
+2. Error messages: `progname: description` format
+3. `progname` set from `argv[0]` (path stripped)
+4. No resource leaks: file descriptors, memory, temp files
+5. Signal handling: SIGINT, SIGTERM handled gracefully
+6. Option parsing handles `--` terminator
+
+### Man Page
+
+1. Sections present in canonical order: NAME, SYNOPSIS, DESCRIPTION, OPTIONS, EXIT STATUS, FILES, ENVIRONMENT, EXAMPLES, SEE ALSO
+2. NAME: one line, `\-` separator, lowercase description, no period
+3. SYNOPSIS: program bold, meta-variables italic, brackets for optional, ellipsis for repeatable
+4. OPTIONS: each in its own `.TP` block
+5. EXIT STATUS: all non-zero codes documented
+6. SEE ALSO: section numbers in parens, alphabetical, comma-separated
+7. Style: third person, present tense, terse
+
+### `--help` / `--version`
+
+1. `Usage:` line with uppercase meta-variables (`FILE`, `DIR`, `NUM`)
+2. Two-column option list, `-h`/`-V` listed last
+3. Bug report contact at end
+4. Exits 0
+
+### Worse is Better Design Review
+
+Controlled by the `worse_is_better` config key (`yes | no | ask`, default: `ask`).
+
+- `yes` — always apply this lens; flag any design that favors interface elegance over implementation simplicity
+- `no` — skip this checklist entirely
+- `ask` — when a design tradeoff arises where the two approaches diverge, stop and ask: "This is a Worse is Better tradeoff: [describe it]. Apply the lens, skip it, or note it as informational?"
+
+When applying the lens:
+
+1. **Implementation simplicity** — if two designs differ in implementation complexity, prefer the simpler one even if its interface is slightly more awkward
+2. **Edge cases pushed out** — are unusual inputs rejected cleanly (error + exit 1) rather than handled with complex internal logic?
+3. **Completeness last** — are missing features documented limitations rather than half-implemented handlers?
+4. **Not a bug excuse** — correctness violations (unchecked return values, reversed streams, wrong exit codes) are bugs, not tradeoffs
+
+When a design decision pits interface elegance against implementation simplicity, note it explicitly:
+
+> "DESIGN NOTE: [option A] is simpler to implement; [option B] is cleaner to use. Worse is Better favors [option A]."
+
+## Reporting Format
 
 ```
-Review this shell script against Unix conventions
+VIOLATION: [rule or convention name]
+LOCATION:  [file:line or section]
+FOUND:     [current state]
+EXPECTED:  [correct state]
+FIX:       [exact correction]
 ```
 
-```
-Does this CLI tool follow POSIX option conventions?
-```
+Group by severity: **errors** (must fix) → **warnings** (should fix) → **suggestions** (consider).
 
-### Advanced Usage
+## Tone
 
-Per-project preferences can be set in a `.unix-conventions` file at the project root to resolve conflicts between standards without being prompted each time:
-
-```
-# .unix-conventions
-standard = gnu          # gnu | posix | ask
-shebang = bash          # bash | sh | ask
-echo_or_printf = printf # printf | echo | ask
-worse_is_better = yes   # yes | no | ask
-```
-
-## Example
-
-**User**: "Review fetch-taoup.sh against Unix conventions"
-
-**Output**:
-```
-WARNINGS
-
-VIOLATION: echo_or_printf = printf
-LOCATION:  fetch-taoup.sh:28
-FOUND:     echo "fetch-taoup: $*" >&2
-EXPECTED:  printf output to stderr with program name prefix
-FIX:       printf 'fetch-taoup: %s\n' "$*" >&2
-
-VIOLATION: echo_or_printf = printf
-LOCATION:  fetch-taoup.sh:43
-FOUND:     echo "fetch-taoup: warning: could not parse..." >&2
-EXPECTED:  printf for all diagnostic output
-FIX:       printf 'fetch-taoup: warning: could not parse chapter order from index.html, falling back to filename order\n' >&2
-```
-
-**Inspired by:** Eric S. Raymond's *The Art of Unix Programming*, the GNU Coding Standards, and Richard P. Gabriel's "Worse is Better"
-
-## Tips
-
-- Set `standard = posix` for tools that must run on macOS, OpenBSD, or musl-based systems; set `gnu` for Linux-only tools
-- Set `worse_is_better = yes` in projects that prioritize implementation simplicity — the skill will flag over-engineered designs
-- The skill only loads references relevant to the task — you won't get man page rules when reviewing a shell script
-
-## Common Use Cases
-
-- Auditing scripts in a new repo before publishing them
-- Reviewing student or junior developer CLI tools against established conventions
-- Ensuring a new tool composes cleanly in pipelines (Rule of Silence, filter pattern)
-- Writing man pages that follow the canonical section order and macro conventions
+Direct and technical. Show the corrected form; minimize explanation of why it is wrong.


### PR DESCRIPTION
Title: Add Unix Conventions skill

---

## What problem it solves

Unix/POSIX/GNU conventions for CLI tools, shell scripts, C programs, and man pages are spread across three authoritative but sometimes conflicting sources: POSIX (IEEE Std 1003.1), the GNU Coding Standards, and Eric S. Raymond's *The Art of Unix Programming*. This skill consolidates them into a single reviewable checklist, resolves conflicts explicitly (asking the user rather than silently picking a standard), and reports every finding with an exact fix.

## Who uses this workflow

Developers writing or reviewing Unix CLI tools, shell scripts, or C programs — particularly those targeting multiple platforms where POSIX/GNU differences matter. Also useful for reviewing man pages and --help output.

## Attribution

- Eric S. Raymond, *The Art of Unix Programming* (TAOUP) — the 17 Rules and Unix philosophy
- GNU Coding Standards — error format, standard options, shell scripting rules
- POSIX (IEEE Std 1003.1) — option syntax, exit codes, standard streams
- Richard P. Gabriel, "Worse is Better" (1989) — design philosophy lens

## Example

Applied to our own fetch scripts, it immediately caught 4 echo-instead-of-printf violations and a missing mktemp guard for atomic file writes — all fixed before publishing.

## Notes

- Claude Code only; requires cloning agiacalone/unix-conventions and running ./install.sh
- Supports per-project config (.unix-conventions) to resolve standard conflicts without prompting