### PR TITLE
Add Imprint: portable AI collaboration profile (1 skill → 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,14 @@ Skills for working with complex file formats:
   - [superpowers-skills](https://github.com/obra/superpowers-skills) - Community-editable skills repository
   - [Blog: Superpowers](https://blog.fsck.com/2025/10/09/superpowers/) - Author's overview by Jesse Vincent
   - Installation: `/plugin marketplace add obra/superpowers-marketplace`
-  - **[ilang-ai/Imprint](https://github.com/ilang-ai/Imprint)** - One skill replaces eleven: memory, compression, onboarding, code review, debugging, planning, progress tracking, testing, git workflow, SEO, and copywriting. Creates a portable collaboration profile under 500 tokens across 19 agents.
-  - Tagline: Your habits, imprinted on AI
-  - Also available on [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ILang.imprint), [Open VSX](https://open-vsx.org/extension/ILang/imprint), [skills.sh](https://skills.sh/ilang-ai/Imprint/imprint)
-  - Installation: `/plugin marketplace add ilang-ai/Imprint`
 - **[obra/superpowers-lab](https://github.com/obra/superpowers-lab)** - Experimental skills for `Claude Code Superpowers` (see above)
   - Uses new techniques that are still being refined and tested (i.e. skills here may change over time)
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
+- **[ilang-ai/Imprint](https://github.com/ilang-ai/Imprint)** - One skill replaces eleven: memory, compression, onboarding, code review, debugging, planning, progress tracking, testing, git workflow, SEO, and copywriting. Creates a portable collaboration profile under 500 tokens across 19 agents.
+  - Tagline: Your habits, imprinted on AI
+  - Also available on [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ILang.imprint), [Open VSX](https://open-vsx.org/extension/ILang/imprint), [skills.sh](https://skills.sh/ilang-ai/Imprint/imprint)
+  - Installation: `/plugin marketplace add ilang-ai/Imprint`
 
 
 ### Individual Skills

--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ Skills for working with complex file formats:
   - [superpowers-skills](https://github.com/obra/superpowers-skills) - Community-editable skills repository
   - [Blog: Superpowers](https://blog.fsck.com/2025/10/09/superpowers/) - Author's overview by Jesse Vincent
   - Installation: `/plugin marketplace add obra/superpowers-marketplace`
- 
+  - **[ilang-ai/Imprint](https://github.com/ilang-ai/Imprint)** - One skill replaces eleven: memory, compression, onboarding, code review, debugging, planning, progress tracking, testing, git workflow, SEO, and copywriting. Creates a portable collaboration profile under 500 tokens across 19 agents.
+  - Tagline: Your habits, imprinted on AI
+  - Also available on [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ILang.imprint), [Open VSX](https://open-vsx.org/extension/ILang/imprint), [skills.sh](https://skills.sh/ilang-ai/Imprint/imprint)
+  - Installation: `/plugin marketplace add ilang-ai/Imprint`
 - **[obra/superpowers-lab](https://github.com/obra/superpowers-lab)** - Experimental skills for `Claude Code Superpowers` (see above)
   - Uses new techniques that are still being refined and tested (i.e. skills here may change over time)
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)


### PR DESCRIPTION
Adds Imprint, a single skill that replaces 11 specialized skills by creating a portable user profile.

- MIT licensed, no external API calls, no SaaS dependency
- Works across Claude Code, Codex, Cursor, Copilot, Gemini, Windsurf, Trae, Cline, Roo + 10 more
- Profile stored as plain text under 500 tokens
- Live on skills.sh, VS Code Marketplace, Open VSX, Gemini CLI Gallery
- GitHub: https://github.com/ilang-ai/Imprint