### PR TITLE
Add ctxlint — CLAUDE.md linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 
+- **[ctxlint](https://github.com/YawLabs/ctxlint)** - Lints CLAUDE.md and other AI context files against your codebase. Includes MCP server for agent self-auditing.
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
 
 ## ✏️ Creating Your First Skill


### PR DESCRIPTION
## Summary

[ctxlint](https://github.com/YawLabs/ctxlint) is an open-source linter for AI context files (CLAUDE.md, .cursorrules, copilot-instructions.md). It validates file paths, shell commands, and references against your actual codebase. Includes a built-in MCP server so agents can self-audit their own context files.

- **GitHub**: https://github.com/YawLabs/ctxlint
- **npm**: [@yawlabs/ctxlint](https://www.npmjs.com/package/@yawlabs/ctxlint)
- **License**: MIT

Added to the **Tools** section.