### PR TITLE
Add solo-skills under Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[rockscy/solo-skills](https://github.com/rockscy/solo-skills)** - 7 bilingual (EN+中文) Claude Code skills shaped for solo founders and indie developers
+  - Skills: `ship-decision`, `launch-tweet`, `changelog-from-commits`, `bug-from-user`, `standup-solo`, `email-customer`, `postmortem-solo`
+  - Every skill has a mandatory "When NOT to use" section + a fixed output format + a worked input/output example
+  - One-line install: `curl -fsSL https://raw.githubusercontent.com/rockscy/solo-skills/main/install.sh | bash`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adding [solo-skills](https://github.com/rockscy/solo-skills) — a bilingual (EN+中文) Claude Code skills pack for solo founders and indie developers.

### Why it fits Collections & Libraries

It's a **collection** of seven small skills, designed to be installed together via a one-liner. Each skill is single-purpose:

- `ship-decision` — regret-minimizing call between 2-3 product options
- `launch-tweet` — draft launch tweet/thread, no marketing hype
- `changelog-from-commits` — turn raw git log into user-facing release notes
- `bug-from-user` — convert a confusing customer email into a reproducible bug report
- `standup-solo` — 5-minute personal standup
- `email-customer` — polite-but-firm reply to refunds, scope creep, complaints
- `postmortem-solo` — ≤350-word blame-free postmortem template

### Distinguishing features

- Every skill includes a mandatory **"When NOT to use"** section — most skill collections only describe when to use a skill; that's only half a spec.
- Every skill has a **fixed output format** (table, structured sections) — never paragraphs of prose advice.
- Every skill has a **worked input/output example** showing real usage.
- Bilingual: English and 中文 sections in every `SKILL.md`.
- One-line install that skips existing files (never overwrites).

Repo: https://github.com/rockscy/solo-skills