### PR TITLE
Add vara-skills to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[vara-skills](https://github.com/gear-foundation/vara-skills)** | 21 skills teaching agents to ship Rust smart contracts on Vara Network — plan → Sails impl → gtest → on-chain deploy via `vara-wallet`. Covers IDL, React frontend, and indexer |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [vara-skills](https://github.com/gear-foundation/vara-skills) to the Individual Skills table under Community Skills.

**What it is:** A 21-skill pack that teaches Claude Code (also Codex and OpenClaw) how to build and ship Rust smart contracts on Vara Network with the Gear/Sails framework. Covers the full pipeline from spec through Rust implementation, IDL/client codegen, deterministic gtest, React frontend, event-driven indexer, and on-chain deploy via the `vara-wallet` skill.

**Why it fits here:** Like the existing entries (`ios-simulator-skill`, `playwright-skill`, `claude-scientific-skills`), this is a framework-onboarding skill pack — it teaches an agent a specific development workflow end-to-end. MIT licensed.

Published by Gear Foundation. Ships as a Claude Code plugin (via `marketplace.json`), Codex install script, and OpenClaw wrapper.