### PR TITLE
Add humanizer-skill (43 AI patterns, 5 voices) to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[humanizer-skill](https://github.com/Aboudjem/humanizer-skill)** | Detects 43 AI writing patterns and rewrites text with human rhythm. Five voice profiles, three modes (detect/rewrite/edit), burstiness and perplexity science, zero dependencies |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Adds

One row in the `Individual Skills` table:

```markdown
| **[humanizer-skill](https://github.com/Aboudjem/humanizer-skill)** | Detects 43 AI writing patterns and rewrites text with human rhythm. Five voice profiles, three modes (detect/rewrite/edit), burstiness and perplexity science, zero dependencies |
```

## What it is

A Claude Code skill that finds AI writing tells and rewrites them in a chosen human voice. Pure Markdown, zero dependencies, zero API calls.

- **43 numbered patterns** (P1-P43), the largest open catalog I have found. Each has a trigger regex, source citation, and before/after example.
- **5 voice profiles** (casual, professional, technical, warm, blunt) layered on **3 modes** (`detect`, `rewrite`, `edit`).
- **`--score`** outputs a 0-100 AI-tell density rating; **`--iterate N`** loops until convergence.
- Cites primary research: RAID benchmark (ACL 2024), NeurIPS 2023 intrinsic dimension, Wikipedia's "Signs of AI writing" editorial guideline.
- Works in Claude Code, Cursor, VS Code, Codex CLI, Gemini CLI, Windsurf, Continue.dev, OpenClaw.

## Social proof (per CONTRIBUTING note about new requirement)

- Repo: https://github.com/Aboudjem/humanizer-skill, MIT licensed, public
- README credits the lineage to [@blader/humanizer](https://github.com/blader/humanizer) (18.5k stars), the original Claude humanizer skill
- 90+ research sources cited in README, every claim falsifiable
- Used by the author in production for blog and technical writing

Thanks for maintaining the list.
