### PR TITLE
Add Claude Code Skills Registry to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[Claude Code Skills Registry](https://claude-skills.bdnhost.net/)** by [BDNHOST](https://github.com/bdnhost) — Auto-discovered, daily-updated catalog of 250+ verified Claude Code skills curated from across the ecosystem
+  - Aggregates skills from 9 sources: `anthropics/skills`, `obra/superpowers`, `jeffallan/claude-skills`, `akin-ozer/cc-devops-skills`, `daymade/claude-code-skills`, `bdnhost/claude-skills`, plus daily GitHub code search
+  - Filter by 15 categories, source repo, language (English / Hebrew / Chinese), and tags
+  - Every skill has a deep-link page (`/s/<id>/`) with rich Open Graph previews, install snippet, and source link
+  - Source code for the BDNHOST-authored skills: [bdnhost/claude-skills](https://github.com/bdnhost/claude-skills)
+  - No tracking, no signup wall, no ads
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## What
Adds the [Claude Code Skills Registry](https://claude-skills.bdnhost.net/) to **🌟 Community Skills → Collections & Libraries**, right after `obra/superpowers-lab`.

## Why it fits this section
This is a curated meta-catalog of Claude Code skills — fits the "Collections & Libraries" intent perfectly:

- **250+ verified skills** with auto-discovery (daily n8n + GitHub code search workflow)
- Aggregates from **9 trusted sources** including the ones already on this list (`obra/superpowers`, `jeffallan/claude-skills`, `akin-ozer/cc-devops-skills`, plus `anthropics/skills`)
- **Hybrid LLM + keyword classifier** sorts skills into 15 categories
- Filter by category, source repo, language (English / Hebrew / Chinese), tags
- Every skill has a deep-link page with rich Open Graph previews and install snippet
- Companion source repo: [bdnhost/claude-skills](https://github.com/bdnhost/claude-skills)
- No tracking, no signup wall, no ads, MIT/CC-BY-4.0

## Format match
Followed the exact format used by the existing `obra/superpowers` and `obra/superpowers-lab` entries — bold title with link, hyphen description, then nested bullets for additional resources.