### PR TITLE
Add equity-research skill (community)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[equity-research](https://github.com/GeniusTrader-Harry/equity-research)** | Thesis-first equity research workflow — 13 phases from raw filings to a defensible 5–8 page investment memo, with explicit asymmetry hunt, pillar audit, and killing conditions |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds `equity-research` to the Individual Skills table under Community Skills.

**Repo**: https://github.com/GeniusTrader-Harry/equity-research

**What it is**: A 13-phase Claude Code skill that produces a defensible 5–8 page investment memo on a single stock. Thesis-first ordering — direction commits before any model is built; pillars are developed *for* the committed direction; bull/bear are the payoff envelope around the base case, not parallel theses.

**Why it might be useful here**:
- Differentiated approach (thesis-first vs. typical model-first equity research)
- Built-in anti-patterns catch common failure modes (fake precision, majority-vs-outlier mistaken for edge, unsourced bps decompositions)
- Falsifiability hard-gate via Phase 10 killing conditions
- Designed for student/recruiting prep + personal coverage work, not full sell-side report production

MIT-licensed. Compatible with the SKILL.md format.

Thanks for maintaining the list 🙏