### PR TITLE
Add master-teacher skill — systematic teaching with mastery learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[master-teacher](https://github.com/jacky-wzj/master-teacher)** | Systematic teaching skill — mastery learning, Socratic questioning, progress tracking. Transforms AI into a master-level instructor for technical topics |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## New Skill: master-teacher

**Repository**: https://github.com/jacky-wzj/master-teacher

Systematic teaching skill that transforms AI agents into master-level instructors. Based on mastery learning, Socratic questioning, structured lesson delivery, and progress tracking. Designed for technical audiences learning complex topics.

Also published on ClawHub as master-teacher@1.0.0.