### PR TITLE
Add clawvr-agent-skill to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[clawvr-agent-skill](https://github.com/Steffd415/clawvr-agent-skill)** | Generates custom AI Operating Systems for any small business across 13+ verticals (dental, salon, restaurant, contractor, real estate, vet, photographer, fitness, insurance, CPA, law, HVAC, general SMB). 6-question intake → master prompt + 6 workflow superprompts + 30-day deployment roadmap. Companion [MCP server](https://github.com/Steffd415/clawvr-mcp-server). Built for the Claude for Small Business ecosystem. MIT |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [clawvr-agent-skill](https://github.com/Steffd415/clawvr-agent-skill) to the Community Skills > Individual Skills table.

Generates custom AI Operating Systems for any small business across 13+ verticals (dental, salon, restaurant, contractor, real estate, vet, photographer, fitness, insurance, CPA, law, HVAC, general SMB). 6-question intake -> master prompt + 6 workflow superprompts + 30-day deployment roadmap.

Companion [Claude MCP server](https://github.com/Steffd415/clawvr-mcp-server). Built for the Claude for Small Business ecosystem. MIT licensed.