### PR TITLE
Add polis-protocol to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[polis-protocol](https://github.com/yehudalevy-collab/polis-protocol)** | Markdown coordination protocol for multi-vendor agent teams. Signed capability cards, ε-greedy bandit routing that learns from settled contracts, chavruta paired review, self-amending constitution. Works across Claude Code, Codex, Gemini CLI |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds **polis-protocol** to **Community Skills → Individual Skills**.

## What it is

A markdown-only coordination protocol for multi-vendor agent teams:

- **Signed capability cards** per citizen
- **ε-greedy multi-armed bandit routing** that learns from settled-contract outcomes
- **Chavruta paired review** for high-stakes contracts
- **Self-amending constitution** via a ratifiable amendment process

Vendor-agnostic — works across Claude Code, Codex, Gemini CLI, and any markdown-capable agent. MIT licensed.

Worked example with 3 citizens, a leader-shift on a tag after a real lesson, and a ratified amendment: [examples/research-team/](https://github.com/yehudalevy-collab/polis-protocol/tree/main/examples/research-team)

Repo: https://github.com/yehudalevy-collab/polis-protocol
