### PR TITLE
Add claw.cleaning to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 
+- **[claw.cleaning](https://github.com/GetColby/claw-cleaning)** - Remote MCP server for booking SF apartment cleanings. Three tools, no local binary, no auth. Skill also shipped at `skill/apartment-cleaning/`.
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
 
 ## ✏️ Creating Your First Skill


### PR DESCRIPTION
Adds `claw.cleaning` under Community Skills → Individual Skills.

claw.cleaning is a remote MCP server (`https://claw.cleaning/mcp`) that lets Claude book real SF apartment cleanings in one turn. Three tools, no local binary, no auth. Skill is also shipped at `skill/apartment-cleaning/` in the repo.

$40/hr, SF only, weekends, pay the cleaner on site.

Repo: https://github.com/GetColby/claw-cleaning