### PR TITLE
Add zipcodeandcounty skill (US ZIP + county MCP wrapper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[zipcodeandcounty](https://github.com/qileza/zip-code-free-api/tree/main/skills/zipcodeandcounty)** | Look up any US ZIP code via a hosted MCP server — city, county (FIPS), timezone, area codes, Census ACS demographics, home prices, rent, property tax, broadband, cost of living. Includes /zip, /county, /distance slash commands. Free, no API key required for low-volume use |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds a new entry under **Community Skills → Individual Skills**.

| Skill | Description |
|---|---|
| **[zipcodeandcounty](https://github.com/qileza/zip-code-free-api/tree/main/skills/zipcodeandcounty)** | Look up any US ZIP code via a hosted MCP server — city, county (FIPS), timezone, area codes, Census ACS demographics, home prices, rent, property tax, broadband, cost of living. Includes /zip, /county, /distance slash commands. Free, no API key required for low-volume use |

## What it provides

- **MCP server registration** — points Claude Code at our hosted streamable-HTTP MCP at `https://zipcodeandcounty.com/api/mcp`
- **3 slash commands** — `/zip <code>`, `/county <fips>`, `/distance <a> <b>`
- **7 underlying tools** the agent can call: lookup_zip, search_zips, nearby_zips, zip_distance, county_info, state_summary, airports_near_zip

## One-line install

```bash
claude mcp add --transport http zipcodeandcounty https://zipcodeandcounty.com/api/mcp
```

Then drop the three slash-command markdown files into `~/.claude/commands/`.

## Skill manifest

Full SKILL.md at https://github.com/qileza/zip-code-free-api/blob/main/skills/zipcodeandcounty/SKILL.md

## Why it qualifies

- Drop-in install (one CLI command or copy-paste JSON)
- Hosted (no local install of any package)
- Free for the use volumes most personal Claude Code sessions need
- Public-domain data — US Census ACS 5-year, USPS, HUD, NANPA, NCES, BEA, IANA
- MIT licensed