### PR TITLE
Add oh-story-claudecode - Chinese web novel writing toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Skills for working with complex file formats:
   - Install from `superpowers-marketplace` plugin
 
 
+- **[worldwonderer/oh-story-claudecode](https://github.com/worldwonderer/oh-story-claudecode)** - Chinese web novel writing toolkit with 13 skills covering the full pipeline: market scanning (Qidian/Fanqie/Jinjiang/Zhihu), deep analysis, long-form & short-form writing, de-AI polish, cover generation, and reverse import. Includes 6 specialized agents (architect, character designer, narrative writer, consistency checker, researcher, explorer)
+  - Installation: `npx skills add worldwonderer/oh-story-claudecode`
+  - 1k+ GitHub stars, actively maintained
+
 ### Individual Skills
 
 > These will be broken down into categories once there are enough community skills available to list


### PR DESCRIPTION
## Summary

Adding [oh-story-claudecode](https://github.com/worldwonderer/oh-story-claudecode) — a Chinese web novel writing skill collection for Claude Code.

**What it does:**
- 13 skills covering the full web novel pipeline: market scanning (Qidian/Fanqie/Jinjiang/Zhihu), deep novel analysis, long-form & short-form writing, de-AI polish, cover generation, and reverse import for existing novels
- 6 specialized agents (story architect, character designer, narrative writer, consistency checker, researcher, explorer)
- Includes hooks for session restore, gap detection, and commit validation
- 1k+ GitHub stars, actively maintained

**Install:**
```bash
npx skills add worldwonderer/oh-story-claudecode
```

I'm the author of this toolkit. It's been developed over the past few months with real web novel writing workflows. Happy to make any adjustments to the description or placement.

## Checklist
- [x] Skill has 10+ GitHub stars (1k+)
- [x] Skill is more than a single SKILL.md file (13 skills with references/)
- [x] Skill provides standalone value (full writing pipeline, no paid services)
- [x] PR not AI-automated (manually submitted by the project author)