### PR TITLE
Add claude-memory-manager to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[claude-memory-manager](https://github.com/jau123/claude-memory-manager)** | Schema + audit script on top of Claude Code's auto-memory. Adds a 3-type schema, required frontmatter, and a bash audit that flags drift in long-running memory libraries |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding a new community skill:

- **Repo**: https://github.com/jau123/claude-memory-manager
- **What it does**: Schema + audit script that sits on top of Claude Code's built-in auto-memory (v2.1.59+). Enforces `<type>_<topic>.md` naming, required frontmatter, and a Why section on `feedback` entries. A bash audit script flags drift (missing frontmatter, oversized files, orphan entries).
- **Why it's useful**: Auto-memory writes plain markdown but doesn't enforce structure. On long-running projects the library quickly becomes unsearchable. This skill is for users whose memory directory has passed a few dozen files.
- **License**: MIT