### PR TITLE
Add 3 Claude Code skills (WeChat / Notion / Audit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[notion-pdf-skill](https://github.com/cathyhang0905/notion-pdf-skill)** | Import PDFs into Notion as PPT-style slideshows — each page becomes an image block. Auto cover (Unsplash) + icon (DiceBear). Only Notion API key required. |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |

--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[wechat-article-reader](https://github.com/cathyzhang0905/wechat-article-reader)** | Read and search WeChat public account articles — no token, no login required. Runs fetches locally to bypass Anthropic-server blocking. |
+| **[notion-pdf-skill](https://github.com/cathyzhang0905/notion-pdf-skill)** | One-step PDF → Notion knowledge base. Skill that ingests a PDF and saves it as a structured Notion page. |
+| **[claude-code-monthly-audit](https://github.com/cathyzhang0905/claude-code-monthly-audit)** | Monthly health check slash command — audits CLAUDE.md, Rules, Skills, Hooks, Agents, and MCP servers in your Claude Code setup. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding 3 Claude Code skills focused on personal information processing and Claude Code self-management:

- **wechat-article-reader** — bypasses Anthropic-server WeChat blocking by running fetches locally on the user's machine
- **notion-pdf-skill** — single-command PDF → Notion knowledge base
- **claude-code-monthly-audit** — slash command for periodic CLAUDE.md / Rules / Skills health check

All three are MIT-licensed, actively maintained, and tested in my own Claude Code setup.
