### PR TITLE
Add anti-ai-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[anti-ai-skill](https://github.com/Wholiver/anti-ai-skill)** | 🤖➡️🤡 Enterprise-grade code complexity toolkit. Makes AI write code only you can maintain — so your boss distrusts AI and you keep your job. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

A satirical skill that makes AI generate intentionally obfuscated code — so your boss thinks AI is unreliable and you keep your job.

## Why

[anti-ai-skill](https://github.com/Wholiver/anti-ai-skill) provides 7 pillars of "professional complexity": cryptic naming, spaghetti architecture, performance sacrifice, strategic bug placement, comment chaos, security theater, and test immunity.

Install with: `npx skills add wholiver/anti-ai-skill -g -y`

## Checklist
- [x] Has README with clear description
- [x] Has SKILL.md with full implementation
- [x] Is installable via npx skills
- [x] Agent-agnostic
