### PR TITLE
Add wallpaper6-design-skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[Hei33enberg/wallpaper6-design-skills](https://github.com/Hei33enberg/wallpaper6-design-skills)** - 64 PatternSkill definitions for **[wallpaper⁶](https://wallpaperwallpaperwallpaperwallpaperwallpaperwallpaper.com)** storefront categories — seamless tiling presets, stock photo queries, Flux/Schnell prompt templates, and print-roll context (53 cm / 106 cm)
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## Summary
- Lists **Hei33enberg/wallpaper6-design-skills** under Community Skills collections — 64 category-aligned PatternSkill files for the wallpaper⁶ storefront (tiling modes, stock queries, AI prompts, print-roll context).

## Test plan
- [x] Link resolves to public GitHub repo with LICENSE and per-category SKILL.md files