### PR TITLE
Add BlogBurst — autonomous social media manager skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[BlogBurst](https://github.com/shensi8312/blogburst-claude-skill)** | Autonomous social media manager — writes posts, replies, and learns what works across Twitter, Bluesky, Telegram, and Discord. Replaces a $500-1,500/mo freelance SMM for $29-99/mo. Public API endpoints let Claude demo content before signup |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Skill

**BlogBurst** — Autonomous social media manager for Claude Code. Writes posts, replies, and learns what works across Twitter, Bluesky, Telegram, and Discord.

- Repo: https://github.com/shensi8312/blogburst-claude-skill
- Positioned as a replacement for a \$500-1500/mo freelance social media manager (\$29-99/mo)
- Public API endpoints (`/blog/platforms`, `/public/free-tools/brand-audit`) let Claude demo real sample posts **without** an API key — no friction for discovery
- Also published to clawhub.ai as an OpenClaw skill

Added to **Individual Skills** table.