### PR TITLE
feat: add longbridge financial markets skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[longbridge](https://github.com/longbridge/skills/tree/main/skills/longbridge)** | Live financial market data for US/HK/A-share/SG markets via Longbridge CLI |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

- Adds **[longbridge](https://github.com/longbridge/skills/tree/main/skills/longbridge)** to the Individual Skills table
- Longbridge provides live financial market data, trading, and portfolio analysis for US, HK, A-share, and Singapore markets via the Longbridge Securities CLI
- Covers quotes, K-lines, fundamentals, news, options, portfolio management, and institutional data

## Test plan

- [ ] Verify the new row renders correctly in the Markdown table
- [ ] Confirm the link resolves to the correct GitHub URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)