### PR TITLE
Add skill-triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[skill-triage](https://github.com/karankumar24/skill-triage)** | Meta-skill that picks the right installed Claude Code skill for a task and falls back to verified web discovery when nothing matches |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [skill-triage](https://github.com/karankumar24/skill-triage) to Individual Skills.

## What it is

A meta-skill for Claude Code that picks the right installed skill for a task. Returns one structured recommendation: ranked candidates, an Avoid list with reasons, ordered phases (pre/impl/post), and a verdict (`proceed directly` / `proceed with skill(s)` / `stop and ask`). Stops and asks before destructive operations.

## Why it's a value-add

Solves a problem the existing Individual Skills don't: with many skills installed, the auto-trigger heuristics fire too eagerly and Claude either picks the first plausible match or chains several. skill-triage enforces a hard skill budget by complexity tier (simple=0, medium=1-2, complex=3-5, high-risk=1-2) and one-skill-per-role, then names rejected candidates under Avoid with reasons.

## More than a single SKILL.md

Includes a frontmatter-only bash scanner (`scripts/scan-skills.sh`) that reads YAML frontmatter from `~/.claude/skills/`, `~/.claude/plugins/cache/*/`, and `.claude/skills/`, plus an examples directory and a SECURITY.md covering the privacy-scrub procedure for the discovery fallback.

## Not a SaaS

Apache-2.0, no paid platform, no API key required, no server in the loop. The discovery fallback uses `WebFetch` and `WebSearch` against public GitHub URLs only, and only when no installed skill matches the task.