### PR TITLE
Add iGPT Skills to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+ - **[igptai/skills](https://github.com/igptai/skills)** - Email intelligence skills marketplace with 13 role-specific plugins, 76 skills, and 13 agents, powered by the iGPT MCP
+  - Plugins for sales, finance, recruiting, customer success, executive, procurement, IT, marketing, projects, real estate, consulting, research, and HR
+  - Read-only OAuth, per-user scoping, citations on every answer
+  - Installation: `/plugin marketplace add igptai/skills`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adding iGPT Skills, a Claude Code plugin marketplace for email intelligence.

**Repository:** https://github.com/igptai/skills
**Install:** `/plugin marketplace add igptai/skills`
**MCP:** https://mcp.igpt.ai/ (Streamable HTTP, OAuth)
**License:** MIT

13 role-specific plugins (sales, finance, recruiting, customer success, executive, procurement, IT, marketing, projects, real estate, consulting, research, HR) with 76 skills and 13 agents total. Each skil