### PR TITLE
Add tiered-close-out skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[tiered-close-out](https://github.com/studio-b-ai/tiered-close-out)** | Three-tier session close-out for Claude Code — routes behavioral rules, operational knowledge, and unfinished work to three independent approval gates, with pluggable blocking domain guards. Generic scaffold to fill in for your stack. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [`tiered-close-out`](https://github.com/studio-b-ai/tiered-close-out) to the Individual Skills table.

`tiered-close-out` is a session close-out skill for Claude Code that splits the wrap-up into three independent artifacts — behavioral rules, operational knowledge, and unfinished-work handoff — and routes each to its own store with its own approval gate (diff-review for rules, batch-approve-with-tags for knowledge, display-only for handoff). It also exposes a pluggable blocking-guard hook so domain-specific tripwires (e.g. "every new DB migration needs a rollback file") can refuse to complete the close-out until the contract is satisfied. The repo is a generic scaffold with three filled-in walkthroughs (CLAUDE.md + claude-mem, CLAUDE.md + qmd-sessions, AGENTS.md + tagged-markdown).

Companion essay explaining the pattern and surveying prior art (dream-skill, claude-mem, qmd-sessions, gstack, claudekit): https://github.com/studio-b-ai/b-studio-website/pull/20.

## Test plan

- [x] Row added at the end of the Individual Skills table, immediately above the "More community skills coming soon" line
- [x] Link target resolves (https://github.com/studio-b-ai/tiered-close-out is public)
- [x] Description fits the table's voice and length

🤖 Generated with [Claude Code](https://claude.com/claude-code)