### PR TITLE
Add phase-review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills for working with complex file formats:
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
+| **[phase-review](https://github.com/tripinfinite-gif/claude-skill-phase-review)** | Adaptive multi-agent phase verification — auto-scales 2→7 fresh subagents (S/M/L) for bug-fixes through architecture changes, with built-in security + architecture + adversarial audit |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |


### PR DESCRIPTION
Adds **phase-review** to the Individual Skills table.

**Repo:** https://github.com/tripinfinite-gif/claude-skill-phase-review

**What it does:** Adaptive multi-agent phase verification for Claude Code. Auto-scales 2→7 fresh subagents based on change size (S/M/L) — bug-fixes get 2 reviewers, architecture changes get 7. Strict role zoning: Spec, Architecture, Quality, Security, Forward-Look, Adversarial Skeptic, Regression Sweep.

**Why it's useful:**
- Sensitive-bump rule (auth/PII/payments/e-signature/file-upload/raw SQL → minimum size M)
- Built-in adversarial skeptic filters REAL findings from PARANOIA
- Bilingual triggers (RU + EN)
- MIT licensed, plugin manifest + manual install both supported
- Zero external deps (uses stock Claude Code subagent types)

**Production track record** on a multi-tenant Russian permit platform:
- L-size review caught 22 findings + 5 questions on a Phase 6a engineering review
- L-size security review validated multi-layer defense against 11 attack vectors on a file-upload feature
- M-size sandbox isolation review caught an SSRF before deploy

Thanks for maintaining this list! 🙏