### PR TITLE
Add cue — agent profile manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[recodeee/cue](https://github.com/recodeee/cue)** - Agent profile manager — per-directory skill/MCP/plugin isolation with inheritance. Scopes the right loadout per project automatically. `npm i -g cue-ai`
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
cue is a profile manager that scopes skills, MCPs, and plugins per-directory. Pin a profile to a repo, type claude, get only the relevant tools.

- https://github.com/recodeee/cue
- npm: cue-ai
- MIT, 10 agents supported