### PR TITLE
Add doaipm skill (DO AI PM method)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[doaipm](https://github.com/zhitongblog/doaipm-skill)** | The DO AI PM method — turn an idea into a real, runnable prototype by describing intent. Speak it, AI builds it; high-fidelity first; five-phase workflow (Discover → Define → Design → Develop → Validate). Works with Claude Code, Codex, Cursor, and Gemini CLI |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding **doaipm** to Community → Individual Skills.

[doaipm](https://github.com/zhitongblog/doaipm-skill) is the DO AI PM method as a portable skill — turn an idea into a real, runnable prototype by describing intent. *Speak it, and AI builds it.* High-fidelity first; five-phase workflow; built-in safety net.

- Real use case: [doaipm.com](https://doaipm.com) (8 languages) + shipping products (SoloMD, Unterm, unfetch, StoryAlter, Unflick) were all built with it.
- Standard `SKILL.md` format; works with Claude Code, Codex, Cursor, Gemini CLI. MIT.