### PR TITLE
Add OpenAccountants to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[OpenAccountants](https://github.com/openaccountants/openaccountants)** | 371 tax classification skills across 134 countries — VAT/GST, income tax, social contributions; bank statement classifier with conservative defaults |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding OpenAccountants to the Individual Skills table.

OpenAccountants is a collection of 371 tax classification skills covering 134 countries — VAT/GST, income tax, and social contributions. You upload the skill files for your country alongside a bank statement, and the AI classifies every transaction into a working paper ready for accountant review.

Each line gets one of three outcomes: Classified (confident), Assumed (conservative default applied, disclosed), or Needs Input (ambiguous — asks the user one question). The design principle is to never guess aggressively; when uncertain, it picks the treatment that increases tax liability so a reviewer can safely unwind it.

Country-specific form coverage includes US Schedule C, Malta TA24, Australian BAS, UK SA100, and others. I'm the maintainer — happy to adjust the description or format to match list conventions.