### PR TITLE
Add printnest-worksheets-lite to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[printnest-worksheets-lite](https://github.com/nishidagonyuya/printnest-worksheets-lite)** | Generate ready-to-sell educational worksheet PDFs (Math, Alphabet, Sight Words, Phonics, Cursive) for Etsy/TPT/KDP sellers — pure Python via ReportLab, no AI image cost |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Adding: printnest-worksheets-lite

Hi! I'm a Japanese Etsy / TPT seller in the printable PDF niche. I was spending hours in Canva per worksheet, so I built a Claude Code Skill to generate them for me. Releasing the 5-type LITE version free in case it helps fellow sellers who code.

### What it does
- 5 generators: Kindergarten Math, Alphabet Tracing Pre-K, Sight Words 100, Phonics CVC, Cursive Handwriting
- Pure Python via ReportLab — zero AI image cost
- Outputs print-ready PDFs + 7 Etsy listing thumbnails + ready-to-paste title/tags/description

### Repo
https://github.com/nishidagonyuya/printnest-worksheets-lite

MIT licensed. PDFs you generate are unrestricted (sell freely on Etsy/TPT/KDP/Gumroad/anywhere).

The Individual Skills list currently lacks creator-economy / print-on-demand tooling — I hope this fills a small gap for the seller community using Claude Code. Happy to take feedback / improve.

Thanks for maintaining this list!
