### PR TITLE
Add Chinese Claude Code Skills directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[Claude Code Skills 中文精选集](https://claude-skills.bt199.com/)** - Chinese-language curated directory of Claude Code Skills, Agents, and Plugins with 140+ resources for developers who prefer browsing and comparing Claude Code resources in Chinese
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## Summary
- Adds a Chinese-language Claude Code Skills directory to Collections & Libraries.
- The directory curates 140+ Claude Code Skills, Agents, and Plugins for Chinese-speaking developers.

## Fit
This is a resource/collection rather than an individual skill. It complements the existing collections section and helps non-English users discover Claude Code ecosystem resources.

## Checks
- [x] One resource only
- [x] Matches existing markdown list style
- [x] Link verified
