### PR TITLE
Add codachi to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[vincent-k2026/codachi](https://github.com/vincent-k2026/codachi)** - Animated statusline pet that monitors your Claude Code session — context burn velocity, cache hit rate, remaining time prediction — and reacts to tool executions with 850+ contextual messages
 
 ## ✏️ Creating Your First Skill
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
-- **[vincent-k2026/codachi](https://github.com/vincent-k2026/codachi)** - Animated statusline pet that monitors your Claude Code session — context burn velocity, cache hit rate, remaining time prediction — and reacts to tool executions with 850+ contextual messages
+- **[vincent-k2026/codachi](https://github.com/vincent-k2026/codachi)** - Statusline tool that predicts minutes-until-context-full from live burn rate, with an ASCII pet that reacts to test runs, commits, and file edits. Zero dependencies, `npx codachi init` to install.
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
Adds codachi to the Tools section.

It's a statusline tool for Claude Code that displays context metrics (cache hit rate, burn velocity, time-until-full) alongside an animated ASCII pet that reacts to tool executions via PostToolExecution hooks. Lightweight Node.js process, zero API overhead.

GitHub: https://github.com/vincent-k2026/codachi