### PR TITLE
Add living-docs — Claude Code plugin for auto-fixing stale docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
+| **[living-docs](https://github.com/phlx0/living-docs)** | Claude Code plugin that auto-detects stale documentation after code changes and applies surgical fixes — catches renamed functions, env vars, CLI flags, and API endpoints across Markdown, JSDoc, OpenAPI, Python docstrings, and Go doc comments |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
## What

Adds [living-docs](https://github.com/phlx0/living-docs) to the Community Skills table.

## About the skill

**living-docs** is a Claude Code plugin that detects stale documentation after code changes and applies surgical fixes — without rewriting content that's already correct.

It catches:
- Function signature changes (old params in JSDoc/README)
- Renamed env vars, CLI flags, config keys
- Moved API endpoints in OpenAPI specs
- New exports missing from docs

Supports Markdown, JSDoc/TSDoc, Python docstrings, Go doc comments, OpenAPI/Swagger, RST.

## Install

```bash
curl -fsSL https://raw.githubusercontent.com/phlx0/living-docs/main/scripts/install.sh | sh
```

Then run `/living-docs` in Claude Code.