### PR TITLE
Add SwarmVault

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[SwarmVault](https://github.com/swarmclawai/swarmvault)** | Local-first RAG knowledge base compiler. Turns raw docs, research, and code into a persistent markdown wiki, knowledge graph, and hybrid SQLite FTS + embeddings search. Ships a bundled skill and MCP server |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding SwarmVault to the Individual Skills table.

SwarmVault is an open-source (MIT) local-first RAG knowledge base compiler. It turns raw docs, research, and code into a persistent markdown wiki, knowledge graph, and hybrid SQLite FTS + embeddings search. It ships a bundled skill with schema-first, graph-query-first conventions and an MCP server for Claude Code, Codex, and OpenCode. It provides standalone value (no paid tier, no SaaS wrapper) and is already published on npm as `@swarmvaultai/cli`.

- https://github.com/swarmclawai/swarmvault
- https://swarmvault.ai

License: MIT