### PR TITLE
Add drpc-agent-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[drpc-agent-skills](https://github.com/drpcorg/drpc-agent-skills)** | Blockchain RPC access — eth_call, getBalance, estimateGas, getLogs and more. Installs as a skill, no MCP server config needed |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [drpc-agent-skills](https://github.com/drpcorg/drpc-agent-skills) to the Individual Skills table.

This skill provides blockchain RPC access (eth_call, getBalance, estimateGas, getLogs, and more) that installs as a Claude Code skill — no MCP server configuration required.