### PR TITLE
Add voice-to-instrument-guide skill to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[voice-to-instrument-guide](https://github.com/stark-ydq/voice-to-instrument-skills)** | Expert guidance for converting voice recordings into realistic instrument sounds — recording best practices, instrument-specific tips (piano, guitar, violin, drums, saxophone, and more), and prompt engineering for music AI tools |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [voice-to-instrument-guide](https://github.com/stark-ydq/voice-to-instrument-skills) to the **Individual Skills** table under Community Skills.

## What the skill does

A focused, MIT-licensed Agent Skill that helps AI assistants give high-quality advice on voice-to-instrument AI music production:

- **Recording best practices** — microphone setup, environment, vocal technique, file formats
- **Instrument-specific tips** — tailored guidance for piano, guitar, violin, drums, saxophone, flute, cello, trumpet, bass, and clarinet
- **Prompt engineering** — how to write effective prompts for text-to-music and voice-conversion AI tools
- **Troubleshooting** — diagnosing muddy, robotic, off-rhythm, or clipped outputs

## Why it fits

- Pure markdown (no code execution, no telemetry, no network calls)
- 100% open source under MIT license
- Follows the existing single-row table format in Individual Skills
- Fills a content gap in the list — no existing music/audio-focused skill

## Format compliance

Single row added to the `Individual Skills` table, matching the existing format exactly.

Repository: https://github.com/stark-ydq/voice-to-instrument-skills