### PR TITLE
Add toprank to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[toprank](https://github.com/nowork-studio/toprank)** | SEO + Google Ads skills for Claude Code — audits Search Console data, finds wasted ad spend, rewrites meta tags, generates schema markup, and ships the fixes |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **toprank** to the Community Skills > Individual Skills table.

## What is toprank?

A Claude Code plugin that provides SEO + Google Ads skills. It gives Claude direct access to Google Search Console and Google Ads — auditing traffic, finding wasted ad spend, rewriting meta tags, generating JSON-LD schema markup, and shipping fixes.

**9 skills included:**
- Google Ads: ads-audit, ads, ads-copy
- SEO: seo-analysis, content-writer, keyword-research, meta-tags-optimizer, schema-markup-generator, setup-cms
- Cross-model review: gemini

## Links
- Source: https://github.com/nowork-studio/toprank
- License: MIT
- Install: \`/plugin marketplace add nowork-studio/toprank\` then \`/plugin install toprank@nowork-studio\`