### PR TITLE
Add claude-overleaf skill — Claude co-author for Overleaf LaTeX papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[claude-overleaf](https://github.com/gsoosk/claude-overleaf)** | Claude co-author for Overleaf LaTeX papers — auto-syncs edits via GitHub Actions, handles first-time setup, conflict resolution, and bidirectional Overleaf ↔ GitHub sync; includes `/overleaf-sync` command |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds claude-overleaf to the Individual Skills table.

  **What it does:** Turns Claude into a co-author for papers living on Overleaf.
  Claude syncs with the Overleaf project via GitHub Actions, edits .tex files as
  instructed, and pushes changes back automatically — no manual git commands needed.

  **Key features:**
  - Auto-activates when user asks to write/edit their paper
  - /overleaf-sync command for explicit session start + first-time setup
  - Bidirectional sync: GitHub → Overleaf on every push, Overleaf → GitHub hourly
  - User-reviewed conflict resolution

  Repo: https://github.com/gsoosk/claude-overleaf