### PR TITLE
Add Helium MCP to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Skills for working with complex file formats:
 | --- | --- |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
+| **[helium-mcp](https://github.com/connerlambden/helium-mcp)** | Claude Code: real-time news intelligence, market data, options pricing, and bias analysis via MCP |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |


### PR DESCRIPTION
Adds **[helium-mcp](https://github.com/connerlambden/helium-mcp)** to the community Individual Skills table.

Helium is positioned for **Claude Code** and exposes real-time news intelligence, market data, options pricing, and bias analysis through MCP.

Made with [Cursor](https://cursor.com)