### PR TITLE
Add watch-video to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[watch-video](https://github.com/MarcinSufa/claude-watch-video)** | Give Claude eyes and ears for any video — local files, public URLs (YouTube, Loom, Vimeo, ~1500 sites via yt-dlp), or Jira attachments. Produces frames + transcript + LLM-driven highlights + paste-ready report (.md / .html / .docx). $0 pipeline (local ffmpeg + free YouTube captions or local Whisper). Smart dedup with transcript-aware protection, OCR layer for screen recordings, opt-in Jira post-back with confirmation gate. Also installable as an MCP server for Claude Desktop, Codex CLI, Cursor, Continue.dev, Cline, etc. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds a row for **watch-video** to the Community Skills > Individual Skills table.

**What it is:** a video-analysis skill that watches local files, public URLs (YouTube / Loom / Vimeo / ~1500 sites via yt-dlp), or Jira attachments. Produces timestamped frames + transcript + LLM-driven highlights with user prompt + paste-ready report in three formats (.md / .html / .docx).

**Why it's worth listing:**
- $0 pipeline cost by default (local ffmpeg + free YouTube captions or local Whisper). Hosted Whisper / LLM highlights are opt-in.
- Smart dedup with perceptual hash + transcript-aware protection -- preserves narrated moments that naive dedup would drop.
- OCR layer tuned for screen-recording UIs (Tesseract with 2x upscale + auto-invert + PSM 6).
- LLM highlights work on Anthropic / OpenAI / Groq via `--highlights-provider`.
- Opt-in Jira posting with a real confirmation gate (declining leaves the ticket completely untouched -- no orphan attachments).
- Also installable as an MCP server for Claude Desktop, Codex CLI, Cursor, Continue.dev, Cline, Windsurf, Zed, VS Code Copilot Chat.

**Repo:** https://github.com/MarcinSufa/claude-watch-video
**License:** MIT
**Latest tag:** v2.0.0

The diff adds a single table row alphabetically-adjacent to existing entries in the Individual Skills table; no other changes.