### PR TITLE
Add git-timesheet to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[git-timesheet](https://github.com/MarcinSufa/git-timesheet)** | Turns your git history into realistic weekly timesheets — hours allocated by commit complexity (lines changed, files touched), not flat splits. Outputs PDF + CSV; 9 countries of public holidays; 6 built-in languages with dynamic translation; pushes to Toggl, Clockify, TMetric, and Harvest APIs; matches custom company PDF templates from sample files. Stop filling timesheets manually. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds a row for **git-timesheet** to the Community Skills > Individual Skills table.

**What it is:** a Claude Code plugin that turns your git commit history into realistic weekly timesheets. Hours are allocated by commit complexity (lines changed, files touched) rather than flat 4+4 splits.

**Why it might fit:**
- Stops manual timesheet entry for developers who track time
- 9 countries of public holidays built-in (incl. PTO/sick days config)
- 6 built-in languages with dynamic translation support
- Pushes time entries directly to Toggl, Clockify, TMetric, and Harvest APIs
- Custom PDF templates -- give it a sample of your company's timesheet and it matches the layout
- PDF + CSV output for both print and import flows

**Repo:** https://github.com/MarcinSufa/git-timesheet
**License:** MIT
**First commit:** 2026-04-22 (24 days in the wild)
**Latest version:** 1.0.4-beta

The diff adds a single table row to the Individual Skills section.