### PR TITLE
Add gorilla-lead-finder under Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[gorilla-lead-finder](https://github.com/opusforge/gorilla-mcp/tree/main/skills/gorilla-lead-finder)** | Drives the Gorilla MCP server end-to-end to find a founder's first SaaS users on Reddit, X, YouTube, and TikTok. Refines the idea, ranks posts by buying intent, drafts platform-tuned outreach |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds the gorilla-lead-finder skill.

Drives the Gorilla MCP server through the full lead-discovery flow: refine the idea, search Reddit/X/YouTube/TikTok, rank posts by buying intent, draft platform-tuned outreach, and produce a Week-1 send cadence. Built so a founder can go from "I just shipped" to "10 messages out before lunch" in one prompt.

Backed by https://usegorilla.app. Paid per run ($0.99 / $3.99 weekly / $149.99 lifetime).

Skill: https://github.com/opusforge/gorilla-mcp/tree/main/skills/gorilla-lead-finder
MCP server: https://github.com/opusforge/gorilla-mcp