### PR TITLE
Add autopunk-media-skills (354 media production skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[autopunk-media-skills](https://github.com/ur-grue/autopunk-media-skills)** - 354 production-tested skills for TV producers, journalists, podcasters, YouTubers, and media professionals. Covers development through distribution with quality-evaluated outputs.
+  - 226 skills tested, 98.5% pass rate across binary assertions
+  - 16 categories: TV documentary, journalism, YouTube, podcast, radio, newsletter, PR, screenwriting, data journalism, image prompting, translation, and more
+  - Installation: `git clone https://github.com/ur-grue/autopunk-media-skills.git ~/.claude/skills/autopunk-media-skills`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## New Entry: autopunk-media-skills

**Section:** Collections & Libraries

354 production-tested Claude skills for media professionals — the largest free skill library for TV producers, journalists, podcasters, YouTubers, and content creators.

- 226 skills tested, 98.5% pass rate across binary assertions
- 16 categories covering research through distribution
- Quality-evaluated using a documented G-Eval framework

Repository: https://github.com/ur-grue/autopunk-media-skills
License: MIT