### PR TITLE
Add regulex-plus skill to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[regulex-plus](https://github.com/PipeDream941/regulex-plus)** | JavaScript regex visualizer that renders railroad SVG/PNG diagrams from the CLI; native CJK support, dark/light themes, auto-invoked when explaining or debugging regex |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [regulex-plus](https://github.com/PipeDream941/regulex-plus) to Individual Skills. It's a JavaScript regex visualizer shipped both as a Claude Skill (`SKILL.md` at repo root) and a Node CLI.

- Repo: https://github.com/PipeDream941/regulex-plus
- Live demo: https://pipedream941.github.io/regulex-plus/
- CLI usage: ``npx regulex-plus '<regex>' --out diagram.png``

**Social proof / why it belongs here**:
- MIT-licensed fork of the well-known [CJex/regulex](https://github.com/CJex/regulex) with active CJK + UI fixes
- Live GitHub Pages demo with bilingual UI, dark/light themes
- Ships both a web app and a Node CLI driven by Playwright
- `SKILL.md` documents when Claude should auto-invoke it (explaining/debugging/optimizing regex, CJK patterns, post-generation verification)

The CLI side is genuinely new and useful for headless agent workflows — you can render a regex diagram inside a Claude Code session and inline it into a PR or docstring.