### PR TITLE
Add drayline/rootnode-skills to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Skills for working with complex file formats:
   - Uses new techniques that are still being refined and tested (i.e. skills here may change over time)
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
+ 
+- **[drayline/rootnode-skills](https://github.com/drayline/rootnode-skills)** - Open-source architecture system for Claude. 27 Skills for chat-side Projects and Claude Code covering audits, scoring, prompt compilation, context budgeting, and Claude Code environment design.
+  - Two-surface coverage: chat-side Claude Projects and Claude Code execution
+  - Methodology: 6-dimension Project Scorecard, 7 structural anti-patterns, 10 behavioral countermeasures
+  - Site: [rootnode.design](https://rootnode.design)
 
 
 ### Individual Skills


### PR DESCRIPTION
I've spent the past few months designing and building in Claude and while I was working I kept finding that I didn't have a reliable way to build and audit my projects. As projects grew (and moved into RAG retrieval), the project architecture would drift and I would spend a ton of time trying to get them back on track.

I explored codifying the Claude environment architecture and that turned into root.node. It's 27 Skills that cover both Claude Projects and Claude Code. There are two core workflows. One scaffolds new Projects and Claude Code environments from a task description. The other audits existing ones for drift and applies the fixes. I also built Skills that support inter-conversation workflow such as session and environment handoffs. Submitting to Collections & Libraries since root.node is a system rather than a single Skill, similar in structure to obra/superpowers.