### PR TITLE
Add superseo-skills — opinionated Claude skills for SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[inhouseseo/superseo-skills](https://github.com/inhouseseo/superseo-skills)** - 11 Claude skills for SEO: page audits, content briefs, article writing, E-E-A-T audits, semantic gap analysis, topic clusters, featured snippet optimizer, and link building
+  - Technical audits weighted by POP test hierarchy, writing skills include a generation-time anti-AI-slop ruleset
+  - Includes 25 content-type templates and 9 link-building tactic playbooks
+  - Installation: `git clone https://github.com/inhouseseo/superseo-skills ~/.claude/skills/superseo-skills`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adds [inhouseseo/superseo-skills](https://github.com/inhouseseo/superseo-skills) to Collections & Libraries.

11 Claude skills for SEO covering page audits, content briefs, article writing with a generation-time anti-AI-slop ruleset, E-E-A-T audits, semantic gap analysis, topic clusters, featured snippet optimizer, and link building. Includes 25 content-type templates and 9 link-building tactic playbooks. CC BY-NC 4.0.