### PR TITLE
Add Skills宝 (skilery.com) - Chinese AI Skills Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[Skills宝 (skilery.com)](https://skilery.com)** - Chinese AI Skills marketplace, one-stop search & install for Claude Code/OpenCode
 
 ## ✏️ Creating Your First Skill
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[ai-skill](https://github.com/anomalyco/ai-skill)** - AI skill discovery and management system
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Hi! I'd like to add a Chinese AI Skills marketplace to the Tools section.

**Skills宝 (skilery.com)**
- Chinese AI Skills marketplace
- One-stop search & install for Claude Code, OpenCode and more platforms
- https://skilery.com

This could be helpful for Chinese users. Thanks for considering!