### PR TITLE
Add VernonOY/alpha-skills to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[VernonOY/alpha-skills](https://github.com/VernonOY/alpha-skills)** - 7 skills that turn Claude Code into a quantitative factor research workstation
+  - `alpha-discover` · `alpha-evaluate` (IC/ICIR/quintile/robustness) · `alpha-mine` (automated factor mining) · `alpha-library` · `alpha-backtest` · `alpha-monitor` (IC decay) · `alpha-report`
+  - Supports A-share, HK, and US equities out of the box; bilingual EN/中文; Apache 2.0
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adds [alpha-skills](https://github.com/VernonOY/alpha-skills) to the **Community Skills → Collections & Libraries** section.

### What it is
A collection of 7 self-contained Claude Code skills that form a full quantitative factor research pipeline:

- `alpha-discover` — design factors from natural-language prompts
- `alpha-evaluate` — multi-level evaluation (IC / ICIR / quintile / robustness)
- `alpha-mine` — automated factor mining with IC screening
- `alpha-library` — SQLite factor registry with lifecycle management
- `alpha-backtest` — single/multi-factor portfolio backtesting with gate checks
- `alpha-monitor` — IC decay detection and health monitoring
- `alpha-report` — panoramic, deep-dive, and comparison reports

### Why it fits Collections & Libraries
Same shape as `obra/superpowers` — a bundle of multiple reusable skills that work together through a shared Python + data-access convention. Users activate skills via natural language (e.g. "evaluate `pv_diverge_20d`" or "mine 50 factors").

### Extras
- Supports **A-share** (China), **Hong Kong**, and **US** equities out of the box with per-market trading-rule adaptation
- Bilingual documentation (English + 中文)
- Apache 2.0 license
- Currently 35 stars, actively maintained

Thanks for curating this list!