### PR TITLE
Add claude-ecom to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[claude-ecom](https://github.com/takechanman1228/claude-ecom)** | Ecommerce business-review skill for D2C stores. Turns order CSVs into structured monthly reviews with multi-horizon KPI decomposition (30d/90d/365d), ~30 health checks across revenue/customer/product, RFM cohorts, and a prioritized action plan with revenue impact estimates |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Hi 👋 — adding `claude-ecom`, an ecommerce business-review skill, to the **Community Skills → Individual Skills** table.

**What it does**: Given an order CSV, it produces a structured monthly business review for D2C stores:
- Multi-horizon KPI decomposition (30d / 90d / 365d)
- ~30 automated health checks across revenue / customer / product
- RFM cohort segmentation (Champions / Loyal / At-Risk / Lost)
- Prioritized action plan with estimated revenue impact per finding

Hybrid architecture: Python backend handles deterministic KPI computation, Claude handles narrative and recommendations.

**Links**:
- Repo: https://github.com/takechanman1228/claude-ecom
- License: MIT
- Latest release: v0.1.3
- Active: yes, recent commits
- SKILL.md with YAML frontmatter at `skills/ecom/SKILL.md`, packaged for pip + Claude Code plugin marketplace

Happy to revise wording or placement. Thanks for maintaining this list!