### PR TITLE
Add Not Human Search to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[Not Human Search](https://github.com/unitedideas/nothumansearch)** | Search 9,000+ AI tools and APIs ranked by agentic readiness via MCP. Install: `claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds Not Human Search as a community skill in the Individual Skills table.

**What it does:** Search engine for AI agents — indexes 9,000+ tools and APIs scored by agentic readiness (llms.txt, OpenAPI, MCP, ai-plugin.json).

**Install:** `claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp`

**Tools:** `search_agents`, `get_site_details`, `get_stats`, `submit_site`, `verify_mcp`

Listed in the [official MCP registry](https://registry.modelcontextprotocol.io). Open source at [unitedideas/nothumansearch](https://github.com/unitedideas/nothumansearch).