### PR TITLE
Add skill: deployhq/deployhq-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[deployhq-cli](https://github.com/deployhq/deployhq-cli)** | Deploy, rollback, and manage servers via the DeployHQ CLI with --json output, breadcrumbs, and self-discovery |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds deployhq-cli to the individual skills table.

**Skill:** [deployhq-cli](https://github.com/deployhq/deployhq-cli)

**What it does:** Agent skill for the DeployHQ CLI (`dhq`) — deploy code, rollback, manage servers and projects via the DeployHQ REST API. Features `--json` output with breadcrumbs (suggested next commands), `dhq commands --json` for self-discovery, and a SKILL.md agent guide with decision trees.

**Install:** `brew install deployhq/tap/dhq` then `dhq setup claude`

**License:** MIT

**Standalone value:** Fully open-source CLI that wraps a public REST API. Works without any paid subscription — free tier accounts supported. No telemetry, no analytics.