### PR TITLE
Add cost-mode skill (token usage reduction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[cost-mode](https://github.com/Sagargupta16/claude-cost-optimizer)** | Reduces token usage 40-70% through concise responses, smart model routing suggestions, and session awareness. Three intensity levels: lite, standard, strict |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **cost-mode** to the Individual Skills table.

**Skill**: [cost-mode](https://github.com/Sagargupta16/claude-cost-optimizer)
**Install**: `npx skills add Sagargupta16/claude-cost-optimizer` or `/plugin marketplace add Sagargupta16/claude-cost-optimizer`
**What it does**: Reduces token usage 40-70% through concise responses, smart model routing suggestions, and session awareness. Three intensity levels (lite, standard, strict).

**Social proof**: 12 stars, active development, includes a React site with Repo Analyzer, Cost Calculator, and Badge Checker. The skill is part of a larger cost optimization toolkit with 10 guides, 7 CLI tools, and 10 templates.

**Non-promotional**: This is an open-source MIT-licensed skill that runs entirely locally. No SaaS, no paid features, no API calls to external services.