### PR TITLE
Add sovacount + savings-mirror (caveman companion tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[sovareq/sovacount](https://github.com/sovareq/sovacount)** - Scope-level LLM tier-router (Haiku/Sonnet/Opus). MIT, Rust. Real-Anthropic benchmark in repo (88% saved on 5-task sample). Companion to caveman.
+- **[sovareq/savings-mirror](https://github.com/sovareq/savings-mirror)** - Read-only USD-savings dashboard for Claude Code. Parses `~/.claude/projects/` JSONL transcripts, splits tier-savings vs caveman-savings per day. MIT, Rust.
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
Two MIT companion tools added under **Community Skills → Tools**:

- **[sovacount](https://github.com/sovareq/sovacount)** — scope-level LLM tier-router (Haiku/Sonnet/Opus). Rust workspace. Includes a [real-Anthropic benchmark](https://github.com/sovareq/sovacount/tree/main/benchmark) (88% saved on a 5-task sample, raw data + methodology committed).
- **[savings-mirror](https://github.com/sovareq/savings-mirror)** — read-only USD-savings dashboard for Claude Code. Parses `~/.claude/projects/` JSONL transcripts, splits **tier-savings** vs **caveman-savings** per day. Local, no telemetry.

Both pair with the existing **caveman** skill (token compression):
- caveman cuts cost on *which tokens* are sent
- sovacount cuts cost on *which model* runs them
- savings-mirror measures both, post-hoc, in USD

Both Rust, MIT, zero telemetry, pure consumers of Claude Code's existing JSONL format. No proxy, no man-in-the-middle.

Placed in the existing **Tools** subsection (not Individual Skills) since they're companion tools rather than SKILL.md-based skills.