### PR TITLE
Add 2389-research/claude-plugins to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[2389-research/claude-plugins](https://github.com/2389-research/claude-plugins)** - Plugin marketplace with 25 skills and MCP servers covering development workflows, multi-agent patterns, and code quality
+  - Includes simmer (iterative refinement with judge panels), review-squad (parallel reviewer agents), speed-run (token-efficient codegen via hosted LLMs), and test-kitchen (parallel implementation exploration)
+  - Also has binary reverse engineering, Firebase/CSS dev workflows, scenario testing (no-mocks TDD), and PR health monitoring
+  - Marketplace site: https://2389-research.github.io/claude-plugins
+  - Installation: `/plugin marketplace add 2389-research/claude-plugins`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adding 2389's open-source plugin marketplace to the Collections & Libraries section. It's a monorepo with 25 skills and MCP servers that we actually use day-to-day at our shop — stuff like iterative refinement loops, parallel code review agents, no-mocks TDD, binary RE, and Firebase/CSS dev workflows.

The marketplace repo has 44 stars and has been actively maintained since late 2025. Each skill is independently installable from the marketplace.

Repository: https://github.com/2389-research/claude-plugins
Marketplace site: https://2389-research.github.io/claude-plugins