### PR TITLE
Add one-person-agency-ai: 14 role-based skills for solo marketers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[atm301/one-person-agency-ai](https://github.com/atm301/one-person-agency-ai)** - 14 role-based AI skills that turn a solo freelancer/marketer into a full agency (Kevin strategist, Hunter ad buyer, Winnie editor, Ada analyst, Ken engineer, and 9 more) with cross-role handoff rules and a `/team` auto-dispatch coordinator
+  - Features: 14 distinct personas, `/team` auto-dispatch + `/meeting` multi-agent discussion, Traditional Chinese-first (English keywords included)
+  - 3 install paths: Claude Code (`cp -r skills/* ~/.claude/skills/`), Claude.ai Projects, or copy-paste prompts for ChatGPT/Gemini
+  - Use cases: marketing agencies, solo creators, indie SaaS operators
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## What

Adds [atm301/one-person-agency-ai](https://github.com/atm301/one-person-agency-ai) to the **Collections & Libraries** section under Community Skills.

## Why

It's a curated collection of 14 role-based skills designed for solo freelancers/marketers/operators — each skill represents a distinct colleague persona (strategist, ad buyer, editor, analyst, engineer, PM, designer, UX, security, QA, etc.) with clear handoff rules between them. A \`/team\` coordinator skill auto-dispatches incoming tasks to the right role.

Fills a gap in the list: most existing collections are engineering-focused (superpowers, Trail of Bits). This is the first marketing/solo-operator focused collection.

## Highlights

- 14 distinct personas with consistent structure (role, style, skills, handoff rules)
- Traditional Chinese-first (with English keyword support for triggering)
- 3 install paths included: Claude Code, Claude.ai Projects, copy-paste prompts for ChatGPT/Gemini
- MIT Licensed