### PR TITLE
Add caveman-plan skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[caveman-plan](https://github.com/spikeon/caveman-plan)** | Epic → Plans → Hunts → Inventory workflow for large multi-file projects with Boss checkpoints. Install: `npx skills add spikeon/caveman-plan` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
Adds [caveman-plan](https://github.com/spikeon/caveman-plan) to the Individual Skills table — Epic → Plans → Hunts → Inventory workflow for large multi-file projects with Boss checkpoints.

## Install
```bash
npx skills add spikeon/caveman-plan -g -y
```

## Test plan
- [x] Skill repo is public with valid `skills/caveman-plan/SKILL.md`
- [x] Installs via `npx skills add spikeon/caveman-plan`

Made with [Cursor](https://cursor.com)