### PR TITLE
Add cv-mirror-mcp to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[cv-mirror-mcp](https://github.com/goofypluto999/cv-mirror-mcp)** | Lints a CV (PDF/DOCX) against 5 real ATS parsers (Workday, Greenhouse, Lever, Taleo, iCIMS) using heuristics derived from public vendor docs. Local-only, no upload. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds cv-mirror-mcp as a new row in the Individual Skills table.

**Repo:** https://github.com/goofypluto999/cv-mirror-mcp

### What it does

MCP server that lints a CV (PDF or DOCX) against 5 real ATS parsers — Workday, Greenhouse, Lever, Taleo, iCIMS — using heuristics derived from public vendor documentation. Each vendor has documented parsing quirks (multi-column handling, emoji stripping, header/footer dropping, date-format detection). Most online ATS scanners give a single 0-100 score that's invented; this surfaces what each vendor actually does.

### Why it fits

- Real working code: 19 unit tests passing, MCP `tools/list` verified
- Local-only execution; no upload, no telemetry, no API key
- Vendor rules cite their public sources in [docs/vendor-sources.md](https://github.com/goofypluto999/cv-mirror-mcp/blob/main/docs/vendor-sources.md)
- Useful for any agent that helps a user with their job search or CV review

Disclosure: I am the author. Happy to adjust placement, copy, or section if helpful.