### PR TITLE
Add CLSkills.in — 2,300+ curated Claude Code skills + 50 free samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ Skills for working with complex file formats:
 
 ### Collections & Libraries
 
+- **[CLSkills.in Free Samples](https://github.com/Samarth0211/claude-skills-free)** - 50 curated Claude Code skills across 16 categories (React, Python, DevOps, Security, Docker, etc.)
+  - Hand-tested, production-ready skills with real instructions
+  - Full library of 2,300+ skills at [clskills.in/browse](https://clskills.in/browse)
+  - [Free 40-page Claude Guide](https://clskills.in/guide) covering setup, MCP, agents, and prompt codes
+
 - **[obra/superpowers](https://github.com/obra/superpowers)** - Core skills library for Claude Code with 20+ battle-tested skills including TDD, debugging, and collaboration patterns
   - Features `/brainstorm`, `/write-plan`, `/execute-plan` commands and skills-search tool
   - [superpowers-skills](https://github.com/obra/superpowers-skills) - Community-editable skills repository


### PR DESCRIPTION
## What's being added

**[CLSkills.in Free Samples](https://github.com/Samarth0211/claude-skills-free)** — 50 hand-tested Claude Code skills across 16 categories, plus links to the full 2,300+ skill library.

### Why it belongs here

- 2,300+ skills is the largest curated (not scraped) Claude Code skills collection
- Every skill is tested with real instructions, not auto-generated
- Free samples repo has 50 production-ready skills across React, Python, DevOps, Security, Docker, Database, etc.
- Includes a free 40-page guide covering Claude Code setup, MCP servers, agents, and skills
- Active project maintained by a solo founder ([@Samarth0211](https://github.com/Samarth0211))

Added under "Collections & Libraries" section.