### PR TITLE
Add macsweep — macOS system maintenance skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[macsweep](https://github.com/leoncuhk/macsweep)** | Complete macOS system maintenance — deep app uninstall (20+ locations), startup service audit, disk cleanup with 3-tier safety classification, system health check. Replaces CleanMyMac / Tencent Lemon / Pearcleaner with zero overhead |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add [macsweep](https://github.com/leoncuhk/macsweep)

Complete macOS system maintenance as a Claude Code skill with 4 modules:

- **App Uninstaller** — deep uninstall scanning 20+ Library subdirectories + Spotlight + BTM ghost cleanup
- **Startup Manager** — audit all LaunchAgents/Daemons, identify each service's actual purpose, manage BTM
- **Disk Cleanup** — 40+ cache types, 3-tier safety classification (SAFE / LOW RISK / MEDIUM RISK), before/after reporting
- **System Health Check** — orphaned app data, broken launch services, ghost BTM entries, disk health

Replaces CleanMyMac, Tencent Lemon, Pearcleaner with zero runtime overhead. Follows the Agent Skills open standard. MIT licensed.

Install: `npx skills add leoncuhk/macsweep`