### PR TITLE
Add gmail-daily-summarizer skill

### DIFF
--- a/gmail-daily-summarizer/SKILL.md
+++ b/gmail-daily-summarizer/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: gmail-daily-summarizer
+description: Summarizes daily emails from specific senders using Claude AI and saves them as Google Docs in Google Drive. Built on Google Apps Script — no server required.
+---
+
+# Gmail Daily Summarizer
+
+This skill helps you set up an automated daily email summarizer using Google Apps Script and Claude AI. It monitors emails from specific senders, summarizes them with Claude, and saves each summary as a Google Doc.
+
+## What it does
+
+- Monitors Gmail for emails from one or more senders (last 24 hours)
+- Summarizes email content using Claude AI (Haiku model)
+- Creates a separate Google Doc per sender
+- Saves docs to a specified Google Drive folder
+- Sends a notification email (and optionally Telegram) with links to summaries
+- Runs automatically every day at a scheduled time
+
+## Requirements
+
+- A Google account (Gmail + Google Drive + Google Docs)
+- A Claude API key from [console.anthropic.com](https://console.anthropic.com)
+- Access to [Google Apps Script](https://script.google.com) (free)
+
+## Setup Instructions
+
+### 1. Open Google Apps Script
+Go to [script.google.com](https://script.google.com) and create a new project. Name it `Gmail Daily Summarizer`.
+
+### 2. Paste the script
+Copy the full code from `scripts/email_summary_bot.gs` and paste it into the script editor, replacing any existing code.
+
+### 3. Fill in the CONFIG values
+
+```javascript
+const CONFIG = {
+  SENDER_EMAILS: [
+    'email1@youremail.com',   // Emails to monitor — add as many as you want
+    'email2@youremail.com',
+  ],
+  FOLDER_ID:          'YOUR_FOLDER_ID',       // From your Google Drive folder URL
+  CLAUDE_API_KEY:     'YOUR_CLAUDE_API_KEY',  // From console.anthropic.com → API Keys
+  NOTIFY_EMAIL:       'yournotifyemail@gmail.com',
+  TELEGRAM_BOT_TOKEN: '',                     // Optional — leave empty to skip
+  TELEGRAM_CHAT_ID:   '',                     // Optional — leave empty to skip
+  TRIGGER_HOUR:       12,                     // Hour to run daily (24-hour format)
+};
+```
+
+**Getting your FOLDER_ID:**
+Open your Google Drive folder → copy the ID from the URL:
+`drive.google.com/drive/folders/`**THIS_PART**
+
+### 4. Set up the daily trigger
+In the script editor, select `setupDailyTrigger` from the function dropdown and click **Run**. Do this only once.
+
+### 5. Grant permissions
+Google will ask you to allow access to Gmail, Drive, Docs, and external URLs. Accept all permissions.
+
+### 6. Test it manually
+Select `runDailySummary` from the dropdown and click **Run**. Check **View → Logs** to confirm it works.
+
+## Output
+
+Each run creates Google Docs named:
+```
+Email Summary - sendername - YYYY-MM-DD
+```
+
+All docs are saved to your specified Google Drive folder.
+
+## Adding more senders
+
+Add email addresses to the `SENDER_EMAILS` array — the script will create a separate doc for each one:
+
+```javascript
+SENDER_EMAILS: [
+  'newsletter@example.com',
+  'updates@another.com',
+  'digest@service.com',
+],
+```
+
+## Source
+
+Full script and documentation: [github.com/xnomad-dev/gmail-to-docs-summarizer](https://github.com/xnomad-dev/gmail-to-docs-summarizer)

--- a/gmail-daily-summarizer/scripts/email_summary_bot.gs
+++ b/gmail-daily-summarizer/scripts/email_summary_bot.gs
@@ -1,0 +1,191 @@
+// ============================================================
+// CONFIG — Fill these in before running anything
+// ============================================================
+const CONFIG = {
+  SENDER_EMAILS: [
+    'email1@youremail.com',   // Add as many as you want
+    'email2@youremail.com',   // <-- replace with real emails
+  ],
+  FOLDER_ID:          'YOUR_FOLDER_ID',
+  CLAUDE_API_KEY:     'YOUR_CLAUDE_API_KEY',
+  NOTIFY_EMAIL:       'yournotifyemail@gmail.com',
+  TELEGRAM_BOT_TOKEN: '---',
+  TELEGRAM_CHAT_ID:   '',
+  TRIGGER_HOUR:       12,
+};
+
+// ============================================================
+// MAIN — Loops through each sender and creates a separate doc
+// ============================================================
+function runDailySummary() {
+  const results = [];
+
+  CONFIG.SENDER_EMAILS.forEach(function(sender) {
+    const emails = fetchEmails(sender);
+
+    if (emails.length === 0) {
+      Logger.log('No emails found from ' + sender + ' today. Skipping.');
+      return;
+    }
+
+    Logger.log('Found ' + emails.length + ' email(s) from ' + sender + '. Summarizing...');
+
+    const content = buildContentString(emails);
+    const summary = summarizeWithClaude(content, sender);
+    const docUrl  = createGoogleDoc(summary, emails.length, sender);
+
+    results.push({ sender: sender, count: emails.length, url: docUrl });
+    Logger.log('Done for ' + sender + '. Doc: ' + docUrl);
+  });
+
+  if (results.length > 0) {
+    notifyUser(results);
+  } else {
+    Logger.log('No emails found from any sender today.');
+  }
+}
+
+// ============================================================
+// GMAIL — Search emails from a sender in the last 24 hours
+// ============================================================
+function fetchEmails(sender) {
+  const since   = new Date();
+  since.setDate(since.getDate() - 1);
+  const dateStr = Utilities.formatDate(since, Session.getScriptTimeZone(), 'yyyy/MM/dd');
+
+  const query   = 'from:' + sender + ' after:' + dateStr;
+  const threads = GmailApp.search(query);
+  const emails  = [];
+
+  threads.forEach(function(thread) {
+    thread.getMessages().forEach(function(msg) {
+      emails.push({
+        subject: msg.getSubject(),
+        body:    msg.getPlainBody().substring(0, 4000),
+        date:    Utilities.formatDate(msg.getDate(), Session.getScriptTimeZone(), 'yyyy-MM-dd HH:mm'),
+      });
+    });
+  });
+
+  return emails;
+}
+
+function buildContentString(emails) {
+  return emails.map(function(e, i) {
+    return '--- Email ' + (i + 1) + ' ---\nSubject: ' + e.subject + '\nDate: ' + e.date + '\n\n' + e.body;
+  }).join('\n\n');
+}
+
+// ============================================================
+// CLAUDE API — Summarize the email content
+// ============================================================
+function summarizeWithClaude(content, sender) {
+  const response = UrlFetchApp.fetch('https://api.anthropic.com/v1/messages', {
+    method:      'post',
+    contentType: 'application/json',
+    headers: {
+      'x-api-key':         CONFIG.CLAUDE_API_KEY,
+      'anthropic-version': '2023-06-01',
+    },
+    payload: JSON.stringify({
+      model:      'claude-haiku-4-5-20251001',
+      max_tokens: 1024,
+      messages: [{
+        role:    'user',
+        content: 'Summarize the following email(s) from ' + sender + '. Include:\n- Key points\n- Action items (if any)\n- Important dates or deadlines\n\n' + content,
+      }],
+    }),
+    muteHttpExceptions: true,
+  });
+
+  const result = JSON.parse(response.getContentText());
+
+  if (result.error) {
+    throw new Error('Claude API error: ' + result.error.message);
+  }
+
+  return result.content[0].text;
+}
+
+// ============================================================
+// GOOGLE DOCS — Create a separate doc per sender
+// ============================================================
+function createGoogleDoc(summary, emailCount, sender) {
+  const today      = new Date();
+  const dateStr    = Utilities.formatDate(today, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+  const senderName = sender.split('@')[0];
+  const docTitle   = 'Email Summary - ' + senderName + ' - ' + dateStr;
+
+  const doc  = DocumentApp.create(docTitle);
+  const body = doc.getBody();
+
+  body.appendParagraph(docTitle).setHeading(DocumentApp.ParagraphHeading.HEADING1);
+  body.appendParagraph('Sender: '       + sender);
+  body.appendParagraph('Date: '         + dateStr);
+  body.appendParagraph('Emails found: ' + emailCount);
+  body.appendParagraph('');
+  body.appendParagraph('Summary').setHeading(DocumentApp.ParagraphHeading.HEADING2);
+  body.appendParagraph(summary);
+
+  doc.saveAndClose();
+
+  const file   = DriveApp.getFileById(doc.getId());
+  const folder = DriveApp.getFolderById(CONFIG.FOLDER_ID);
+  folder.addFile(file);
+  DriveApp.getRootFolder().removeFile(file);
+
+  return doc.getUrl();
+}
+
+// ============================================================
+// NOTIFICATIONS — One combined email/Telegram for all senders
+// ============================================================
+function notifyUser(results) {
+  const today = Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd');
+  const subject = 'Email Summaries Ready - ' + today;
+
+  let body = 'Your daily email summaries are ready.\n\n';
+  results.forEach(function(r) {
+    body += 'Sender: ' + r.sender + '\n';
+    body += 'Emails: ' + r.count  + '\n';
+    body += 'Doc: '    + r.url    + '\n\n';
+  });
+
+  GmailApp.sendEmail(CONFIG.NOTIFY_EMAIL, subject, body);
+
+  if (CONFIG.TELEGRAM_BOT_TOKEN && CONFIG.TELEGRAM_CHAT_ID) {
+    let text = 'Email Summaries Ready - ' + today + '\n\n';
+    results.forEach(function(r) {
+      text += 'Sender: ' + r.sender + '\n' + r.url + '\n\n';
+    });
+
+    UrlFetchApp.fetch(
+      'https://api.telegram.org/bot' + CONFIG.TELEGRAM_BOT_TOKEN + '/sendMessage',
+      {
+        method:      'post',
+        contentType: 'application/json',
+        payload: JSON.stringify({ chat_id: CONFIG.TELEGRAM_CHAT_ID, text: text }),
+        muteHttpExceptions: true,
+      }
+    );
+  }
+}
+
+// ============================================================
+// TRIGGER SETUP — Run this ONE TIME to schedule daily runs
+// ============================================================
+function setupDailyTrigger() {
+  ScriptApp.getProjectTriggers().forEach(function(t) {
+    if (t.getHandlerFunction() === 'runDailySummary') {
+      ScriptApp.deleteTrigger(t);
+    }
+  });
+
+  ScriptApp.newTrigger('runDailySummary')
+    .timeBased()
+    .everyDays(1)
+    .atHour(CONFIG.TRIGGER_HOUR)
+    .create();
+
+  Logger.log('Daily trigger set for ' + CONFIG.TRIGGER_HOUR + ':00.');
+}


### PR DESCRIPTION
## New Skill: Gmail Daily Summarizer

Adds a new community skill that automates daily email summarization using Claude AI and Google Apps Script.

### What it does
- Monitors Gmail for emails from specific senders (last 24 hours)
- Summarizes content using Claude AI (Haiku model)
- Creates a separate Google Doc per sender
- Saves docs to Google Drive
- Sends email/Telegram notification with doc links
- Runs automatically daily via a time-based trigger

### Files added
- `gmail-daily-summarizer/SKILL.md` — skill definition and setup guide
- `gmail-daily-summarizer/scripts/email_summary_bot.gs` — Google Apps Script code

### Requirements
- Google account (Gmail, Drive, Docs)
- Claude API key from console.anthropic.com
- Google Apps Script (free)

Source repo: https://github.com/xnomad-dev/gmail-to-docs-summarizer
