### PR TITLE
Add everything-to-podcast skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[everything-to-podcast](https://github.com/lssuzie/everything-to-podcast)** | Turn any text (PDF, EPUB, TXT, Markdown) into high-quality audiobooks or podcasts. AI reads and summarizes, then TTS generates audio with sentence-boundary slicing and checkpoint resume. Supports Chinese and English. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add [everything-to-podcast](https://github.com/lssuzie/everything-to-podcast) to Individual Skills

**What it does:** Turn any text (PDF, EPUB, TXT, Markdown) into high-quality audiobooks or podcasts. Two modes:
- **AI代读模式**: AI reads, summarizes each chapter, then generates a podcast audio
- **全文朗读模式**: Full text converted to audiobook with TTS

**Key features:**
- Sentence-boundary slicing (100 char max) for stable audio quality
- Checkpoint resume — picks up where it left off after interruptions
- Multi-format: PDF, EPUB, TXT, Markdown
- Chinese and English TTS support
- NFKC encoding normalization for OCR/PDF sources
- Works with Claude Code, Codex CLI, and 20+ agent platforms via open SKILL.md standard

**Install:**
```bash
npx skills add lssuzie/everything-to-podcast
```