### PR TITLE
Add guanyuan-majia to Community Skills > Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[guanyuan-majia](https://github.com/maojiebc/guanyuan-majia)** | Guandata BI (观远 BI) full-stack Skill — data queries, ETL governance & SmartETL full-chain rewrite, custom chart HTML/CSS/JS injection & debugging. Tool-agnostic (Claude Code / OpenClaw / Codex / Hermes). Battle-tested with 60+ real ETL operations |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds **guanyuan-majia** to **Community Skills → Individual Skills**.

| Field | Value |
|---|---|
| Repo | https://github.com/maojiebc/guanyuan-majia |
| License | MIT |
| Version | v1.6.0 |
| Compatibility | Claude Code · OpenClaw · Codex · Hermes (gbrain) — tool-agnostic |
| Install | `gh skill install maojiebc/guanyuan-majia` · `npx skills add maojiebc/guanyuan-majia` · `/plugin marketplace add maojiebc/guanyuan-majia` |
| Docs | Bilingual README (CN + EN), 22 KB each · `SKILL.md` 55 KB · `references/` for progressive disclosure · `AGENTS.md` for Codex/Hermes resolver · `manifest.json` for tool-agnostic metadata · `llms.txt` for AI/GEO discovery |

## What it does

A real-use, battle-tested Agent Skill for **Guandata BI / 观远 BI** with three pillars:

- **Part A — data query & card creation**: 26 chart types, 26 aggregations, 13 filter operators, 6 date granularities, custom formula fields, draft-release handling for Guandata 7.0+.
- **Part B — ETL governance & write**: 11 verified BI HTTP API endpoints, dependency-graph + cycle detection, dual-source field-usage audit (page + etl, avoids 8× over-estimation), ODS/DIM/DWD/DWS/APP 5-layer reorg, v2→v3 batch refactor SDK, and CTO Zhang Jin's full-chain rewrite methodology (4 deliverables + 8 hard rules + 5-step workflow).
- **Part C — custom chart dev & debugging**: `renderChart` 4-arg runtime contract, 5 data-shape recognition, `payload_json` truncation 3-step diagnosis, z-index baselines, lifecycle management, MutationObserver loop traps.

Plus a 10-class ETL error fix manual and a 30-rule governance whitepaper, all sourced from real production usage on a 张亮麻辣烫 data middleware (77 ETLs / 251 datasets / 86 dashboards).

## Quality bar

- ✅ Public repo, MIT license, classified by GitHub
- ✅ Working SKILL.md with name + description frontmatter
- ✅ More than a single SKILL.md — also ships `manifest.json`, `AGENTS.md`, `SECURITY.md`, `ATTRIBUTIONS.md`, `CHANGELOG.md`, `bin/install.js`, `references/` library, `llms.txt`, `.claude-plugin/marketplace.json`
- ✅ Bilingual documentation (CN + EN)
- ✅ Real production usage, 60+ documented war stories, not AI-generated boilerplate
- ✅ Currently at v1.6.0 with 9 prior versions and full CHANGELOG
- ✅ No SaaS wrapper / no commercial upsell — Guandata is the BI platform, not a service the author sells

Happy to adjust the entry wording or move it to a more specific category if one is added later. Thanks for maintaining this list!