### PR TITLE
Add skill-to-web-prompt to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Skills for working with complex file formats:
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
+| **[skill-to-web-prompt](https://github.com/Ww-Cooooo/skill-to-web-prompt)** | Convert Claude Code skills into self-contained prompts for web AI (DeepSeek, ChatGPT, Doubao) with honest fidelity analysis |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 
 _More community skills coming soon! Submit a PR to add your skill._


### PR DESCRIPTION
Add [skill-to-web-prompt](https://github.com/Ww-Cooooo/skill-to-web-prompt), a Claude Code skill that converts Claude Code skills into self-contained prompts for web AI tools (DeepSeek, ChatGPT, Doubao) with honest fidelity analysis.