### PR TITLE
Add claude-code-sessions skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills for working with complex file formats:
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[claude-code-sessions](https://github.com/apappascs/claude-code-sessions)** | Session intelligence plugin. 11 skills for full-text search, token analytics, task management, session comparison, timeline views, and context recovery across all sessions. Includes a web dashboard. Zero runtime dependencies, read-only |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |


### PR DESCRIPTION
Adds [claude-code-sessions](https://github.com/apappascs/claude-code-sessions) to Individual Skills.

Session intelligence plugin with 11 skills:

- /session-search, /session-stats, /session-list, /session-detail, /session-diff
- /session-timeline, /session-resume, /session-tasks, /session-export
- /session-cleanup, /session-delete

Plus a web dashboard. Same TypeScript modules power skills, dashboard, and CLI. Zero runtime dependencies. Read-only. MIT licensed.