### PR TITLE
Add chatgpt-plus-guide skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[chatgpt-plus-guide](https://github.com/xyzm6/chatgpt-plus-guide)** | Practical guide for ChatGPT Plus/Pro subscribers — regional pricing, payment methods for blocked regions, account safety checklist |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds [chatgpt-plus-guide](https://github.com/xyzm6/chatgpt-plus-guide) to the Community Skills > Individual Skills table
- Claude Code skill that provides practical, up-to-date knowledge about ChatGPT Plus/Pro subscriptions: regional pricing, payment methods for blocked regions, Plus vs Pro decision guidance, account safety rules, and renewal troubleshooting

## Why this belongs here

The skill follows the standard Claude Code skill structure (SKILL.md with frontmatter, resources directory) and provides genuinely useful reference knowledge that Claude cannot reliably answer on its own — particularly around region-specific pricing and payment workarounds.

## Checklist

- [x] Follows the existing table format
- [x] Link is valid and points to a public repository
- [x] Description is concise (one line)
- [x] Skill has proper SKILL.md with frontmatter