### PR TITLE
Add Council Pilot — Autonomous expert-council-driven project builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[Council Pilot](https://github.com/wd041216-bit/council-pilot)** | Autonomous expert-council-driven project builder — builds expert councils from public sources, drives projects through build-score-debug loops until 100/100 maturity |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skill: Council Pilot

**Repository:** https://github.com/wd041216-bit/council-pilot  
**License:** MIT  
**Social proof:** Listed in awesome-claude-code (issue #1605), submitted to awesome-ai-agents-2026 (PR #162), submitted to ComposioHQ/awesome-claude-skills (PR #690)

### What it does

Council Pilot is a Claude Code skill that builds an expert council from public sources, then autonomously drives your project through build-score-debug loops until it reaches 100/100 maturity.

Give it a one-liner and it works autonomously for hours:
```
/council-pilot "Build a real-time collaborative whiteboard with WebSocket sync"
```

### Key differentiators

1. **Autonomous long-running work** — One sentence triggers 2-3+ hours of focused, self-directed work producing a complete version iteration
2. **Adversarial expert scoring** — Expert lenses distilled from real public sources with source-gating tiers (A/B/C). The council debates every scoring decision
3. **Domain-flexible** — Swap domains and get a completely different expert council built from scratch

### Checklist

- [x] Skill is based on real use case
- [x] Well-documented with references, CLI, and SKILL.md
- [x] Includes practical examples
- [x] MIT licensed
- [x] Social proof provided (multiple awesome list submissions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)