### PR TITLE
Add rtlify-ai to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[rtlify-ai](https://github.com/idanlevi1/rtlify)** | RTL (Right-to-Left) architecture rules for AI coding agents. Teaches logical CSS, Tailwind logical classes, bidi text, icon flipping, RN RTL APIs. Works with 7 editors. Install: `npx rtlify-ai init` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add rtlify-ai

RTL (Right-to-Left) architecture rules for AI coding agents.

- Teaches logical CSS properties, Tailwind logical classes, bidi text, icon flipping, React Native RTL APIs
- Works with 7 editors: Claude Code, Cursor, Copilot, Windsurf, Cline, Gemini CLI, Codex CLI
- Zero dependencies — `npx rtlify-ai init`
- `npx rtlify-ai check` audits violations
- GitHub: [idanlevi1/rtlify](https://github.com/idanlevi1/rtlify)