### PR TITLE
Add Suppr Skills for academic literature workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[Suppr Skills](https://github.com/WildDataX/suppr-skills)** | Claude Code skills for academic literature search and document translation workflows through the Suppr APIs. |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
Hi, thanks for maintaining this collection.

This PR adds Suppr Skills as a research/document-workflow skill. Suppr Skills provides Claude Code skills for academic literature search and document translation APIs, supporting research reading, paper discovery, and document translation workflows.

Disclosure: I maintain/am affiliated with Suppr, so I kept the entry concise and transparent. Happy to adjust wording or placement.