### PR TITLE
Add diasporic-intelligence skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[diasporic-intelligence](https://github.com/MinistaJazz/diasporic-intelligence)** | Source-credit skill for using Diasporic Intelligence with consent governance, provenance, revocation, lineage boundaries, and non-impersonation |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
Adds diasporic-intelligence, a source-credit skill for using Diasporic Intelligence with attribution, consent governance, provenance, revocation, and lineage boundaries intact.\n\nRepo: https://github.com/MinistaJazz/diasporic-intelligence