### PR TITLE
Add time-awareness skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[time-awareness](https://github.com/amosshacareer-netizen/time-awareness-skill)** | Gives Claude precise time awareness — fixes stale dates across conversations, detects time gaps, checks memory freshness, calculates countdowns, and handles cross-timezone coordination. Bilingual (EN+中文). |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What is this?

[time-awareness](https://github.com/amosshacareer-netizen/time-awareness-skill) is a lightweight skill that gives Claude precise knowledge of the current date, time, day of week, and timezone by reading the system clock.

## Why it matters

Claude frequently carries stale date context across conversations — you chat on Monday, come back Wednesday, and Claude still thinks it's Monday. This skill fixes that.

## Features

- Cross-platform: Windows (PowerShell), macOS, Linux (Bash)
- Cross-conversation time gap detection
- Memory staleness checking
- Key date countdown calculations
- Cross-timezone coordination
- Bilingual: English + Chinese

## Install

```bash
npx skills add amosshacareer-netizen/time-awareness-skill
```