### PR TITLE
Add PO UI and Protheus skill to awesome list

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[poui-protheus / po-table](https://github.com/danielmontagna86-source/claude-skills-poui)** | PO UI and Protheus/ADVPL skill that helps reduce hallucinated Angular code by using local `po-table` references, typed examples and anti-hallucination rules. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds `poui-protheus / po-table`, a Claude Skill focused on PO UI, Angular and TOTVS Protheus/ADVPL.

The skill helps reduce hallucinated Angular code by requiring Claude Code to consult local component references before generating examples. It currently focuses on `po-table` and includes:

- `SKILL.md` with anti-hallucination rules;
- curated local reference for common `po-table` inputs, outputs and column patterns;
- Angular example with selection, actions, labels, currency/date columns and loading state;
- Protheus-oriented guidance for backend, auditability, permissions and performance;
- contribution guide and roadmap for more PO UI components.

## Repository

https://github.com/danielmontagna86-source/claude-skills-poui

## License

MIT

## Notes

- Does not require a paid SaaS or external service to provide value.
- Includes more than a single `SKILL.md` file: references, examples, prompts, roadmap and contribution guide.
- Intended for developers working with `@po-ui/ng-components`, Angular and Protheus/ADVPL.