### PR TITLE
Add Walter Skills to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Skills for working with complex file formats:
   - Uses new techniques that are still being refined and tested (i.e. skills here may change over time)
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
+ 
+  - **[walterwritesai/walter-skills](https://github.com/walterwritesai/walter-skills)** - 12 drop-in markdown skills for Claude projects covering SEO content writing, AI humanization, AI detection, keyword preservation, agency QC, local SEO, programmatic SEO, content repurposing, and brand voice
+  - Each skill follows the Agent Skills spec with YAML frontmatter
+  - Invokes Walter Writes AI tools via MCP for humanization and detection
+  - MIT licensed
 
 
 ### Individual Skills


### PR DESCRIPTION
Adds Walter Skills to the Community Skills > Collections & Libraries section, linking to [https://github.com/walterwritesai/walter-skills](https://github.com/walterwritesai/walter-skills).

Walter Skills is a public MIT-licensed collection of 12 drop-in markdown skills for Claude projects, covering SEO content writing, AI humanization, AI detection, keyword preservation, agency QC, local SEO, programmatic SEO, content repurposing, and brand voice. Each follows the Agent Skills spec with YAML frontmatter and invokes Walter Writes AI tools via MCP for humanization and detection.

Entry uses the same indentation and sub-bullet pattern as the existing obra/superpowers entry in this section.

Happy to adjust wording, sub-bullets, or scope if helpful.