### PR TITLE
Add terraform-skill to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[terraform-skill](https://github.com/antonbabenko/terraform-skill)** | Terraform and OpenTofu patterns for AI agents: testing, modules, state management, CI/CD, and security scanning |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
terraform-skill. 1.6K stars. Terraform + OpenTofu patterns for AI agents.

Covers testing, modules, state management, CI/CD, security scanning.

Multi-host: Claude Code, Cursor, Copilot, Gemini CLI, OpenCode, Codex, Antigravity.

https://github.com/antonbabenko/terraform-skill