### PR TITLE
Add voxflow to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[voxflow](https://github.com/VoxFlowStudio/skills)** | AI voice CLI shipping 5 skills (hub, podcast, transcribe, video, paper-slide) for TTS in 200+ voices across 40+ languages, multi-speaker podcasts, video dubbing from SRT, ASR, and short-form Remotion video reels |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **voxflow** to the `🌟 Community Skills → Individual Skills` table.

[voxflow](https://github.com/VoxFlowStudio/skills) is a 14-month solo project — an AI voice/audio CLI that ships as 5 SKILL.md files:

- `hub` — TTS, voice search/cloning, narration, AI stories
- `podcast` — multi-speaker AI dialogue
- `transcribe` — ASR (cloud or local Whisper), subtitle translation, video dubbing
- `video` — short-form video generation via Remotion
- `paper-slide` — paper-textured vertical knowledge reels

Same skill files install via \`npx skills add VoxFlowStudio/skills\` and work in Claude Code, Cursor, Codex CLI, Gemini CLI, and Cline.

CLI: https://www.npmjs.com/package/voxflow
Demo: https://github.com/VoxFlowStudio/skills/raw/main/demo.gif

Free tier 10K quota/month.