### PR TITLE
Add Solo Founder OS — 10 production-tested skills bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,3 +451,7 @@ A: For skills from git repositories, pull the latest changes. For manually insta
 ## 🤝 Contributing
 
 Contributions welcome! See [contribution guidelines](CONTRIBUTING.md) for details. To add a skill or resource: fork, add to appropriate section, submit PR.
+
+## Skill Bundles
+
+- **[Solo Founder OS](https://github.com/pagoda111king/claude-code-pack)** — Pack of 10 production-tested skills (idea-eval · lead-intake · proposal-gen · case-study-gen · prior-art-search · eval-refine · ship-checklist · release-window · soft-launch · content-blitz) plus 11 agents · 10 commands · 4 hooks. Battle-tested config from 6 months of solo SaaS work.


### PR DESCRIPTION
## What

Adding [Solo Founder OS](https://github.com/pagoda111king/claude-code-pack) to the skills section.

## Why it might fit

This is a *bundle* of 10 production-tested skills (rather than a single skill):
- `idea-eval` — 6-dimension scoring before building anything
- `lead-intake` — discovery call script + lead scoring
- `proposal-gen` — interview → client proposal
- `case-study-gen` — post-delivery → 5 reusable content pieces
- `prior-art-search` — OSS-first research before reinventing
- `eval-refine` — quick refinement loop on outputs
- `ship-checklist` — pre-release full audit
- `release-window` — picking ship timing
- `soft-launch` — staged release pattern
- `content-blitz` — batch content production

Each refined over 6 months of real solo founder usage. Comes packaged with 11 agents · 10 commands · 4 hooks · CLAUDE.md template (the full pack is a Claude Code config OS).

## License

MIT for code (hooks/scripts) · CC BY-NC 4.0 for skills/agents/commands.

If category placement is off, happy to adjust — wasn't sure if 'Skill Bundles' is the right section name.