### PR TITLE
Add design-cognition-skill to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[design-cognition-skill](https://github.com/S0ulFood/design-cognition-skill)** | AI design thinking framework with four roles (Strategist, Researcher, Executor, Critic) for pressure-testing design decisions |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
Adds [design-cognition-skill](https://github.com/S0ulFood/design-cognition-skill) to the Individual Skills table.

## About the skill
AI design thinking framework with four distinct roles:
- **Strategist** — questions the problem before anyone solves it
- **Researcher** — validates assumptions with evidence
- **Executor** — builds against validated direction
- **Critic** — finds what is wrong before it becomes expensive

The key capability: Claude uses multiple roles to pressure-test its own design output from structurally different perspectives.