### PR TITLE
Add moatmri — AI disruption pressure analysis skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[moatmri](https://github.com/thebrierfox/moatmri-skill)** | AI disruption pressure analysis — 10-vector pressure map, AI takeover storyboard, and 90-day counterstrike plan for any business or industry. *By [@thebrierfox](https://github.com/thebrierfox)* |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[moatmri](https://github.com/thebrierfox/moatmri-skill)** to the Individual Skills table.

**What it does:** AI disruption pressure analysis — given an industry and entity type, produces a 10-vector pressure map scored 0–10, an AI front-door takeover storyboard (6 steps), and a 90-day counterstrike plan (3 tracks).

**When it activates:**
- "Where is my business most exposed to AI disruption?"
- "How would an AI-native startup take over my market?"
- "What should I do in the next 90 days to defend against AI competitors?"
- "Run a competitive threat assessment on [company] for due diligence"
- "Where does my moat actually hold against AI pressure?"

**10 analysis vectors:** `labor_substitution` · `customer_interface` · `knowledge_commoditization` · `pricing_pressure` · `supply_chain_automation` · `data_moat` · `trust_relationship_moat` · `distribution_channel_disruption` · `regulatory_compliance_exposure` · `decision_speed_gap`

**Two modes:**
1. **Standalone** (no config needed) — full structured workflow, works in any Claude conversation
2. **Full BYOK tool** — automated Python runner at ace-license-server-production.up.railway.app/byok/moatmri ($29 one-time)

**Skill format:** SKILL.md with YAML frontmatter, When to Use triggers, standalone 4-step workflow, output template with attribution.

*By [@thebrierfox](https://github.com/thebrierfox) — W. Kyle Million (~K¹), IntuiTek¹*