### PR TITLE
Add chrome-relay to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills for working with complex file formats:
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[chrome-relay](https://chrome-relay.kushalsm.com/)** | Drive your already-open Chrome session — cookies, SSO, extensions, localhost — from a local CLI bridge. Install via `npx skills add chrome-relay` + Chrome extension; no remote relay, no Playwright fixtures, no MCP server needed |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |


### PR DESCRIPTION
Adds **chrome-relay** to the Individual Skills table, immediately after `playwright-skill`. They're complementary, not competing:

- `playwright-skill` — fresh Playwright Chromium per run; clean room, no auth.
- `chrome-relay` — your already-open Chrome session; cookies, SSO, extensions, localhost preserved.

Same shape (Claude Code skill), different tradeoff on the auth/state axis.

**Install:** `npx skills add chrome-relay` + the [Chrome extension](https://chromewebstore.google.com/detail/chrome-relay/cpdiapbifblhlcpnmlmfpgfjlacebokb) (native messaging via Web Store, no remote relay).

**Architecture:** Chrome extension ↔ local CLI bridge over native messaging. No Playwright, no MCP server, no headless browser. The agent drives the tab the user has open.

**Links:**
- Landing: https://chrome-relay.kushalsm.com/
- npm: https://www.npmjs.com/package/chrome-relay (`chrome-relay@0.2.3`, MIT)
- Chrome Web Store: https://chromewebstore.google.com/detail/chrome-relay/cpdiapbifblhlcpnmlmfpgfjlacebokb

The list convention already allows non-GitHub landing pages (e.g., the `shadcn/ui` row links to `ui.shadcn.com/docs/skills`), so chrome-relay's landing-page link follows the same precedent. Happy to switch to the npm URL or split into a dedicated row format if you prefer.