### PR TITLE
Add clear-copy to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[clear-copy](https://github.com/DesiredPathConsulting/clear-copy)** | Corpus-calibrated prose linter, not a humanizer. Scores prose against deterministic deduction rules across sentence-length burstiness, AI-vocabulary tells, and mechanical flags. Ships two registers (legal, marketing) with a transparent scoring formula. Includes a Node CLI usable in CI |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [clear-copy](https://github.com/DesiredPathConsulting/clear-copy) to Individual Skills.

A prose linter, not a humanizer. Scores prose against a deterministic deduction formula and a corpus-calibrated reference register, then leaves the rewrite to the writer. Different shape from the existing humanizer skills in the ecosystem (blader/humanizer, Aboudjem/humanizer-skill, conorbronsdon/avoid-ai-writing), which all rewrite text rather than score it.

- Two registers ship out of the box: `legal` (bar-journal prose) and `marketing` (landing-page / founder-letter prose).
- Includes a zero-dependency Node CLI usable in CI (`--triage`, `--diff`, `--html` modes).
- Scoring formula is published in full (see `references/stats-compute.md`); no opaque 0-100 score.
- Apache-2.0.

Happy to adjust the description length or category placement if it would fit the table better.