### PR TITLE
Add claude-persona to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[claude-persona](https://github.com/takechanman1228/claude-persona)** | AI persona panels for customer research — runs agent-separated concept tests with each persona as an independent subprocess, then synthesizes themes, cross-tabs, and verbatims into an executive report |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Hi 👋 — adding `claude-persona` to the **Community Skills → Individual Skills** table.

**What it does**: Build an AI persona panel, ask open-ended customer questions, and pressure-test product concepts before fieldwork. Inspired by Microsoft's [TinyTroupe](https://github.com/microsoft/TinyTroupe).

- `/persona generate` — reusable panels with diverse demographics, Big Five traits, and segment balance
- `/persona ask` — open-ended interviews for motivations, barriers, and decision criteria
- `/persona concept-test` — structured A/B/C comparison of messages, offers, or features
- Agent-separated simulation: each persona runs in its own `claude -p` subprocess (no shared context, no groupthink)
- Output: executive report with theme synthesis, cross-tabs (segment × choice), charts, and verbatims

**Links**:
- Repo: https://github.com/takechanman1228/claude-persona
- License: MIT
- SKILL.md at `skills/persona/SKILL.md` with YAML frontmatter
- Installable via plugin marketplace: `/plugin marketplace add takechanman1228/claude-persona`
- Four bundled demos (Gen Z skincare, premium chocolate, RTD soda, sneakers) with pre-generated panels and results

Happy to revise wording or placement. Thanks for maintaining this list!