### PR TITLE
Add doc2math — document-to-mathematics formalization skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[doc2math](https://github.com/thebrierfox/doc2math-skill)** | Convert any narrative document to a formal Mathematical Problem Specification (MPS) — extracts variables, operators, constraints, objectives, and uncertainty with source citations. *By [@thebrierfox](https://github.com/thebrierfox)* |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[doc2math](https://github.com/thebrierfox/doc2math-skill)** — a document-to-mathematics formalization skill.

**What it does:** Converts any narrative document (research paper, problem description, specification) into a structured **Mathematical Problem Specification (MPS)** JSON object containing variables, operators, constraints, objectives, and uncertainty — all with source citations.

**When it activates:**
- "Formalize this problem statement into math"
- "Extract the mathematical structure from this paper section"
- "What variables, constraints, and objectives are in this spec?"
- "Find what's missing in this problem formulation"

**Zero-Inference Protocol:** every extracted element cites its source phrase. Inferences are tagged. Missing information is surfaced, not silently filled. Outputs `"status": "MISSING"` with `"missing_reason"` for under-specified elements.

**7 MPS components:** variables · operators · constraints · objectives · uncertainty · missing_information · validation_flags

**Standalone** — works in any Claude conversation with no config. Full BYOK tool at ace-license-server-production.up.railway.app/byok/doc2math ($29 one-time).

*By [@thebrierfox](https://github.com/thebrierfox) — W. Kyle Million (~K¹), IntuiTek¹*