### PR TITLE
Add logic-lens — logic-first behavioral bug detection skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 
+| **[logic-lens](https://github.com/hyhmrright/logic-lens)** | Logic-first code review via semi-formal execution tracing — detects behavioral bugs that linters and type checkers miss. Structured findings: Premises → Trace → Divergence → Remedy. Six skills: logic-review, logic-explain, logic-diff, logic-locate, logic-health, logic-fix-all |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
## logic-lens

Logic-first code review plugin for Claude Code that detects behavioral bugs via semi-formal execution tracing.

- **Repo:** https://github.com/hyhmrright/logic-lens
- **Platforms:** Claude Code plugin + Gemini CLI extension + Codex CLI
- **What it finds:** Logic errors that linters and type checkers miss — off-by-one errors, wrong predicate conditions, incorrect state transitions, unreachable branches
- **Finding format:** Premises → Trace → Divergence → Remedy (with L1–L6 risk codes)
- **Six skills:** logic-review, logic-explain, logic-diff, logic-locate, logic-health, logic-fix-all

Unlike static analysis tools, logic-lens traces *execution paths* through your code to find bugs that are syntactically valid but semantically wrong.