### PR TITLE
Add planmysaas to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[planmysaas](https://github.com/creationskiro/planmysaas-claude-skill)** | Turns idea to a complete 8-stage SaaS blueprint with a decision-grade, rubric-graded build playbook for Claude Code |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Skill: planmysaas

**Repo:** https://github.com/creationskiro/planmysaas-claude-skill
**License:** MIT · **Release:** v1.0.0

### What it does
Turns a one-line idea into a complete 8-stage SaaS blueprint:

1. Idea refine
2. Research
3. Analysis (PMF, SWOT, TAM/SAM/SOM, Porter's 5F, BMC, GTM)
4. Architecture
5. Features
6. Frontend
7. Phases
8. Decision-grade build playbook (rubric-graded, dependency-ordered, leaf to root)

Stage 8 is the differentiator — instead of generic checklists, it produces 9–12 build steps each with goal, inputs, outputs, an 8–14 box acceptance rubric, edge cases, common pitfalls, quality bar, and a stop-and-review gate.

### Install
```bash
git clone https://github.com/creationskiro/planmysaas-claude-skill ~/.claude/skills/planmysaas
```

Then `/planmysaas "<your idea>"` from inside Claude Code.

### Why this list
Plain markdown skill, no build step, MIT licensed, 0 dependencies. Added to the Individual Skills table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)