### PR TITLE
Add malware-check skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
+| **[malware-check](https://github.com/momenbasel/malware-check)** | Enterprise-grade static and dynamic analysis for detecting malicious code, suspicious binaries, and privacy violations. YARA rules, Docker sandbox behavioral analysis, SARIF CI/CD reporting |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
 _More community skills coming soon! Submit a PR to add your skill._

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Skills for working with complex file formats:
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
-| **[malware-check](https://github.com/momenbasel/malware-check)** | Enterprise-grade static and dynamic analysis for detecting malicious code, suspicious binaries, and privacy violations. YARA rules, Docker sandbox behavioral analysis, SARIF CI/CD reporting |
+| **[malware-check](https://github.com/momenbasel/malware-check)** | Static and dynamic malware analysis for detecting malicious code, suspicious binaries, and privacy violations, with YARA rules, Docker sandbox behavioral analysis, and SARIF reporting |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
 _More community skills coming soon! Submit a PR to add your skill._


### PR DESCRIPTION
## Summary

Adds [malware-check](https://github.com/momenbasel/malware-check) to the Individual Skills table.

malware-check is a security skill that performs static and dynamic analysis to detect malicious code, suspicious binaries, and privacy violations. It uses YARA rules for pattern matching, Docker sandbox for behavioral analysis, and outputs SARIF reports for CI/CD integration.

- Placed in the Individual Skills table alongside existing security-related entries
- Follows the existing table formatting convention

## Checklist

- [x] Follows contribution formatting guidelines
- [x] Link verified and working
- [x] Description is concise and non-promotional
- [x] Single item per PR