### PR TITLE
Add claude-report-skill to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[claude-report-skill](https://github.com/MarcinDudekDev/claude-report-skill)** | Generate beautiful, self-contained HTML reports instead of long terminal output. 5 report types (task-completion, research, audit, error-blocker, comparison), zero dependencies, cross-platform. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [claude-report-skill](https://github.com/MarcinDudekDev/claude-report-skill) to the Individual Skills table.

**Description:** Generate beautiful, self-contained HTML reports instead of long terminal output. 5 report types (task-completion, research, audit, error-blocker, comparison), zero dependencies, cross-platform.

The skill helps Claude Code produce structured HTML output for longer task summaries, research findings, audits, and comparisons — keeping the terminal clean for short answers while delivering rich reports for complex outputs.