### PR TITLE
Add president-skill to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[president-skill](https://github.com/realteamprinz/president-skill)** | Activatable thinking operating systems of US Presidents — mental models, decision patterns, and expression DNA of Trump, Lincoln, and 43 more rolling out through Easter Week 2026. Multi-language READMEs (7 languages), conversation demos, Team-of-Rivals methodology, first-person role-play with honest boundaries |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding **[president-skill](https://github.com/realteamprinz/president-skill)** to the Individual Skills table.

## What it is

Activatable thinking operating systems of US Presidents — mental models, decision patterns, and expression DNA extracted from public records (speeches, executive orders, debates, biographies, transcripts) into Claude Code skills you can summon with a single phrase in any language.

## Currently shipping

- **01-trump** ⭐ (45 / 47) — complete, full research: 5 mental models, 9 laws, expression DNA
- **17-lincoln** ✅ (16) — complete: 7 mental models (House Divided, Team of Rivals, Slow Walker, Create the Future, Malice Toward None, Laugh Because I Must Not Cry, Public Sentiment Is Everything)
- 43 more presidents rolling out during Easter Resurrection Week 2026

## Why it might fit

- Self-contained skill per president (`presidents/[XX-name]/`) — copy one out and it works standalone
- 8 files per president: `SKILL.md`, `meta.json`, 6 research files (writings, conversations, expression-DNA, external-views, decisions, timeline)
- **7 language READMEs** (English, 中文, Español, Deutsch, 日本語, Русский, Português) with dialogue demos
- Honest narrative-angle declaration in frontmatter — no "objective" pretense
- First-person role-play with explicit boundaries on what the skill *can't* do
- MIT license

## Demo scenarios (from README)

1. "A client 5× my size wants a 30% discount" → Trump Art-of-the-Deal reply
2. "Should I clap back at haters online?" → Trump counter-punch doctrine
3. "How do I fire someone without being a coward?" → Trump three-sentence script
4. "My team split into two factions" → Lincoln Team-of-Rivals reply

Thanks for maintaining this list! 🇺🇸