### PR TITLE
Add yield-intelligence — passive income portfolio analysis skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[yield-intelligence](https://github.com/thebrierfox/yield-intelligence-skill)** | Passive income portfolio analysis — scans US Treasuries, dividend ETFs, and REITs; builds allocations targeting a specific monthly income goal. *By [@thebrierfox](https://github.com/thebrierfox)* |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[yield-intelligence](https://github.com/thebrierfox/yield-intelligence-skill)** to the Individual Skills table.

**What it does:** Passive income portfolio analysis — scans US Treasuries, dividend ETFs, and REITs; builds allocations targeting a specific monthly income goal.

**When it activates:**
- "I want to generate $X/month in passive income"
- "What are the best dividend ETFs right now?"
- "Build me a conservative income portfolio"
- "How much capital do I need to retire on dividends?"

**Two modes:**
1. **Standalone** (no config needed) — structured 4-step workflow with scoring formula and output template
2. **MCP-backed** — connects to `https://api.intuitek.ai/yield/mcp` for live Treasury rates and AI-optimized portfolio construction

**Skill format:** SKILL.md with YAML frontmatter, follows progressive disclosure architecture. Compatible with Claude.ai, Claude Code, and API.

Repository: [thebrierfox/yield-intelligence-skill](https://github.com/thebrierfox/yield-intelligence-skill) — MIT License
Built by [IntuiTek¹](https://intuitek.ai) (~K¹)