### PR TITLE
Add R69 Labs agent commerce skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[R69 Labs Agent Skills](https://github.com/rizzdbx/r69-agent-skills)** | Agent-commerce skills for Pyrimid Protocol, MYA Launchpad, and AgentZone: x402/Base USDC payments, agent monetization opportunities, ERC-8004 discovery, and reputation-aware marketplace workflows |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds R69 Labs Agent Skills collection with Pyrimid Protocol, MYA Launchpad, and AgentZone skills.\n\nSkill source: https://github.com/rizzdbx/r69-agent-skills\n\nPublic skill URLs:\n- https://pyrimid.ai/skill.md\n- https://monetizeyouragent.fun/skill.md\n- https://agentzone.fun/skill.md