### PR TITLE
Add claude-memory-kit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[claude-memory-kit](https://github.com/awrshift/claude-memory-kit)** | Persistent memory across sessions — hot cache, knowledge wiki, safety hooks, and `/close-day` daily synthesis |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds claude-memory-kit to Individual Skills table.

**Repo:** https://github.com/awrshift/claude-memory-kit
**Stars:** 10
**License:** MIT

Persistent memory system for Claude Code — two-layer architecture (hot cache + knowledge wiki), 4 safety hooks, `/close-day` end-of-day synthesis. Zero external dependencies. 700+ production sessions.