### PR TITLE
Add awesome-agentic-ai-zh to Written Tutorials — Claude Code ecosyste…

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ The easiest way to create a skill is to use the built-in `skill-creator`:
 
 - [How to Create Your First Claude Skill](https://skywork.ai/blog/ai-agent/how-to-create-claude-skill-step-by-step-guide/) - Step-by-step tutorial with examples
 - [How to Use Skills in Claude Code](https://skywork.ai/blog/how-to-use-skills-in-claude-code-install-path-project-scoping-testing/) - Installation, project scoping, and testing guide
+- [awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh) - Trilingual (EN / 繁中 / 简中) staged roadmap for agentic AI; Stage 5 covers the Claude Code ecosystem (Skills, MCP, plugins, subagents), including when to use a Skill vs an MCP server or a subagent. MIT.
 
 ### Video Tutorials
 


### PR DESCRIPTION
I'd like to add awesome-agentic-ai-zh to Written Tutorials.

It's a trilingual (EN / 繁中 / 简中) learning roadmap for agentic AI that I built and maintain. The part most relevant to this list is Stage 5, "Claude Code Ecosystem": it walks through Skills, MCP, plugins, and subagents, with a section on when to use a Skill versus an MCP server or a subagent, plus a hands-on skill-authoring exercise.

I'm suggesting Written Tutorials rather than a blog-post link because it's a sequenced path, not a single article — it answers "how do Skills fit with the rest of the toolkit, and what order do I learn this in." The repo is broader than Claude Skills though (8 stages, LLM basics through multi-agent), so if you'd rather it sit under a different heading, or not at all, that's completely fine.

One note on the name: it ends in -zh because it started as a Chinese-language project, but it's trilingual and the English edition is maintained and CI-checked, not machine-translated.

Repo: https://github.com/WenyuChiou/awesome-agentic-ai-zh