### PR TITLE
Add options-flow-analyzer — P/C ratio with lottery call filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[options-flow-analyzer](https://github.com/tellmefrankie/ai-investment-skills)** | Calculates put/call ratios across a watchlist, filters lottery calls (price &lt;$0.10 or &gt;5% OTM), and flags statistical outliers — separates real institutional flow from retail noise |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds options-flow-analyzer to the Individual Skills table.

Calculates put/call ratios across a watchlist, filters lottery calls (price <$0.10 or >5% OTM), and flags statistical outliers. Separates real institutional flow from retail noise — a problem most options scanners ignore.

Source: github.com/tellmefrankie/ai-investment-skills