### PR TITLE
Add lean-ops — token/tool usage minimiser

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| lean-ops | Minimise token and tool usage — parallel calls, aggregators over crawlers, targeted file reads, noise directory exclusion | C-Moir/claude-lean-ops |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
A skill that minimises token and tool usage across any task.

- Parallel tool calls by default
- Aggregators over crawling (npm, pypi, crates.io, caniuse, gh CLI)
- Grep before read, offset/limit for large files
- Noise directory exclusion (node_modules, dist, .git, etc.)
- Context window awareness section
- Applies by default — no invocation needed

https://github.com/C-Moir/claude-lean-ops