### PR TITLE
Add dependabot-triage skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[dependabot-triage](https://github.com/akshayrao14/git-practices/tree/main/skills/dependabot-triage)** | Defensive Dependabot triage for JS/TS repos (npm, pnpm, yarn, bun) — minimal-patched versioning, exposure mapping (Public/API · Client-Bundle · Internal/Dev), mandatory npm↔pnpm lockfile parity check, changelog scrape with BREAKING/DEPRECATED/MIGRATION safety interlock. Standard + Fast-Track modes |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds [`dependabot-triage`](https://github.com/akshayrao14/git-practices/tree/main/skills/dependabot-triage) to the **Individual Skills** table.

## Why it's valuable

Most existing Dependabot autofix skills are *bump-and-PR* — they pick \`latest-in-major\` and open a PR. That class of skill has burned teams when the bump itself shipped breaking changes, or when the npm lockfile and pnpm lockfile resolved different versions of the same package (CI runs npm, dev runs pnpm, only one path got patched).

This skill takes a different approach:

- **Defensive minimal-patched versioning** — picks the smallest version that supersets every CVE patch in the cluster, not \`latest-in-major\`. Smaller change surface, lower regression risk.
- **Exposure mapping** replaces heuristic reachability. Every import site of the vulnerable package is bucketed into Public/API · Client-Bundle · Internal/Dev so the user sees the actual surface area instead of a guess at "is it reachable".
- **Mandatory lockfile parity check** between \`package-lock.json\` and \`pnpm-lock.yaml\`. If they resolve to different versions of the target package, the skill aborts before opening the PR.
- **Changelog scrape with safety interlock** — fetches release notes between current and target versions, flags \`BREAKING\` / \`DEPRECATED\` / \`MIGRATION\` keywords, and pauses for explicit user confirmation before applying the bump.
- **Standard** (full defensive) and **Fast-Track** (low-risk Internal/Dev or CVSS<7) modes. Fast-Track auto-reverts to Standard on parity or build failure rather than retrying blindly.

Lockfile coverage: npm, pnpm, yarn, bun. Browser frontends + Node.js services.

## Compliance

- ✅ Non-promotional — open-source, MIT licensed, no SaaS dependency.
- ✅ Standalone value — no paid backend, no funnel.
- ✅ Cross-agent compatible (Claude Code, Codex CLI, Cursor) per Agent Skills open standard.
- ✅ Tagged release: [v2.1.1](https://github.com/akshayrao14/git-practices/releases/tag/v2.1.1).
- ✅ Listed on [skills.sh](https://skills.sh/akshayrao14/git-practices).

## Format

Single row added to the Individual Skills table, matching existing pattern.