### PR TITLE
Add full-page-screenshot to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[full-page-screenshot](https://github.com/LewisLiu007/full-page-screenshot)** | Zero-dependency full-page screenshot via Chrome DevTools Protocol. Handles SPAs, lazy-loading, ultra-long pages. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds **[full-page-screenshot](https://github.com/LewisLiu007/full-page-screenshot)** to the Individual Skills table
- Zero-dependency Node.js skill that captures full-page screenshots of web pages via Chrome DevTools Protocol
- Handles SPAs, lazy-loading, and ultra-long pages

## Notes

This is a new skill repo. I understand 10+ stars are required for inclusion — happy to wait until that threshold is met before merge.