### PR TITLE
Add immich-photo-manager to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[immich-photo-manager](https://github.com/drolosoft/immich-photo-manager)** | Intelligent photo management for self-hosted Immich: 13 skills over an MCP server with 94 tools, covering natural language and OCR search, geographic album curation, duplicate detection, people and faces, metadata repair, library health, and PDF album reports; tested live on Immich 2.x and 3.x |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds immich-photo-manager to the Individual Skills table.

It is a Claude Code plugin for self-hosted Immich photo libraries: 13 skills (photo search, cleanup, duplicate report, album curation, album PDF report, travel map, metadata fixer, storage optimizer, library health, people report, rotate photos, timeline gaps) on top of an MCP server with 94 tools. Not a single SKILL.md: each skill is a full workflow with its tools, its confirmation steps and its output.

In use it is sentences like "create albums for everywhere I have traveled" or "find duplicates and keep the best of each group" or "which months have no photos". Every release runs live against real Immich 2.7.5 and 3.1.0 before it is tagged. MIT, 44 stars, plugin scanner 100/100.
