### PR TITLE
Add unslop to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[unslop](https://github.com/MohamedAbdallah-14/unslop)** | Removes AI writing patterns (tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocab). Five intensity levels. Detection and rewriting are split — use as a lint pass or full rewrite. MIT licensed. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [unslop](https://github.com/MohamedAbdallah-14/unslop) to the Individual Skills table.

**What it does:** Claude Code plugin that removes AI writing patterns from text — tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocabulary, performative balance, tidy essay shapes. Targets ~15 documented AI writing tells with dedicated detectors and rewriters.

**Key points:**
- Five intensity levels (subtle → balanced → full → voice-match → anti-detector)
- Detection and rewriting are split — can run lint-only passes without rewriting
- Pattern-based, not detector-based (targets readable prose, not GPTZero scores)
- MIT licensed, no SaaS, no auth