### PR TITLE
feat: add cli-charts — terminal-native chart skill for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
+| **[cli-charts](https://github.com/2233admin/chartex)** | 24 terminal-native chart types (bar, line, pie, sparkline, heatmap, candlestick, and more) rendered directly in the terminal — no browser, no files. Designed for AI agents (Claude Code, Codex, Gemini CLI) that live in the CLI |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
## Summary

Adds **[cli-charts](https://github.com/2233admin/chartex)** to the Individual Skills table.

cli-charts is a terminal-native visualization toolkit with 24 chart types (bar, line, pie, sparkline, heatmap, candlestick, confusion matrix, graph, and more) rendered directly in the CLI — no browser, no generated files.

It's specifically designed for AI agents (Claude Code, Codex, Gemini CLI) that operate in the terminal and need a native sense of sight without leaving the shell.

```bash
pip install cli-charts

cli-charts bar --json '{"labels":["Q1","Q2","Q3"],"values":[10,14,12]}' --title "Revenue"
cli-charts pie --json '{"labels":["A","B","C"],"values":[60,30,10]}'
cli-charts sparkline --json '{"values":[10,22,18,35,40,55]}'
```

**PyPI**: https://pypi.org/project/cli-charts/
**GitHub**: https://github.com/2233admin/chartex

## Checklist
- [x] Link is working and publicly accessible
- [x] Description matches the table format
- [x] Entry is in the Individual Skills section