### PR TITLE
Add TBD to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[tbd-vote-cli](https://github.com/ego-protocol/tbd-vote-cli)** | Trade on TBD, a Solana-based prediction market for human opinions, via the `@tbd-vote/cli` package; defers to an [AGENTS.md](https://www.tbd.vote/agents/AGENTS.md) spec for autonomous-loop instructions and HTTP fallback |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds TBD to the Community Skills > Individual Skills table.

[TBD](https://www.tbd.vote) is a Solana-based prediction market for human opinions — wagering on what people think and believe rather than purely objective event outcomes. The [`@tbd-vote/cli`](https://www.npmjs.com/package/@tbd-vote/cli) npm package and [SKILL.md](https://github.com/ego-protocol/tbd-vote-cli/blob/main/SKILL.md) let agents authenticate, browse opinion campaigns, and place bets via JSON-friendly commands. The skill defers to a long-form [AGENTS.md spec](https://www.tbd.vote/agents/AGENTS.md) for autonomous-loop patterns and HTTP fallback.

- Repo: https://github.com/ego-protocol/tbd-vote-cli
- Website: https://www.tbd.vote
- AGENTS.md: https://www.tbd.vote/agents/AGENTS.md
- npm: https://www.npmjs.com/package/@tbd-vote/cli