### PR TITLE
✨ Add KubeStellar Console to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[kubestellar-console](https://github.com/kubestellar/console)** | Multi-cluster Kubernetes operations — AI-powered dashboards, MCP server (kc-agent), and 20+ CNCF project integrations for edge-to-cloud cluster management |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add KubeStellar Console

Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **Individual Skills** table.

### What it provides

- **CLAUDE.md:** Multi-cluster Kubernetes management patterns, card development, Go backend, React/TypeScript frontend
- **AGENTS.md:** Agent-neutral instructions for any AI coding tool
- **MCP Server (kc-agent):** Bridges kubeconfig contexts to LLMs
- **Domain:** 20+ CNCF project integrations (Argo CD, Kyverno, Istio)

### About

- **License:** Apache-2.0 | **CNCF Sandbox** project
- **Website:** https://console.kubestellar.io