### PR TITLE
add: harness-engineering to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[harness-engineering](https://github.com/Junhanliu-dev/harness-engineering)** | Discovers an existing codebase's patterns and generates a Harness Engineering structure (rules, skills, agents, hooks, 10-stage pipeline) that constrains AI coders to match project conventions. TS/Go/Python boundary hooks, programmatic quality gates, sub-agent separation of execution and judgment |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
Adds [harness-engineering](https://github.com/Junhanliu-dev/harness-engineering) to the Community Skills > Individual Skills table.

## What it does
Discovers an existing codebase's patterns and generates a Harness Engineering structure (rules, skills, agents, hooks, 10-stage pipeline) that constrains AI coders to match project conventions. TS/Go/Python boundary hooks, programmatic quality gates, sub-agent separation of execution and judgment.

## Test plan
- [x] SKILL.md follows current Anthropic skill spec (YAML frontmatter with name + description)
- [x] Distributable as a Claude Code plugin via `.claude-plugin/marketplace.json`
- [x] Smoke-tested on a TypeScript/Express dummy project — 9 well-formed output files, 5/5 skill folder/name parity
- [x] Public repo, MIT license