### PR TITLE
Add @hanv89/azure-arch-skill — Azure & Fabric architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[@hanv89/azure-arch-skill](https://github.com/hanv89/azure-icons-for-architecture-diagrams)** | Microsoft Azure & Microsoft Fabric architecture diagrams in PlantUML with `<img:URL>` references to 840 first-party-MIT icons. Per-vendor `INDEX.md` lets the agent find icons by name/tag instead of guessing filenames. Install: `npx @hanv89/azure-arch-skill@latest install --agent=claude-code` (Codex + Cursor also supported) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding `@hanv89/azure-arch-skill` to **Community Skills → Individual Skills**.

## What

A Claude Skill (also works with Codex CLI and Cursor) that teaches the agent to draw Microsoft Azure & Microsoft Fabric architecture diagrams in PlantUML, using literal `<img:URL>` references to 840 first-party-MIT-licensed icons:
- 528 Azure icons from `plantuml-stdlib/Azure-PlantUML` (MIT community redistribution).
- 312 Microsoft Fabric icons from `@fabric-msft/svg-icons` (Microsoft first-party MIT).

## Install

```bash
npx @hanv89/azure-arch-skill@latest install --agent=claude-code
```

Or `--agent=codex | cursor | all`. Once installed, in a fresh agent session: *"Draw the AKS app + Fabric data plane architecture."* The agent emits `.puml` renderable on `play.plantuml.com`, Confluence's PlantUML app, or GitHub's inline renderer.

## Standalone value

- **MIT** code + CLI, no paid component, no SaaS gate, no telemetry.
- v1.1.0 ships per-vendor `INDEX.md` (`dist/Azure/INDEX.md`, `dist/Fabric/INDEX.md`) so the agent finds icons by name/tag — important for non-obvious cases like `Microsoft Entra ID` → `AzureActiveDirectory.png`.
- 6 worked examples in the bundle (context, data pipeline, system architecture, sequence flow, component view, deployment).
- Tri-agent install + uninstall + idempotent update; SLSA provenance on npm; weekly upstream-sync cron with health monitors before opening any refresh PR.

## Links

- Repo: https://github.com/hanv89/azure-icons-for-architecture-diagrams
- npm (with SLSA provenance): https://www.npmjs.com/package/@hanv89/azure-arch-skill/v/1.1.0
- License: MIT for the code; icons redistributed under Microsoft Trademark Guidelines + per-source Microsoft icon Terms of Use (NOTICE).