### PR TITLE
Add fabbo-ai-generator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[fabbo-ai-generator](https://github.com/fabbo-ai/fabbo-ai-generator)** | Generate AI videos and images on [fabbo.ai](https://fabbo.ai) by driving a real Playwright browser — supports text-to-video, image-to-video, text-to-image, reference-to-video, and image editing modes |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **fabbo-ai-generator** to the Individual Skills table.

- **Repo:** https://github.com/fabbo-ai/fabbo-ai-generator
- **What it does:** Generates AI videos and images on [fabbo.ai](https://fabbo.ai) by driving a real Playwright browser session with a persistent profile (sign in once, then unattended).
- **Modes supported:** text-to-video, image-to-video, text-to-image, reference-to-video, frame-to-video, image editing.
- **Output:** returns both the remote URL and a local file path as a single JSON payload.

Single-line addition to `README.md`, no other changes.