### PR TITLE
Add novel-writer-workflow to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[novel-writer-workflow](https://github.com/GonsonInter/novel-writer-workflow)** | Two-phase novel-writing workflow with six composable skills — ideation, framework, chapter SOP, consistency guards, and finalization; scene-level 2-round independent agent review and scriptable hard-constraint scanning |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds [novel-writer-workflow](https://github.com/GonsonInter/novel-writer-workflow) to the Individual Skills table.

## About the skill

A bundle of six composable Claude Code skills for novel writing, organized in a two-phase workflow:

- **Phase 1 — Ideation**: theme / characters / worldview / target audience / core conflict
- **Phase 2 — Execution**: framework → chapter SOP → consistency guards (background) → finalization

Key design choices:
- **Scene-level unit** (not chapter): finer-grained review catches bugs earlier
- **Two rounds of independent agent review per scene**, must reach 0 P0 + 0 P1 to close; final round uses a fresh agent instance
- **Scriptable hard-constraint scanning**: surname lock, punctuation mode, em-dash density cap, markdown-bold ban, meta "Ch N" ban
- **Cross-chapter consistency tables**: props timeline / time anchors / terminology / key numbers
- **P0/P1/P2 triage with minimal-diff discipline** during finalization

Battle-tested on a ~130k-character Chinese novel.

## License

MIT