### PR TITLE
Add taprun (Claude Code skills marketplace) to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[LeonTing1010/taprun](https://github.com/LeonTing1010/taprun)** - First-principles engineering methodology marketplace: 8 skills covering verification gates, plan writing, semi-autonomous task execution, demand archaeology, constraint-driven development, engineering philosophy, and first-principle audit
+  - Skills namespace: `/taprun:verify`, `/taprun:writing-plans`, `/taprun:run-task`, `/taprun:demand-archaeologist`, `/taprun:constraint-driven-development`, `/taprun:engineering-philosophy`, `/taprun:first-principle-audit`, `/taprun:jimeng-generator`
+  - Installation: `claude plugin marketplace add LeonTing1010/taprun && claude plugin install taprun@tap`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## Summary

Adds **[taprun](https://github.com/LeonTing1010/taprun)** — a Claude Code skills marketplace with 8 first-principles engineering methodology skills — to the **Community Skills > Collections & Libraries** section.

## What it is

taprun is a Public MIT plugin marketplace containing first-principles engineering skills. All skills namespace under `/taprun:`:

- `/taprun:verify` — Multi-layer deterministic verification gates (typecheck, architecture, lint, tests) — replaces AI self-assessment
- `/taprun:writing-plans` — Intent–verification task decomposition for complex implementations
- `/taprun:run-task` — Semi-autonomous task execution from `task.yaml` with worktree isolation, verification gates, auto-PR
- `/taprun:demand-archaeologist` — Evidence-based demand discovery and product validation
- `/taprun:constraint-driven-development` — RED → GREEN → Why workflow for business logic
- `/taprun:engineering-philosophy` — First-principles framework (12 facts + two eternal principles) for architecture decisions
- `/taprun:first-principle-audit` — Logical audit: assumption list, probability intervals, stakeholder analysis, rebuild path
- `/taprun:jimeng-generator` — Generate images via 即梦AI

## Installation

\`\`\`
claude plugin marketplace add LeonTing1010/taprun && claude plugin install taprun@tap
\`\`\`

## Why this fits Collections & Libraries

It's a marketplace of multiple skills (8) packaged as one plugin, similar in shape to `obra/superpowers` (which is already listed in the same section).