### PR TITLE
Add SocialClaw — social media scheduling and publishing skill for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[socialclaw](https://github.com/ndesv21/socialclaw)** | Social media scheduling and publishing for AI agents — post to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest through one workspace API key. Supports campaigns, media upload, analytics, and draft publishing |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What is SocialClaw?

[SocialClaw](https://github.com/ndesv21/socialclaw) is an agent-first social publishing backend and Claude Code skill. It lets AI agents schedule and publish content across 13 social platforms through one workspace API key.

## Supported Providers

X, LinkedIn (profile + page), Instagram (Business + standalone), Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest

## Install

\`\`\`bash
npx skills add ndesv21/socialclaw
\`\`\`

## What it enables

- Connect/disconnect social accounts via OAuth
- Upload media and get SocialClaw-hosted delivery URLs
- Validate, preview, apply, and inspect scheduled posts and campaigns
- Inspect analytics, account capabilities, run status, and workspace health
- Draft campaigns for staged review before publishing

## Links

- GitHub: https://github.com/ndesv21/socialclaw
- Dashboard: https://getsocialclaw.com/dashboard
- npm: https://www.npmjs.com/package/socialclaw