### PR TITLE
Add wecom-gui-message: macOS GUI automation for WeCom messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[wecom-gui-message](https://github.com/jacky-wzj/wecom-gui-message)** | macOS GUI automation for sending messages via WeCom (Enterprise WeChat) desktop client using OCR + cliclick |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## wecom-gui-message

macOS GUI automation skill for sending messages via WeCom (Enterprise WeChat) desktop client.

**Tech stack:** peekaboo + screencapture + Swift Vision OCR + cliclick

**Key features:**
- Window-specific screenshot capture (avoids blank OCR from fullscreen)
- Coordinate offset conversion (window coords → screen coords)
- Auto login detection with QR code capture
- Side panel detection and dismissal
- Input box coordinate estimation (WeCom has no placeholder text)

**Links:**
- GitHub: https://github.com/jacky-wzj/wecom-gui-message
- ClawHub: wecom-gui-message@3.0.0