### PR TITLE
Add Paymob Integration Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[paymob-integration-skill](https://github.com/PaymobAccept/Paymob-Claude-Integration-Skill)** | Complete guide for integrating Paymob payment gateway (Intention API, Accept API, HMAC webhook validation) across Node.js, Python, PHP, .NET, Ruby, React, Next.js, Vue, Flutter, React Native. Covers card payments, mobile wallets (Vodafone Cash, Orange Money, Etisalat), kiosk payments, cash collection. Supports Egypt, Pakistan, UAE, Saudi Arabia, Oman, Jordan. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add Paymob Integration Skill

I've created a comprehensive Paymob integration skill to help developers across 
multiple tech stacks build payment systems correctly.

### What it covers:
- Node.js, Python, PHP, .NET, Ruby, React, Vue, Flutter integration
- Intention API (modern) and Accept API (legacy) flows
- Complete HMAC webhook validation with code examples
- Egyptian payment methods: Vodafone Cash, Orange Money, Etisalat
- Kiosk payments and cash collection patterns
- Supports Egypt, Pakistan, UAE, Saudi Arabia, Oman, Jordan

### Why add it:
The official Paymob docs jump between old and new APIs. This skill brings 
everything together in one place with practical examples for any tech stack.

**Repository:** https://github.com/PaymobAccept/Paymob-Claude-Integration-Skill
**License:** MIT
**Stars:** 11+