### PR TITLE
Add vaultweaver — LLM Knowledge Base compiler skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
+| **[vaultweaver](https://github.com/Apexlify/vaultweaver)** | LLM Knowledge Base compiler — drop files, get an interconnected Obsidian-compatible wiki. Based on Karpathy's LLM Wiki pattern. Auto-ingest, BM25 search, drift detection |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
## New Skill: Vaultweaver

**Repo:** https://github.com/Apexlify/vaultweaver

**What it does:** Claude Code skill implementing Karpathy's LLM Knowledge Bases pattern. Drop files in `raw/`, Claude compiles them into an interconnected Obsidian-compatible markdown wiki with concepts, entities, cross-references, and auto-maintained index.

**Key features:**
- 8 commands: init, ingest, compile, query, lint, search, status, serve
- Auto-pilot hooks (drift detection + auto-ingest)
- BM25 search engine with web UI
- Obsidian-native: `[[wiki-links]]`, YAML frontmatter, graph view
- 7 health checks

**Category:** Knowledge Management / Research

**Based on:** [Karpathy's LLM Knowledge Bases](https://x.com/karpathy/status/2039805659525644595)