### PR TITLE
Add guanyuan-majia (Guandata BI multi-agent skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[guanyuan-majia](https://github.com/maojiebc/guanyuan-majia)** | Guandata BI (观远 BI) full-stack skill — data query / ETL governance / custom chart dev. 60+ ETL ops battle-tested. Multi-agent: Claude Code, OpenClaw, Codex, Hermes |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add `guanyuan-majia` to Community Skills > Individual Skills

A multi-agent Skill for **Guandata BI (观远 BI)** — a Chinese enterprise BI platform — covering the full operational lifecycle:

- **Part A** — Data query, card creation, BI HTTP API
- **Part B** — ETL governance, write/delete, SmartETL full-chain rewrite, ExecPlan engineering
- **Part C** — Custom chart HTML/CSS/JS injection + 10-class error handbook

### Highlights
- **60+ real ETL operations** battle-tested in production
- **Methodology contributions** from Guandata's CTO 张进 (Part B-17 SmartETL rewrite + Part C custom chart) and OpenAI Codex (Part B-17.11 ExecPlan spec)
- **Tool-agnostic**: Claude Code · OpenClaw · Codex · Hermes (gbrain) — single SKILL.md, 4 install paths
- **Progressive disclosure** (V1.5.0): SKILL.md router (~48 KB) + 8 reference playbooks loaded on demand
- Published on **ClawHub**: https://clawhub.ai/skills/guanyuan-majia

Repo: https://github.com/maojiebc/guanyuan-majia · License: MIT · Latest: v1.5.2