### PR TITLE
Add Skill Locker to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[Skill Locker](https://skilllocker.ai)** - Paid catalog of 296 hand-authored skills across 33 non-developer-first pillars (business, marketing, career, course creation, health & wellness, agency operations, fundraising, community building, personal brand, SEO, and more)
+  - All skills at v1.3.0 — each through 3 Karpathy-loop improvement cycles
+  - [Open catalog dataset](https://skilllocker.ai/skills.json) — JSON metadata, free for tools/research/comparison sites
+  - [Guided discovery surface](https://skilllocker.ai/find) — pick a role + task, get 3 recommended skills
+  - [Free tier](https://skilllocker.ai/auth/login): 5 free skills (anti-slop checker, 3-minute email, 60-second bio, content idea machine, meeting debrief)
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adds [Skill Locker](https://skilllocker.ai) to the **Collections & Libraries** section under Community Skills.

**What it is:** a paid Claude Code skill marketplace with 296 hand-authored skills across 33 categories. Distinctive in this market for being *non-developer-first* — categories include business operations, marketing, career, course creation, health & wellness, agency operations, fundraising, community building, personal brand, and SEO. Most existing collections lean engineering-shaped, so this fills a different audience layer.

**Quality signals:**
- Every skill at v1.3.0 with 3 Karpathy-loop improvement cycles
- Each has a dedicated landing page with description, when-it-triggers, example
- Open catalog dataset published at https://skilllocker.ai/skills.json for tools/comparisons
- Free tier (5 skills, no card required) so the quality bar is verifiable before paying

Happy to revise the entry, slim it down, or omit if it's not a fit. Thanks for the list — it's the most-cited Claude skills resource in the community.