### PR TITLE
Add claude-indie-toolkit to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[tastekim/claude-indie-toolkit](https://github.com/tastekim/claude-indie-toolkit)** - Workflow toolkit for solo founders shipping side projects with Claude Code — 5 agents + 3 skills + 2 commands + 1 PreToolUse hook, designed with explicit kill criteria and "refuse to" clauses
+  - Agents: `idea-validator` (5-pillar GO/NO-GO), `pricing-strategist` (Van Westendorp + competitive benchmarking), `landing-page-architect` (AIDA + PAS, 12-section), `cold-outreach-writer` (4-line reply-optimized framework), `launch-day-orchestrator` (22-day playbook)
+  - Skills: `mvp-spec-writer` (hard constraints: ≤4 weeks, ≤5 screens, ≤7 user actions), `competitor-deep-dive`, `revenue-modeler`
+  - Commands: `/validate-idea`, `/launch-checklist`
+  - Hook: `scope-creep-guard` — blocks Claude from writing files outside the project's MVP-SPEC.md
+  - Includes Korean adaptation guide (한국어 가이드)
+  - Free preview agent + sample output on GitHub (MIT); full pack on Gumroad
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Hi! I'd like to add **claude-indie-toolkit** under Community Skills > Collections & Libraries.

## What it is
A workflow toolkit for solo founders shipping side projects with Claude Code: 5 agents + 3 skills + 2 commands + 1 PreToolUse hook. Designed with explicit kill criteria and "refuse to" clauses so the agents push back on bad indie hacker decisions instead of just helping execute them.

## Why it might be a fit for the list
- Not a single skill — it's a structured collection like `obra/superpowers`, aligned with where you placed that entry.
- Each agent encodes a concrete methodology (Van Westendorp price sensitivity, AIDA + PAS landing pages, 4-line cold email framework, etc.) rather than generic prompts.
- The PreToolUse `scope-creep-guard` hook is a slightly unusual pattern that other authors may find useful.
- Repo includes a free preview agent + sample output (MIT-licensed) so the entry is useful even without the paid full pack.

## Repo
https://github.com/tastekim/claude-indie-toolkit

## Disclosure
I'm the author. The full pack is sold on Gumroad. Happy to revise the description, move to a different section, or shorten the bullet list — just let me know what you'd prefer.

Thanks for maintaining the list!