### PR TITLE
Add paperjsx skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[paperjsx](https://github.com/paperjsx/agent-skill)** | Generate PPTX presentations, DOCX documents, XLSX spreadsheets, and PDF invoices/reports/charts from structured JSON. Runs locally via `@paperjsx/mcp-server` — no API key, no network calls |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds the **PaperJSX** agent skill to the Individual Skills table.

- Generates PPTX, DOCX, XLSX, and PDF documents from JSON
- Runs locally via `@paperjsx/mcp-server` — no API key, no network calls
- License: Apache-2.0
- Skill repo: https://github.com/paperjsx/agent-skill
- npm package: https://www.npmjs.com/package/@paperjsx/mcp-server