### PR TITLE
Add SciAgent-Skills to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Skills for working with complex file formats:
 - **[SciAgent-Skills](https://github.com/jaechang-hits/SciAgent-Skills)** - 197 life science skills for Claude Code covering genomics, proteomics, drug discovery, and more
   - Achieved 92.0% on the BixBench bioinformatics benchmark (+26.7 percentage points over baseline)
   - Categories include molecular biology, structural biology, biostatistics, scientific computing, and scientific writing
-  - Fork of [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills), expanded with registry validation and quality tests
+  - Includes registry validation, quality tests, and Claude Code plugin support
 
 ### Individual Skills
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[SciAgent-Skills](https://github.com/jaechang-hits/SciAgent-Skills)** - 197 life science skills for Claude Code covering genomics, proteomics, drug discovery, and more
+  - Achieved 92.0% on the BixBench bioinformatics benchmark (+26.7 percentage points over baseline)
+  - Categories include molecular biology, structural biology, biostatistics, scientific computing, and scientific writing
+  - Fork of [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills), expanded with registry validation and quality tests
 
 ### Individual Skills
 


### PR DESCRIPTION
## What

Adds [SciAgent-Skills](https://github.com/jaechang-hits/SciAgent-Skills) to the **Collections & Libraries** section under Community Skills.

## Why

SciAgent-Skills is a collection of 197 life science skills for Claude Code spanning genomics, proteomics, drug discovery, biostatistics, scientific computing, and scientific writing. It achieved 92.0% on the BixBench bioinformatics benchmark (+26.7 percentage points over baseline). Includes registry validation, quality tests, and Claude Code plugin support.

## Checklist

- [x] Follows the formatting guidelines in CONTRIBUTING.md
- [x] Placed in the appropriate section (Collections & Libraries)
- [x] All links tested and working
- [x] Description is concise and non-promotional
- [x] One item per PR