### PR TITLE
Add buy-me-a-car skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[buy-me-a-car](https://github.com/DaizeDong/buy-me-a-car)** | End-to-end used-car pre-purchase workflow: multi-site research, mass dealer outreach, OTD negotiation, CARFAX analysis, and dossier PDF generation. Covers all 50 US states + DC; bilingual EN/CN |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adding [buy-me-a-car](https://github.com/DaizeDong/buy-me-a-car) to the Individual Skills table.

`buy-me-a-car` is an end-to-end used-car pre-purchase workflow plugin for Claude Code. It guides a buyer through every step of the process, from listing discovery to a final negotiated out-the-door price, by combining multi-site research, mass dealer outreach via Gmail, CARFAX/PDF report analysis, and a state-specific out-the-door (OTD) price calculator.

## Key Features

- 8-phase workflow from initial research through dealer outreach, negotiation, and final dossier generation
- Mass dealer outreach with Gmail cron-based monitoring for replies
- 50-state + DC OTD price calculator with sales tax, fees, and market-data anchors
- CARFAX / vehicle history PDF analysis for risk flagging
- Per-vehicle dossier PDF generation summarizing findings
- Bilingual interface: English and Chinese

## Details

- License: MIT
- Active maintainer (@DaizeDong)
- Real-world tested on actual used-car purchase workflows

Placed in the "Individual Skills" table since there is no dedicated automotive/personal-tools category yet.