### PR TITLE
Add hermes-supercode-skills: 13 production-grade Claude Code skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[hermes-supercode-skills](https://github.com/mturac/hermes-supercode-skills)** | 13 production-grade Claude Code skills: db-whisperer, auth-architect, obs-guardian, deploy-ninja, quantum-debugger, api-sculptor + 8 more. Each skill follows Recon→Plan→Execute→Verify with structured JSON output and tiered safety rails. Also available for [Codex](https://github.com/mturac/hermes-supercode-skills-codex). |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What's this?

[hermes-supercode-skills](https://github.com/mturac/hermes-supercode-skills) is a collection of 13 production-grade Claude Code skill modules:

- **db-whisperer** — Query optimization, indexing, schema migrations
- **auth-architect** — OAuth2/OIDC, JWT, RBAC, SSO, MFA
- **obs-guardian** — OpenTelemetry, structured logging, Prometheus/Grafana, SLOs
- **deploy-ninja** — Zero-downtime deployments, canary, blue-green, rollback
- **quantum-debugger** — Race conditions, memory leaks, performance profiling
- **security-sentinel** — Security audits, vulnerability scanning
- **api-sculptor** — REST/GraphQL/gRPC design, OpenAPI specs
- **pipeline-architect** — ETL/ELT pipelines, streaming, data warehouse
- **ghost-scraper** — Ethical web scraping
- **mcp-conductor** — Multi-agent task orchestration
- **prediction-alpha** — Prediction market analysis
- **prompt-forge** — LLM prompt engineering
- **infra-automation** — DNS, SSL, Cloudflare Workers, CDN

Each skill follows Recon→Plan→Execute→Verify with structured JSON output and tiered safety rails.

Also available for OpenAI Codex: https://github.com/mturac/hermes-supercode-skills-codex