### PR TITLE
Add linkedin-skills to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
+| **[linkedin-skills](https://github.com/sergebulaev/linkedin-skills)** | 10 Claude Code skills for LinkedIn marketing — post writing, comment drafting, pre-publish algorithm audit, AI-tell humanizer, profile optimizer, content planner, and thread engagement |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
10 Claude Code skills for LinkedIn marketing. MIT licensed. Covers post writing, comment drafting, pre-publish algorithm audit, AI-tell humanizer, profile optimizer, 7-day content planner, and thread engagement tracking.

Repo: https://github.com/sergebulaev/linkedin-skills