### PR TITLE
Add building-blog to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[building-blog](https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill)** | Adds an SEO-first, i18n-ready blog to a Next.js + Sanity site via 40-question intake, a one-page plan, and a 20-section spec |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds `building-blog` to **Community Skills → Individual Skills**.

- **Source:** https://github.com/BuildShipGrowRepeat/nextjs-sanity-blog-skill
- **What it does:** Walks 40 intake questions, scans the host project, drafts a one-page plan for approval, then implements an SEO-first, i18n-ready blog on Next.js + Sanity against a 20-section spec with a pass/fail checklist.
- **Standalone value:** No SaaS lock-in. The spec lives in markdown and runs against any Next.js + Sanity v3 project. Optional AI hero images use Gemini 3 Pro Image (Nano Banana Pro) but are not required.
- **License:** MIT, active.