### PR TITLE
Add 2389-research/claude-plugins collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[2389-research/claude-plugins](https://github.com/2389-research/claude-plugins)** - Marketplace of 25+ open-source Claude Code plugins and MCP servers covering development, testing, multi-agent orchestration, and more
+  - Includes plugins like [simmer](https://github.com/2389-research/simmer) (iterative refinement), [test-kitchen](https://github.com/2389-research/test-kitchen) (parallel exploration), [fresh-eyes-review](https://github.com/2389-research/fresh-eyes-review) (pre-commit review), and [review-squad](https://github.com/2389-research/review-squad) (multi-agent code review)
+  - Each plugin lives in its own repo with docs, install instructions, and a generated [marketplace site](https://2389-research.github.io/claude-plugins)
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adding 2389 Research's Claude Code plugin collection to Collections & Libraries. It's a marketplace with 25+ plugins and MCP servers — things like iterative refinement (simmer), parallel code exploration (test-kitchen), pre-commit review (fresh-eyes-review), and multi-agent code review (review-squad). Each plugin has its own repo with docs and install instructions. The main repo has 47 stars and has been actively maintained since late 2025.