### PR TITLE
Add ai-investment-skills to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[tellmefrankie/ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills)** - 6 Claude Code skills for investment analysis built from live portfolio management
+  - Free: EV Calculator (probability-weighted bull/base/bear scenarios), News Sentiment Engine
+  - Pro ($29): Investment Briefing Agent (9-wave analysis), Options Flow Analyzer (real vs lottery calls), Price Monitor with Telegram alerts, Multi-Agent Orchestrator
+  - Caught XLI put/call ratio 5.32 anomaly live — production-tested, not a demo
+  - Installation: `cp ev-calculator/SKILL.md ~/.claude/skills/`
 
 ### Individual Skills
 


### PR DESCRIPTION
## What this adds

**[ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills)** — 6 Claude Code skills for investment analysis, built from 6+ months of live portfolio management.

**Free skills (clone immediately):**
- EV Calculator — probability-weighted bull/base/bear scenario analysis
- News Sentiment Engine — RSS-based AI/tech news with sentiment scoring

**Full bundle skills:**
- Investment Briefing Agent — 9-wave coordinated analysis (macro, sector, technicals, news, critique, simulation)
- Options Flow Analyzer — separates real institutional trades from lottery calls (caught XLI P/C 5.32 anomaly live)
- Price Monitor & Alert — real-time stop-loss/take-profit via Telegram
- Multi-Agent Orchestrator — parallel agent team with quality assurance

**Why it fits Collections & Libraries:** It is a coherent set of production-tested skills around a specific domain (investment analysis), not a single utility.