### PR TITLE
Add Claude Forge — 24-skill production-grade distribution (Collections & Libraries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[Claude Forge](https://github.com/sangrokjung/claude-forge)** — Production-grade Claude Code distribution including **24 skills** (auto-ship, frontend-design, security-review, ci-bi, blog-publish, daily-report, content-creator, generate-image, etc.) plus the agent harness needed to make them work end-to-end (11 agents, 33 commands, 15 hooks, 4 MCP servers, statusLine).
+  - Skills follow the Anthropic 2026 Skills/Commands hybrid policy with documented boundary in [`docs/SKILLS-VS-COMMANDS.md`](https://github.com/sangrokjung/claude-forge/blob/main/docs/SKILLS-VS-COMMANDS.md)
+  - Submitted to [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) (in review)
+  - Inspired by oh-my-zsh's role for zsh
+  - Installation: `/plugin marketplace add sangrokjung/claude-forge` (lightweight) or `curl -fsSL https://raw.githubusercontent.com/sangrokjung/claude-forge/main/install.sh | bash` (full)
+  - License: MIT
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Hi Travis! Adding [Claude Forge](https://github.com/sangrokjung/claude-forge) to the **Collections & Libraries** section.

**What it is:** A production-grade Claude Code distribution that bundles 24 skills together with the supporting harness (11 agents, 33 commands, 15 hooks, 4 MCP servers, statusLine) so the skills work end-to-end. Inspired by oh-my-zsh's role for zsh.

**Why Collections & Libraries (not Individual Skills):** Like `obra/superpowers`, claude-forge is a curated multi-skill set rather than a single `SKILL.md`. Examples of bundled skills:

- **`auto-ship`** — full release pipeline (test → review → tag → release)
- **`frontend-design`** — distinctive UIs avoiding "AI slop"
- **`security-review`** — OWASP / secrets / dependency audit
- **`ci-bi`** — competitive intelligence + benchmarks
- **`blog-publish`** / **`daily-report`** / **`content-creator`** / **`generate-image`** — content workflows
- ...plus 16 more

**Social proof / vetting** (per the new CONTRIBUTING requirement):
- Submitted to `anthropics/claude-plugins-official` (in review)
- 4-way independent skeptical review completed 2026-04-23 (super-research / security / architect / codex)
- Active maintenance: weekly releases
- License: MIT, all open source, no paid funnel

**Why not "Individual Skills"?** Each skill has its own `SKILL.md`, but they're shipped as a coherent set with shared agent / hook infrastructure. Splitting them across the table would lose that "one install, everything works" property. Happy to also list individual skills there if you'd prefer.

Note on Skills/Commands hybrid: claude-forge documents its [Skills vs Commands boundary](https://github.com/sangrokjung/claude-forge/blob/main/docs/SKILLS-VS-COMMANDS.md) so users can pick the right entry point per workflow.

Happy to adjust placement, wording, or structure per your conventions.

— @sangrokjung
