### PR TITLE
Add skill-lab-hub to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[sdfkr22/skill-lab-hub](https://github.com/sdfkr22/skill-lab-hub)** | Turkish token-saving hybrid mode , session-based GitHub bug reporter and more | 
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Personal Claude Code skill marketplace with two independently installable skills:

- **turkce-token-tasarrufu** — Turkish/English hybrid mode that reduces token usage in Turkish conversations
- **session-bug-hunter** — Analyzes the current Claude Code session to detect bugs and opens structured GitHub issues

### Why this belongs here
The Turkish token-saving skill is unique in the ecosystem — no other listed skill targets non-English token optimization. The bug reporter skill follows the session-aware pattern and is practical for daily dev workflows.

### Install
```bash
# Both skills
/plugin install pack@skill-lab-hub

# Individually
/plugin install turkce-token-tasarrufu@skill-lab-hub
/plugin install session-bug-hunter@skill-lab-hub
```

🔗 https://github.com/sdfkr22/skill-lab-hub