### PR TITLE
Add task observer skill to the individual skills table

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
-| **[task-observer](https://github.com/rebelytics/one-skill-to-rule-them-all)** | Meta-skill that observes Claude sessions to automatically improve all used skills (including itself) and creating new ones |
+| **[task-observer](https://github.com/rebelytics/one-skill-to-rule-them-all)** | Meta-skill that observes Claude sessions to automatically improve all used skills (including itself) and create new ones |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[task-observer](https://github.com/rebelytics/one-skill-to-rule-them-all)** | Meta-skill that observes Claude sessions to automatically improve all used skills (including itself) and creating new ones |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding the task-observer skill to the individual skills table.

This is an open-source skill with **more than 300 GitHub stars**. It observes Claude sessions and logs observations for improving all skills used (including itself) and for creating new skills.

I've been using this skill for three months and it has logged and applied more than 600 observations across my 40 skills - which were all created based on task-observer sessions themselves.

Link to the skill repo: [https://github.com/rebelytics/one-skill-to-rule-them-all](https://github.com/rebelytics/one-skill-to-rule-them-all)
License: CC BY 4.0

The repo contains a readme and a detailed user guide, along with a license file and two images that represent the skill.

I confirm that I've read the contributing guidelines and that I've created this PR manually. I appreciate your work.