### PR TITLE
Add ai-investment-skills — investment analysis skill collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills)** | Six investment analysis skills: options flow scanner with real/lottery call filtering (caught XLI P/C 5.32 live), news sentiment analyzer, EV calculator, stop-loss monitor, sector ETF analyzer, 9-wave briefing agent |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What I'm adding

**[tellmefrankie/ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills)** to the Individual Skills table.

Six production-tested investment analysis skills for Claude Code:

1. **Options flow scanner** — real/lottery call filtering. Caught XLI P/C 5.32 anomaly 5 consecutive weeks. Prevented RXRX false positive (84% lottery calls masked as bullish signal, filtered real P/C was 2.1/bearish).
2. **News Sentiment Analyzer** — processes 200+ articles, scores per ticker/sector, 2 hrs → 5 min
3. **EV Calculator** — personalized break-even with subsidy calculation
4. **Stop-loss monitor** — real-time price alerts via Telegram
5. **Sector rotation signal** — ETF P/C baseline comparison
6. **9-wave investment briefing agent** — macro → sector → individual → options → catalyst → risk synthesis

All SKILL.md format, drop-in compatible with Claude Code.