### PR TITLE
Add imessage-sms-agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[imessage-sms-agent](https://github.com/emotion-machine-org/imessage-sms-agent)** | Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo). Install: `npx skills add emotion-machine-org/imessage-sms-agent` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
-| **[imessage-with-no-mac](https://github.com/emotion-machine-org/imessage-with-no-mac)** | Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo). Install: `npx skills add emotion-machine-org/imessage-with-no-mac` |
+| **[imessage-with-no-mac](https://github.com/emotion-machine-org/imessage-with-no-mac)** | Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger Install: `npx skills add emotion-machine-org/imessage-with-no-mac` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
-| **[imessage-sms-agent](https://github.com/emotion-machine-org/imessage-with-no-mac)** | Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo). Install: `npx skills add emotion-machine-org/imessage-with-no-mac` |
+| **[imessage-with-no-mac](https://github.com/emotion-machine-org/imessage-with-no-mac)** | Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo). Install: `npx skills add emotion-machine-org/imessage-with-no-mac` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
-| **[imessage-sms-agent](https://github.com/emotion-machine-org/imessage-no-mac-sms)** | Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo). Install: `npx skills add emotion-machine-org/imessage-no-mac-sms` |
+| **[imessage-sms-agent](https://github.com/emotion-machine-org/imessage-with-no-mac)** | Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo). Install: `npx skills add emotion-machine-org/imessage-with-no-mac` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
-| **[imessage-sms-agent](https://github.com/emotion-machine-org/imessage-sms-agent)** | Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo). Install: `npx skills add emotion-machine-org/imessage-sms-agent` |
+| **[imessage-sms-agent](https://github.com/emotion-machine-org/imessage-no-mac-sms)** | Give any AI agent iMessage, RCS & SMS capabilities. No Mac required. Works with Claude Code, Codex, Cursor, Gemini CLI. Powered by Claw Messenger ($5/mo). Install: `npx skills add emotion-machine-org/imessage-no-mac-sms` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [imessage-sms-agent](https://github.com/emotion-machine-org/imessage-sms-agent) to the Community Skills section.

**What it does:** Gives any AI agent iMessage, RCS & SMS capabilities via Claw Messenger. No Mac or phone required.

**Install:** `npx skills add emotion-machine-org/imessage-sms-agent`