### PR TITLE
Add Soul Guardian — persistent AI counselor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[soul-guardian](https://github.com/taohaowei/soul-guardian)** | Persistent AI counselor with memory system and Chinese family therapy — remembers you across sessions, keeps all data local in ~/.counselor/ |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What is Soul Guardian?

[Soul Guardian](https://github.com/taohaowei/soul-guardian) is a persistent AI counselor skill for Claude Code that:

- **Remembers you** — builds a psychological profile in `~/.counselor/` that grows with each conversation
- **Keeps data local** — no cloud, no uploads, no telemetry
- **Understands Chinese family dynamics** — in-law conflicts, parenting anxiety, eldercare, intergenerational patterns
- **Multi-modal therapy** — combines Person-Centered, Narrative, CBT, Family Systems, and Positive Psychology

## Install

```bash
npx skills add taohaowei/soul-guardian -g
```

Then type `/counselor` in Claude Code.

## Checklist

- [x] Skill has a proper `SKILL.md` with frontmatter
- [x] Public GitHub repo with MIT license
- [x] Added to the "Individual Skills" table in README.md