### PR TITLE
Add SNAP Protocol — private agent-to-agent payments on Solana

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[snap-private-payments](https://github.com/agentzeny/snap-public/tree/main/integrations)** | Private agent-to-agent payments on Solana using Groth16 zero-knowledge proofs. MCP server + SDK for shielded deposits, anonymous withdrawals, pool listing, and fee estimation. Live on mainnet. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds SNAP Protocol to the Individual Skills table.

**SNAP** enables private agent-to-agent payments on Solana mainnet using Groth16 zero-knowledge proofs. Agents deposit SOL or USDC into shielded pools and withdraw anonymously — observers cannot link sender to receiver.

**Claude Code integration:** MCP server with 4 tools (snap_list_pools, snap_deposit, snap_withdraw, snap_estimate_fee). Also ships as a SKILL.md and SDK (`snap-solana-sdk`).

- Website: https://agentzeny.ai
- GitHub: https://github.com/agentzeny/snap-public
- SDK: https://www.npmjs.com/package/snap-solana-sdk
- Live on Solana mainnet with 3 pools (0.1 SOL, 1 USDC, 10 USDC)