### PR TITLE
Add winston-coach

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[winston-coach](https://github.com/Anastasios3/winston-coach)** | Apply Patrick Winston's MIT framework (How to Speak + Make It Clear) to any writing or speaking task — talks, decks, reports, emails, pitches. Mandatory humanizer pass strips AI tells from every written output. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **winston-coach** — a Claude skill that applies Patrick Winston's framework from MIT's "How to Speak" lecture and his book *Make It Clear: Speak and Write to Persuade and Inform* to any writing or speaking task.

**What it does**
- 14 Winston tools: Empowerment Promise, VSN-C structure (Vision-Steps-News-Contributions), Winston's Star (Symbol-Slogan-Surprise-Salient-Story), the four engagement heuristics, slide hygiene, six standard openings for written work, the abstract checklist, broken-glass outline, surface clues for skimmers, plus format-specific guidance.
- Routes by format: talks, decks, reports, memos, emails, blog posts, pitches, recommendation letters, abstracts, press releases, papers, more.
- Mandatory humanizer pass on every written output — strips em-dash overuse, AI vocabulary, copula avoidance, synonym cycling, fake parallelisms, the usual tells.
- Eats its own dog food: the skill content itself avoids the patterns it strips.

**Why it might be useful**
Winston's "How to Speak" has ~19M views on YouTube and is widely cited but rarely applied consistently. Packaging the framework as a Claude skill means it auto-applies on every writing or speaking task without having to re-read the source. The skill also corrects several common popularization errors (e.g., "salient" means *sticks out*, not *important*; the book co-author is Karen Prendergast not "Prensky"; the book was finished by Winston himself in 2020, not posthumously by someone else).

**Repo:** https://github.com/Anastasios3/winston-coach
**License:** CC BY-NC-SA 4.0
**Working SKILL.md with YAML frontmatter:** yes
**Author:** [@Anastasios3](https://github.com/Anastasios3)

Happy to adjust the entry placement or wording if needed.
