### PR TITLE
Add medsci-skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[medsci-skills](https://github.com/Aperivue/medsci-skills)** | 32 skills for medical research — literature search with verified citations, statistical analysis (Python/R), reporting guideline compliance (PRISMA/STARD/STROBE), manuscript writing, and figure generation |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds medsci-skills to the Individual Skills table.

I'm a radiologist and built this for my own research workflow. It bundles 32 skills covering the full medical research pipeline: literature search with API-verified citations, statistical analysis in Python/R, reporting guideline checks (PRISMA/STARD/STROBE), manuscript writing, and figure generation.

- 43 stars, MIT licensed
- Three runnable end-to-end demos on public datasets (Wisconsin BC, metafor::dat.bcg, NHANES)
- Each skill has its own SKILL.md

Happy to adjust the entry or move it to a different section.