### PR TITLE
Add orchestra to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[hassan-mohiddin/orchestra](https://github.com/hassan-mohiddin/orchestra)** - Disciplined AI engineering toolkit. Typed design docs (Feature LLD / Bug Report / ADR / Postmortem / Runbook / Design Doc), 4-gate spec review (Completeness / Evidence / Clarity / Consistency), enforced Refs:-line commit gate, mandatory mermaid diagrams, AGENTS.md / llms.txt sync, bug-iteration loop preventing orphan fix-commits
+  - First skill: `orchestra:design-docs`. Future skills: workflow, skills-registry, tasks, gates
+  - Patterns from Michael Nygard (ADR), Google SRE (postmortems), Pragmatic Engineer (RFC vs ADR), agents.md, llmstxt.org
+  - Ships Python lint CLI for Refs:-line + metadata + status validation, auto `DECISIONS.md` with bidirectional ADR supersession check
+  - Installation: `/plugin marketplace add hassan-mohiddin/orchestra` then `/plugin install orchestra@orchestra`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## What

Adds [hassan-mohiddin/orchestra](https://github.com/hassan-mohiddin/orchestra) to the Collections & Libraries section.

## Why it fits

Orchestra ships as a multi-skill umbrella (matches the obra/superpowers shape). v1.0 ships `orchestra:design-docs` — a typed-doc-taxonomy skill with industry-aligned templates (Nygard ADR, Google SRE postmortem, Linux Foundation AGENTS.md, llmstxt.org). Future v1.1+ skills cover workflow, skills-registry, tasks, and gates under the same umbrella.

## What's in v1.0

- 7 typed doc templates (Feature LLD / Bug Report / ADR / ADR-short / Postmortem / Runbook / Design Doc)
- 2 cross-tool standards (AGENTS.md, llms.txt)
- 4-gate spec review (Completeness / Evidence / Clarity / Consistency)
- Mandatory mermaid diagrams (sequence, activity, architecture, deployment + 28-error troubleshooting)
- Bug iteration loop (one BUG-NNN spans attempts; \`fix:\` only after user confirms)
- 5 doc gates (Discovery / Design / Spec Review / Commit / Sync)
- Auto-numbering script (octal-safe)
- Python lint CLI for Refs:-line + metadata + status validation
- Auto \`DECISIONS.md\` index with bidirectional ADR supersession check
- 3 lint-green example docs (Bug Report, ADR, Postmortem)

## Validation

Internally evaluated via skill-creator-style 8-scenario eval — 72/72 assertions pass. Schema is byte-identical-shape to working obra/superpowers + mattpocock-skills plugins on Claude Code v2.1.129.

## Install

\`\`\`
/plugin marketplace add hassan-mohiddin/orchestra
/plugin install orchestra@orchestra
\`\`\`

License: MIT.