### PR TITLE
Add production-audit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[production-audit](https://github.com/commitshow/production-audit)** | Audit a shipped repo for the production-readiness gaps that ~70% of AI-coded projects miss (RLS, webhook idempotency, Stripe API idempotency, column GRANT mismatches, secret-in-bundle, etc.). Companion to in-session security skills — scans deployed product, not editor buffer |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [`production-audit`](https://github.com/commitshow/production-audit) under **Individual Skills**.

A Claude Code skill that audits a shipped repo for the 14 production-readiness gaps ~70% of AI-coded projects miss — RLS coverage, webhook idempotency, Stripe API idempotency, column GRANT mismatches, secret-in-bundle, mobile input zoom, and more.

**Why it complements existing entries**: the current Security skill in the list (Trail of Bits) is an in-session lens — scans editor buffer with CodeQL/Semgrep. `production-audit` scans the **deployed product** post-merge: live URL, GitHub signals, repo structure, secrets in shipped bundle. Different timing, different inputs, different findings.

Install: \`npx skills add commitshow/production-audit\` or \`/plugin marketplace add https://github.com/commitshow/production-audit\` inside Claude Code.

Verifications: ✅ valid SKILL.md frontmatter · ✅ canonical \`.claude/skills/\` layout · ✅ \`.claude-plugin/marketplace.json\` present · ✅ install via \`npx skills add\` confirmed · ✅ MIT license · ✅ README has install + usage + companion-skills sections.