### PR TITLE
Add santifer/career-ops to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[santifer/career-ops](https://github.com/santifer/career-ops)** - 14-skill collection that turns Claude Code into an AI-powered job search command center — JD evaluation, ATS PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R stories, batch processing, and a Go dashboard TUI
+  - Multi-CLI support (Claude Code, OpenCode, Gemini CLI)
+  - README in 9 languages (EN/ES/DE/FR/PT-BR/KO/JA/ZH-CN/ZH-TW)
+  - [Case study](https://santifer.io/career-ops-system) — 740+ offers evaluated, 100+ tailored CVs
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adding **[santifer/career-ops](https://github.com/santifer/career-ops)** (46.5K ⭐ / 9.7K forks) to the **Collections & Libraries** section.

### What it is

A 14-skill collection that turns Claude Code (and OpenCode / Gemini CLI) into an AI-powered job search command center.

### Skills included

- JD evaluation — A-F scoring across 10 weighted dimensions
- ATS-optimized PDF generation per job description (Space Grotesk + DM Sans, keyword-injected)
- Portal scanners — Greenhouse, Ashby, Lever, Wellfound (45+ companies pre-configured)
- Interview prep — STAR+R story bank that builds across evaluations
- Negotiation scripts — salary, geographic discount pushback, competing offer leverage
- Batch processing — `claude -p` parallel sub-agents
- Pipeline integrity — dedup, status normalization, health checks
- Go dashboard TUI — terminal UI to browse, filter, sort the pipeline

### Why it fits Collections & Libraries

Sits naturally alongside [obra/superpowers](https://github.com/obra/superpowers) — same shape: a multi-skill library for Claude Code, not a single skill.

### Social proof (per CONTRIBUTING)

- 46,511 stars / 9,725 forks / 151 open issues (active development)
- MIT licensed, fully OSS — not a SaaS wrapper, no paywall
- README in 9 languages (EN/ES/DE/FR/PT-BR/KO/JA/ZH-CN/ZH-TW)
- [Case study](https://santifer.io/career-ops-system): 740+ offers evaluated, 100+ tailored CVs, Head of Applied AI role landed
- Works with Claude Code, OpenCode, Gemini CLI (multi-CLI)