### PR TITLE
Add Master-skill: Chinese Buddhist master AI teaching personas

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[Master-skill](https://github.com/xr843/Master-skill)** | Chinese Buddhist master AI teaching personas powered by FoJin. 8 pre-built masters with CBETA source citations. AgentSkills standard. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adding [Master-skill](https://github.com/xr843/Master-skill) to the Individual Skills table.

**What it does:** Provides 8 pre-built Chinese Buddhist master AI teaching personas (Kumarajiva, Xuanzang, Huineng, Zhiyi, Fazang, Yinguang, Xuyun, Ouyi) powered by the FoJin Buddhist knowledge base. Each master responds with citations from CBETA canonical texts, following the AgentSkills standard.

**Why it's valuable:**
- Unique domain: no other skill in this list covers Buddhist studies or CJK classical text workflows
- 106 GitHub stars — community has validated its usefulness
- Multiple SKILL.md files (one per master) with full YAML frontmatter and documented personas
- Backed by real classical source citations (CBETA), not hallucinated content
- AgentSkills standard compliant

**Links:**
- Repo: https://github.com/xr843/Master-skill
- Stars: 106 ⭐
- License: MIT