### PR TITLE
Add buyer-eval: structured B2B vendor evaluation skill (27 published evals, MIT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
-| **[buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill)** | Structured B2B vendor evaluation that interrogates vendor AI agents, cross-references claims against independent sources, and scores across 7 weighted dimensions. 27 published evaluations, MIT licensed ||
+| **[buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill)** | Structured B2B vendor evaluation that interrogates vendor AI agents, cross-references claims against independent sources, and scores across 7 weighted dimensions. 27 published evaluations, MIT licensed |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[buyer-eval](https://github.com/salespeak-ai/buyer-eval-skill)** | Structured B2B vendor evaluation that interrogates vendor AI agents, cross-references claims against independent sources, and scores across 7 weighted dimensions. 27 published evaluations, MIT licensed ||
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Skill overview

buyer-eval evaluates B2B software vendors using structured adversarial methodology. It talks to vendor AI agents, cross-references claims against G2/analyst reports, and produces scored evaluations across 7 dimensions.

## Why this isn't a SaaS wrapper

The skill is fully functional without any paid service. It's MIT licensed, requires no API key, and all 27 evaluation results are published openly. The methodology is auditable. While it can optionally interact with vendor AI agents (including Salespeak's), the core evaluation runs entirely on public data sources.

## Social proof

- 27 real-world evaluations published at eval.salespeak.ai/buyer-eval
- 50+ GitHub stars
- Launched on Product Hunt
- Open-source methodology referenced in B2B procurement discussions
- GitHub: https://github.com/salespeak-ai/buyer-eval-skill

## Checklist

- [x] Real use case (active procurement tool, not theoretical)
- [x] More than just a SKILL.md file
- [x] 50+ GitHub stars
- [x] Not a SaaS wrapper
- [x] MIT licensed