### PR TITLE
Add bro — session continuity memory for Claude Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[bro](https://github.com/balaka/bro)** | Session continuity memory for Claude Desktop. Captures mood, vocabulary, decisions, and rules so context survives `/compact` resets. One folder per work thread, weekly auto-update check. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Adding: bro

Repo: https://github.com/balaka/bro

**What it is:** Session continuity memory for Claude Desktop. Captures
conversation state (mood, vocabulary, decisions, rejected options,
design/code/investigation context) in a daily markdown file per work
thread, so context survives `/compact` resets.

**Details:**
- One-liner curl install, no build step, pure markdown
- Folder-per-thread layout (parallel work streams don't collide)
- Self-updating via weekly GitHub check
- 4 real-world examples in README
- MIT licensed, single maintainer

Added to Individual Skills table. Thanks for maintaining this list!