### PR TITLE
Add claude-team-toolkit (15-skill collection for Rails + RN teams)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[tuannv14/claude-team-toolkit](https://github.com/tuannv14/claude-team-toolkit)** - Team-ready skill pack with 15 multi-account integrations for Rails + React Native team workflows
+  - Skills: Trello, Azure DevOps (cloud + self-hosted Server), Heroku, Sentry, Slack, Firebase, Shopify, PostgreSQL, RSpec, Rails-security, k6, Maestro, Fastlane, React Native, xlsx-testcases
+  - Multi-account profiles (AWS-style INI), audit log, security-first defaults, ~74% token savings on multi-step sessions
+  - Listed on [ClaudePluginHub](https://www.claudepluginhub.com/plugins/tuannv14-claude-team-toolkit)
+  - Installation: `/plugin marketplace add tuannv14/claude-team-toolkit`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## What

Adds [`tuannv14/claude-team-toolkit`](https://github.com/tuannv14/claude-team-toolkit) to **Community Skills → Collections & Libraries**.

## Why

A 15-skill bundle with shared infrastructure (multi-account INI profiles modeled after AWS CLI, audit logging, security-first defaults, ~74% token savings on multi-step sessions). Covers full Rails + React Native team workflow including service APIs, mobile dev, and test/QA.

## Differentiator

Most listed skills are single-purpose. This is a curated bundle with **unified credential management** across all 15 skills — one pattern to learn.

## Skills included

- Service APIs: trello, azure-devops (Services + self-hosted Server), heroku, sentry, slack, firebase, shopify, postgres
- Mobile: react-native, maestro (E2E), fastlane
- Test/QA: rspec, rails-security, k6, xlsx-testcases (xlsx → Maestro spec + ADO Test Plans sync)

## Verified

- License: MIT
- CI: green ([lint workflow](https://github.com/tuannv14/claude-team-toolkit/actions))
- ClaudePluginHub: [listed](https://www.claudepluginhub.com/plugins/tuannv14-claude-team-toolkit)
- 6 GitHub releases tagged (v0.1.0 → v0.8.1)
- Branch protection enabled on main
- Community health files: SECURITY.md, CODE_OF_CONDUCT.md, CHANGELOG.md, MAINTAINERS.md, SUPPORT.md, issue/PR templates, dependabot, CODEOWNERS