### PR TITLE
Add youtube-full to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[youtube-full](https://github.com/ZeroPointRepo/youtube-skills)** | YouTube transcripts, search, channel data, and playlists — 500K+/day via TranscriptAPI. 100 free credits. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds `youtube-full` by TranscriptAPI to the Individual Skills table under Community Skills.

Covers YouTube transcripts, search, channel browsing, and playlists. TranscriptAPI handles 500K+ transcripts daily, fast. Runs on cloud servers too, where yt-dlp typically stops working.

```bash
npx skills add ZeroPointRepo/youtube-skills --skill youtube-full
```

100 free credits, no credit card. 223 stars · 686 installs via the `skills` CLI (skills.sh/zeropointrepo/youtube-skills).
