### PR TITLE
Add ai-investment-skills — options flow scanner + position classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills)** | Daily options flow scanner, stop-loss monitor, earnings risk check, and real-vs-lottery position classifier. Runs on a cron schedule with Telegram alerts. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What this adds

**[ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills)** — Daily options flow scanner, stop-loss monitor, earnings risk check, and real-vs-lottery position classifier. Runs on a cron schedule with Telegram alerts.

## Why it fits

- Follows the SKILL.md format (compatible with Claude Code, Cursor, Codex CLI)
- Includes free tier (EV calculator + news sentiment engine) and pro bundle
- Has working examples with real options chain data (Polygon.io)
- Actively maintained — daily cron runs documented publicly on dev.to

## Checklist
- [x] Skill follows the SKILL.md format
- [x] GitHub repo is public
- [x] Description is concise and accurate
- [x] Added to Individual Skills table in alphabetical-ish order