### PR TITLE
Add amux — open-source Claude Code agent multiplexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 
+- **[esteininger/amux](https://github.com/esteininger/amux)** - Open-source agent multiplexer for running dozens of parallel Claude Code sessions with web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, and mobile PWA — all in a single Python file
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
 
 ## ✏️ Creating Your First Skill

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 
-- **[esteininger/amux](https://github.com/esteininger/amux)** - Open-source agent multiplexer for running dozens of parallel Claude Code sessions with web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, and mobile PWA — all in a single Python file
+- **[mixpeek/amux](https://github.com/mixpeek/amux)** - Open-source agent multiplexer for running dozens of parallel Claude Code sessions with web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, and mobile PWA — all in a single Python file
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
 
 ## ✏️ Creating Your First Skill


### PR DESCRIPTION
## Summary

- Adds [amux](https://github.com/mixpeek/amux) to the **Tools** section
- amux is an open-source agent multiplexer for running dozens of parallel Claude Code sessions with a web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, and mobile PWA — all in a single Python file