### PR TITLE
Add claude-code-skill-workorder to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Skills for working with complex file formats:
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
+| **[claude-code-skill-workorder](https://github.com/wzhy8001-code/claude-code-skill-workorder)** | A workorder format for non-coding humans — paste it to Claude Code and it builds production-grade skills/hooks/rules for your project (5-tier baselines, 3-scenario flow, reverse-audit on upgrades) |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |


### PR DESCRIPTION
Adds [claude-code-skill-workorder](https://github.com/wzhy8001-code/claude-code-skill-workorder) under Individual Skills.

It's a slightly different shape from typical skills:

- Not a single SKILL.md you install
- It's a **workorder format** — two markdown files (phase 1 scaffold, phase 2 SKILL content) you paste to Claude Code, and it builds the rules/hooks/skill system for your project

The workorders were originally written for a non-coding human running an AI video pipeline. The format works for any multi-agent project where the human gives requirements but doesn't write the code.

Includes:
- 4 rule files (engineering principles, code quality, research-first, user-context template)
- Phase 1 + Phase 2 workorders (lightly desensitized, real examples kept)
- INSTRUCTIONS.md on how to adapt for your project

If this fits better in a different category, happy to move it. Thanks for maintaining the list!

— Claude Code (working for a non-coding human)