### PR TITLE
Add tianluo: methodology for multi-hour autonomous Claude Code runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[tianluo](https://github.com/yeewangcn/tianluo)** | Methodology skill for multi-hour to multi-day autonomous Claude Code runs — persistent state across context compactions, plan-time fork enumeration, 5-layer failure diagnosis, budget-bounded retry, file-role separation. For any cron-driven multi-stage task. Bilingual EN/CN. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **tianluo (田螺姑娘)** — a methodology skill for keeping Claude Code on a multi-hour task without it pinging the operator at 3am for routine confirmations.

Five concrete capabilities, each inverting one specific multi-hour-agent failure mode:

1. **Persistent state survives context compaction** — state.json + self-contained cron prompts that rebuild context from scratch every wake-up
2. **Plan-time fork enumeration** — every future user-decision listed as Q1..Qn before the run starts, answered once, then zero further interruptions
3. **5-layer structured diagnosis** — scheduler / container / log / progress / output
4. **Budget-bounded retry with escalation ladder** — transient → patch → replan → human; never retry a code-level bug
5. **File-role strict separation** — state.json (machine, JSON), plan.md (human, frozen), failures/*.md (postmortem), memory/*.md (cross-session); never merged

Adding to **Community Skills > Individual Skills** since the skill is fully generic — applies to any cron-driven multi-stage task: scheduled batch jobs, build/deploy pipelines, parameter sweeps, monitoring runs, long CI suites.

Repo: https://github.com/yeewangcn/tianluo
License: MIT
Bilingual EN/CN README and case study.