### PR TITLE
feat: add antigravity-fullstack-hq to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[sabahattink/antigravity-fullstack-hq](https://github.com/sabahattink/antigravity-fullstack-hq)** - Permission-first CLAUDE.md + agent stack for Claude Code and Google Antigravity — 10 agents, 28 skills, one-command install
+  - Features permission-first workflow that requires explicit approval before any action, preventing unexpected AI changes
+  - Dual-IDE support: works with both **Claude Code** and **Google Antigravity IDE** out of the box
+  - Includes 10 specialist agents, 28 skill modules (Next.js, NestJS, Prisma, auth, security...), and 10 slash command workflows
+  - Installation: `curl -fsSL https://raw.githubusercontent.com/sabahattink/antigravity-fullstack-hq/main/install.sh | bash`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## What this adds

Adds **[sabahattink/antigravity-fullstack-hq](https://github.com/sabahattink/antigravity-fullstack-hq)** to the **Collections & Libraries** section.

## About the repo

A permission-first CLAUDE.md + agent stack that works with both **Claude Code** and **Google Antigravity IDE** — installed with a single command.

**What's inside:**
- 🔐 **Permission-first workflow** — agent plans, shows intent, and waits for explicit approval before acting
- 🤖 **10 specialist agents** — frontend, backend, database, architect, code-reviewer, test-engineer, security-auditor, devops-engineer, performance-optimizer, documentation-writer
- 📚 **28 skill modules** — Next.js, NestJS, Prisma, TypeScript, React, Tailwind, auth, security, Docker, GitHub Actions, and more
- ⚡ **10 slash command workflows** — `/plan`, `/brainstorm`, `/debug`, `/create`, `/enhance`, `/test`, `/status`, `/preview`, `/orchestrate`, `/ui-ux-pro-max`
- 🖥️ **Dual-IDE support** — one install script, two IDEs (`--only-claude` or `--only-antigravity` flags available)

**Install:**
```bash
curl -fsSL https://raw.githubusercontent.com/sabahattink/antigravity-fullstack-hq/main/install.sh | bash
```

## Why it fits this list

- All 28 skills follow the standard `SKILL.md` frontmatter format
- MIT licensed, actively maintained
- v1.0.0 released with full changelog

## Checklist

- [x] Follows the existing list format
- [x] Added to the correct section (Collections & Libraries)
- [x] Link is correct and repo is public
- [x] Description is concise and accurate
