### PR TITLE
Add atelier — design-automation plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Skills for working with complex file formats:
 
 ### Collections & Libraries
 
+- **[atelier](https://github.com/EthanY33/atelier)** - Design-automation plugin for Claude Code: seven skills around a shared `brand-memory` schema — design tokens, OG cards, responsive images, brand assets, accessibility audit, HTML→video. MIT.
+
 - **[obra/superpowers](https://github.com/obra/superpowers)** - Core skills library for Claude Code with 20+ battle-tested skills including TDD, debugging, and collaboration patterns
   - Features `/brainstorm`, `/write-plan`, `/execute-plan` commands and skills-search tool
   - [superpowers-skills](https://github.com/obra/superpowers-skills) - Community-editable skills repository


### PR DESCRIPTION
Adds [atelier](https://github.com/EthanY33/atelier) to the **Collections & Libraries** section under Community Skills.

atelier is an MIT-licensed Claude Code plugin: seven skills built around a shared `.atelier/brand.json` schema — design tokens, OG cards, responsive images, brand assets, accessibility audit, HTML→video. Currently at v0.2.1 with full CI on Ubuntu + Windows (Node 20) and a 70% coverage gate.

- Repo: https://github.com/EthanY33/atelier
- Latest release: v0.2.1 (security patches for `html-to-video` shell injection, `brand-memory` load validation, Tailwind emitter string-escape)