### PR TITLE
Add capcut-edit (CapCut/JianYing draft editor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[capcut-edit](https://github.com/renezander030/capcut-cli)** | Edit CapCut and JianYing video drafts from the command line. Subtitles, timing, audio, decorators (keyframes, masks, transitions, text/image animations), template apply, long-form-to-shorts cut, multi-language translate. Zero deps (Node only), both CapCut + JianYing namespaces in one binary. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Hi,

Adding **[capcut-edit](https://github.com/renezander030/capcut-cli)** under Community Skills → Individual Skills.

**What it is:** a Claude Code skill that drives [`capcut-cli`](https://github.com/renezander030/capcut-cli), a zero-dependency Node CLI for editing CapCut and JianYing video draft files (`draft_content.json`) directly. No Python, no HTTP server, no MCP daemon — pure deterministic JSON edits.

**Why it belongs:** distinctly different from the existing video-adjacent skills. It's not a generator (Remotion) or an AI model wrapper — it's the **client library for an existing creative tool**, letting agents make precise edits inside drafts that humans review and render in CapCut.

**Highlights:**
- Both CapCut + JianYing namespaces in one binary (most tools are one or the other)
- 60+ tests, 3,700-line schema docs, MIT
- Enum discovery for AI agents (transitions, masks, text effects, scene effects, fonts, audio effects)
- v0.4 ships caption factory (whisper → real caption objects), version migrate/lint, multi-language draft clone
- Bilingual README (EN + 简体中文 — JianYing user base is largely CN)

Repo: https://github.com/renezander030/capcut-cli

Rene