### PR TITLE
Add agentkit-seo — career SEO skills for Claude Code and other agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[agentkit-seo](https://github.com/agentkit-seo/agentkit-seo)** | Skills for Claude Code, Codex, Gemini CLI, and OpenCode that optimize GitHub profiles, LinkedIn, CV/ATS, and portfolios using a structured personal context file. |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
AgentKit SEO installs as agent skills for Claude Code, Codex, Gemini CLI, and OpenCode.

It gives AI agents a structured personal context file (agent-context-file) before optimizing GitHub profiles, LinkedIn, CVs, and portfolios.

- MIT licensed
- Published on npm: https://www.npmjs.com/package/agentkit-seo
- Repo: https://github.com/agentkit-seo/agentkit-seo
- Website: https://agentkit-seo.github.io