### PR TITLE
Add obsidian-theme-designer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[obsidian-theme-designer](https://github.com/XiangyuSu611/obsidian-theme-designer)** | Design Obsidian themes visually in the browser with style direction, color palette, font showcase, dual light/dark mode preview, and automated font installation |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds [Obsidian Theme Designer](https://github.com/XiangyuSu611/obsidian-theme-designer) to the Community Skills > Individual Skills table
- A Claude Code skill for designing Obsidian themes visually in the browser — style direction, color palette, font showcase, dual light/dark mode preview, and automated font installation

## Details

The skill goes beyond a single SKILL.md file and includes bundled scripts and resources for browser-based theme preview, font management, and CSS generation. It provides a complete workflow for Obsidian theme design within Claude Code.

## Checklist

- [x] Entry added to the Individual Skills table
- [x] Follows existing table format
- [x] Link is valid and points to a public repository
- [x] Description is concise and accurate