### PR TITLE
Add LAN Skills to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[lan-accelerator/lan-skills](https://github.com/lan-accelerator/lan-skills)** - 27 AI skills for the venture capital ecosystem — startups, LPs, corporates, and fund operators. Built by LAN Accelerator.
+  - 4 suites: Startups (13), VC Operators (5), LP & Angel (5), Corporates (4)
+  - Grounded in YC, Sequoia, a16z, Brad Feld, ILPA, LAVCA, and Cuantico frameworks
+  - Installation: `npx lan-skills` or `./install.sh`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## Summary

- Adds **[LAN Skills](https://github.com/lan-accelerator/lan-skills)** to the **Collections & Libraries** section
- 27 AI skills for the venture capital ecosystem — startups, LPs, corporates, and fund operators
- 4 suites: Startups (13), VC Operators (5), LP & Angel (5), Corporates (4)
- Grounded in YC, Sequoia, a16z, Brad Feld, ILPA, LAVCA 2025, and Cuantico 2026 frameworks
- Built by [LAN Accelerator](https://lan.vc)

## Installation

```bash
npx lan-skills
# or
git clone https://github.com/lan-accelerator/lan-skills.git && ./install.sh
```