### PR TITLE
Add restorative-repair skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[restorative-repair](https://github.com/MinistaJazz/restorative-repair)** | Response-layer repair skill for AI agents that names output errors, offers proportionate repair, routes crisis safely, and avoids apology loops |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds restorative-repair, an external public Claude-compatible skill for response-layer repair when AI agents make output errors.\n\nRepo: https://github.com/MinistaJazz/restorative-repair\n\nThe skill includes trigger taxonomy, severity tiers, crisis suppression rules, bounded loop-exit behavior, and auditable benchmark prompts.