### PR TITLE
Add StyleSeed — design-judgment engine (74 rules + 15 skills) for Claude Code, Cursor & Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[bitjaru/styleseed](https://github.com/bitjaru/styleseed)** - Design-rules engine with 19 skills that stops coding agents from producing generic "AI-looking" UI — 74 rules, a scored quality gate (`/ss-score` loops to ≥80 before showing you), a visual gate (`/ss-verify` screenshots and judges the pixels), and 6 aesthetic presets (`/ss-restyle`)
+  - Installation: `npx skills add bitjaru/styleseed` (also works with Codex, Cursor, Gemini CLI via `.agents/skills`)
+  - [Live demo & scorecard](https://styleseed-demo.vercel.app) - the maker's own landing scored 58/100 on its own gate; full breakdown published
+  - [Show HN discussion](https://news.ycombinator.com/item?id=48920888)
 
 ### Individual Skills
 


### PR DESCRIPTION
Adding **StyleSeed** to the Community Skills → Individual Skills table.

**Link:** https://github.com/bitjaru/styleseed (184 stars, MIT)

StyleSeed is a design engine bundled as **11 Claude Code slash-command skills** that teach Claude Code to produce professional UI:

| Skill | Purpose |
|---|---|
| `/ss-setup` | Interactive project setup wizard |
| `/ss-component` | Generate design-system-compliant components |
| `/ss-page` | Scaffold mobile pages with proper rhythm |
| `/ss-pattern` | Compose UI patterns (card grids, lists, etc.) |
| `/ss-review` | Verify UI against 69 design rules |
| `/ss-a11y` | Accessibility audit + auto-fix |
| `/ss-audit` | Nielsen heuristics review |
| `/ss-lint` | Fast linter for design rule violations |
| `/ss-tokens`, `/ss-copy`, `/ss-feedback`, `/ss-flow` | Tokens, microcopy, feedback states, flows |

Ships with 48 shadcn-style components and 5 brand skins (Toss, Stripe, Linear, Vercel, Notion). Featured on GeekNews KR (25 points) and distributed since 2026-04-07.