### PR TITLE
Add LaunchMyStore — universal SKILL.md skill for the LaunchMyStore e-commerce platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[LaunchMyStore](https://github.com/LaunchMyStore/skill)** | Natural-language router for the LaunchMyStore e-commerce platform — scaffolds apps with the `lms` CLI, dispatches App Bridge actions, builds WASM Functions (cart transform / discount / shipping / payment / delivery / order validation), writes Aqua/Liquid themes, and drives the LaunchMyStore MCP server (130+ merchant-store tools). Universal SKILL.md install (also works in OpenAI Codex, Cursor, Gemini CLI, Windsurf). |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds **LaunchMyStore** — a universal SKILL.md skill for the LaunchMyStore e-commerce platform.

A single `/launchmystore` invocation routes plain-English intent to the right developer surface:

- **`@launchmystore/cli`** — scaffold apps, push extensions, build & deploy WASM Functions, tail webhooks
- **`@launchmystore/app-bridge`** + **`@launchmystore/app-bridge-react`** — 21 action families (Toast, Modal, ResourcePicker, SessionToken, TitleBar, …)
- **6 WASM Function types** — cart transform, discount, shipping rate, payment customization, delivery customization, order validation. Compiled locally with Javy, deployed via `lms function deploy --wasm`.
- **Aqua themes** — Liquid-dialect sections, blocks, snippets, section groups, settings schema, and the `{owner}.metafields.{namespace}.{key}` access pattern
- **LaunchMyStore MCP server** — 130+ tools for products, orders, customers, themes, billing, analytics (`chat_with_data`, `nightly_briefing`, etc.)

## Universal install

Built on the open **SKILL.md** standard — works identically in Claude Code, Claude.ai, the Claude API, OpenAI Codex, Cursor, Gemini CLI, Windsurf, Antigravity, Aider, OpenCode, Kilo Code, Augment, Hermes Agent, and Mistral Vibe.

- **npm:** `npm install -g @launchmystore/claude-skill` (postinstall fans out to every detected host)
- **Plugin marketplace:** `/plugin marketplace add LaunchMyStore/skill` then `/plugin install launchmystore@launchmystore`
- **Manual clone:** `git clone https://github.com/LaunchMyStore/skill ~/.skills/launchmystore`

## Repo

<https://github.com/LaunchMyStore/skill> · MIT licensed · v1.1.0

49 files, ~108 KB unpacked: SKILL.md + 10 references (~57 KB total) + worked examples for every function type and theme primitive + an admin-block App Bridge sample.

## Checklist

- [x] Skill is publicly available on GitHub with an open-source licence (MIT)
- [x] Published to npm under `@launchmystore/claude-skill`
- [x] Description is specific and accurate
- [x] No duplicate of an existing entry
- [x] Alphabetical position preserved
