### PR TITLE
Add haruspex-skills (four stock-analysis skills) to Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[haruspex-skills](https://github.com/Haruspex-guru/haruspex-skills)** | Four skills for stock traders powered by Haruspex: single-ticker analysis (`haruspex-stock-analyst`), watchlist review (`haruspex-watchlist-review`), thesis tracking (`haruspex-thesis-tracker`), and a Japanese-language flagship variant (`haruspex-stock-analyst-ja`). Analysis-only with compliance disclaimer; depends on [`@haruspex-guru/mcp-server`](https://www.npmjs.com/package/@haruspex-guru/mcp-server) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [`haruspex-skills`](https://github.com/Haruspex-guru/haruspex-skills) — a small focused package of four Anthropic Agent Skills for stock traders, powered by the Haruspex API.

**Skills:**
- `haruspex-stock-analyst` — single-ticker fundamental + signals analysis
- `haruspex-watchlist-review` — batched multi-ticker review
- `haruspex-thesis-tracker` — maps a stated investment thesis to relevant Haruspex dimensions
- `haruspex-stock-analyst-ja` — Japanese-language flagship variant

**Notes:**
- Analysis-only — the skills explicitly do not give direct buy/sell/hold recommendations. Every output appends a compliance disclaimer.
- Depends on [`@haruspex-guru/mcp-server`](https://www.npmjs.com/package/@haruspex-guru/mcp-server) for live data (published on npm, MIT-licensed).
- Latest release: [v0.2.0](https://github.com/Haruspex-guru/haruspex-skills/releases/tag/v0.2.0).
- Companion PR at [anthropics/skills#1073](https://github.com/anthropics/skills/pull/1073).

Tested end-to-end in Claude Code: skills auto-trigger on representative queries, MCP tool calls succeed, output matches the documented templates with share URLs and disclaimer footers.

I added a single row under **Community Skills → Individual Skills** (the same table as `playwright-skill`, `claude-d3js-skill`, etc.). Happy to split into per-skill rows or move into a different section if you prefer.