### PR TITLE
feat: add tokenwise to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[tokenwise](https://github.com/CodeShuX/tokenwise)** | Measurement-driven model router — auto-routes Claude Code subtasks across Haiku/Sonnet/Opus, logs every routed task with verified $ saved, and A/B tests cheaper tiers before trusting them |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [TokenWise](https://github.com/CodeShuX/tokenwise) as a row in the \`### Individual Skills\` table — a Claude Code skill that auto-routes subtasks across Haiku, Sonnet, and Opus based on task class, logs every routed task with verified \$ saved, and A/B tests cheaper tiers before trusting them.

## What it does

- Routes Opus orchestrator → Haiku/Sonnet workers (5× cost ratio per Anthropic May-2026 pricing)
- Logs every routed task with token + cost numbers (\`.tokenwise/log.ndjson\`, local-only, zero telemetry)
- \`/tokenwise:ab\` runs the same task across multiple tiers and scores quality
- \`/tokenwise:report\` shows verified savings vs all-Opus baseline
- \`/tokenwise:install\` is guided with diff preview, automatic backups, \`--dry-run\` mode

License: MIT