### PR TITLE
Add atelier — design-automation plugin (7 skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Skills for working with complex file formats:
 
 ### Collections & Libraries
 
+- **[atelier](https://github.com/EthanY33/atelier)** - Design-automation plugin for Claude Code: seven skills around a shared `brand-memory` schema — design tokens, OG cards, responsive images, brand assets, accessibility audit, HTML→video. MIT.
+
 - **[obra/superpowers](https://github.com/obra/superpowers)** - Core skills library for Claude Code with 20+ battle-tested skills including TDD, debugging, and collaboration patterns
   - Features `/brainstorm`, `/write-plan`, `/execute-plan` commands and skills-search tool
   - [superpowers-skills](https://github.com/obra/superpowers-skills) - Community-editable skills repository


### PR DESCRIPTION
## Summary

Adds **atelier** — a Claude Code plugin that publishes seven design-automation skills around a shared `brand-memory` schema.

### What it does

atelier is a standalone open-source plugin (MIT, no telemetry, no paid backend). The seven skills:

- `brand-memory` — JSON-Schema-validated `.atelier/brand.json` source of truth.
- `design-token-sync` — push brand to tokens.css, tailwind.config.js, tokens.d.ts, Figma variables.
- `og-card-generator` — 1200×630 OG/Twitter cards per page.
- `responsive-image-pipeline` — AVIF/WebP + LQIP + srcset with SHA cache.
- `brand-asset-pipeline` — logo SVG → favicons, app icons, social covers.
- `accessibility-design-audit` — WCAG AA (axe-core + Playwright) → markdown report.
- `html-to-video` — any HTML page → MP4 / WebM / GIF.

### Links

- Repo: https://github.com/EthanY33/atelier
- Release: https://github.com/EthanY33/atelier/releases/tag/v0.1.0
- License: MIT

### Quality

- 52 tests passing, 86% coverage (Vitest).
- CI matrix: ubuntu-latest + windows-latest (Node 20).
- Exact-pinned dependencies, committed lockfile, Dependabot.
- README includes a live demo GIF generated by the plugin's own `html-to-video` skill.

### Non-promotional

atelier does not require any paid service, SaaS, or external account. All seven skills are standalone Node.js scripts using open-source deps (sharp, Playwright, ffmpeg, axe-core). The plugin is not a funnel to a paid product — it's a complete, self-contained tool.

### Checklist

- [x] Related to Claude Skills/Code
- [x] Standalone value, not a SaaS wrapper
- [x] Non-promotional
- [x] Accurate information
- [x] Proper formatting (matching surrounding entries)