### PR TITLE
Add qa-skills to Collections & Libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Skills for working with complex file formats:
 
 ### Individual Skills
 
+
+- **[qa-skills](https://github.com/petrkindlmann/qa-skills)** — 42 QA and test-automation skills for Claude Code, Codex, Cursor, and other Agent Skills Standard runtimes. Covers Playwright, Cypress, API/unit/mobile testing, AI test generation, bug triage, accessibility, performance, CI/CD.
 > These will be broken down into categories once there are enough community skills available to list
 
 | Skill | Description |


### PR DESCRIPTION
## Adding qa-skills

Adding a new entry: qa-skills — a library of 42 QA and test-automation skills for AI coding agents (Claude Code, Codex, Cursor, Gemini CLI, and any Agent Skills Standard runtime).

Why it fits this list:
- This list covers awesome Claude Skills and qa-skills is the first comprehensive QA skill pack for AI agents following the Agent Skills Standard
Quality checks:
- [x] Repo is public and actively maintained
- [ ] - [x] MIT licensed
- [ ] - [x] README explains install and usage
- [ ] - [x] Follows the Agent Skills Standard (agentskills.io)
- [ ] - [x] One-line install: npx skills add petrkindlmann/qa-skills
Entry added:

```
- **[qa-skills](https://github.com/petrkindlmann/qa-skills)** — 42 QA and test-automation skills for Claude Code, Codex, Cursor, and other Agent Skills Standard runtimes.
- ```