### PR TITLE
add samkshipta (skill) and claude-skill-linter (tool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,14 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
+| **[samkshipta](https://github.com/MukundaKatta/samkshipta)** | Sanskrit-inspired aphoristic compression — 60-70% fewer output tokens in formal register. Three intensity levels (lite / saṃkṣipta / sūtra). Formal sibling of caveman-style compression, for code review and client-facing contexts where grunts don't land. |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[MukundaKatta/claude-skill-linter](https://github.com/MukundaKatta/claude-skill-linter)** - GitHub Action that validates `SKILL.md` frontmatter on every push — catches missing required fields, malformed YAML, hardcoded secrets (`sk-`, `ghp_`, `AIza`, `xoxb-`), and bad kebab-case names before they ship.
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
## What

Two additions:

### 1. Individual Skills → `samkshipta`

**Repo:** https://github.com/MukundaKatta/samkshipta (v0.1.0, MIT)

Sanskrit-inspired token-compression skill. Three intensity levels:

| Level | Savings | Use when |
|---|---|---|
| `samkshipta-lite` | ~30% | Mixed audience, teaching |
| `samkshipta` | ~60-70% | Expert peer, code review |
| `samkshipta-sutra` | ~75-85% | Commit messages, expert-only |

Formal register throughout — the boardroom sibling of [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman)'s meme-informal take on the same compression idea. Caveman credited as inspiration in the README.

Includes two slash commands (`/samkshipta-commit`, `/samkshipta-review`), bash installer, and a documented benchmarking methodology.

### 2. Tools → `claude-skill-linter`

**Repo:** https://github.com/MukundaKatta/claude-skill-linter (v0.1.0, MIT)

GitHub Action that lints `SKILL.md` files. Catches:

- ❌ Missing required frontmatter (`name`, `description`)
- ❌ Malformed/unparseable YAML
- ❌ Hardcoded secrets (`sk-`, `ghp_`, `AIza`, `xoxb-`, `github_pat_`)
- ❌ Non-kebab-case `name`
- ⚠️ Description lacking trigger language
- ⚠️ Broken relative-path references
- ⚠️ Unknown frontmatter fields (typo detection)

Deployable as a one-line `uses:` in any repo with `SKILL.md` files. Currently running in CI against `MukundaKatta/samkshipta` and submitted as a PR ([#172](https://github.com/JuliusBrussee/caveman/pull/172)) to add it to `JuliusBrussee/caveman`.

## Disclosure

I'm the author of both. Additions follow the non-promotional guideline — both are genuinely free (MIT), standalone, and solve real problems (token cost for saṃkṣipta; malformed SKILL.md for the linter). Happy to remove either if maintainers don't think they fit.

## Test plan

- [x] Links resolve and point to public MIT repos
- [x] saṃkṣipta passes its own lint in strict mode (dogfooded via CI)
- [x] claude-skill-linter has CI workflow + fixture tests (3/3 passing)
- [x] Formatting matches existing table/list style in the list