### PR TITLE
Add The Froject (workspace generator) to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[The Froject](https://www.thefroject.com)** - Free browser-based wizard that generates complete Claude Code workspaces with role-tailored skills, commands, agents, rules, and hooks. Built non-developer-first for marketing, sales, customer success, HR, finance, and operations teams. Plugin marketplace at [bjorn-ingmanson/thefroject-plugins](https://github.com/bjorn-ingmanson/thefroject-plugins).
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
Adding [The Froject](https://www.thefroject.com) to the Community Skills > Tools section.

The Froject is a free browser-based wizard that generates complete Claude Code workspaces. It produces role-tailored skills, commands, agents, rules, and hooks bundled into a downloadable ZIP. Built non-developer-first for marketing, sales, customer success, HR, finance, and operations teams — but also covers software, product, research, and data science.

Fits well alongside `Skill_Seekers` in Tools because The Froject is a tool that generates skills (and a complete workspace), rather than being a skill itself.

The plugins are also published as a separate marketplace at [bjorn-ingmanson/thefroject-plugins](https://github.com/bjorn-ingmanson/thefroject-plugins) for users who already have a workspace and just want a curated bundle.

Happy to adjust placement or wording if you'd prefer a different section.