### PR TITLE
Add ShipPage to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[ShipPage](https://github.com/jieshu666/ShipPage-Skill)** | Zero-config HTML publishing for AI agents. One HTTP POST turns any HTML or Markdown into a public URL at shippage.ai/p/{slug}. Auto-registers on first call — no account, no API keys. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [ShipPage](https://github.com/jieshu666/ShipPage-Skill) to **Community Skills → Individual Skills**.

Zero-config HTML publishing for AI agents. One HTTP POST turns any HTML or Markdown into a public URL at `shippage.ai/p/{slug}`. Auto-registers on first call — no account, no API keys to configure.

**Install** (Claude Code): `clawhub install shippage` • **MCP** (Claude Desktop/Cursor): `npx shippage-mcp`

Free tier: 20 publishes/month, 14-day retention. Built on Cloudflare Workers. MIT.