### PR TITLE
Add awesome-mental-models to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[machinarii/awesome-mental-models](https://github.com/machinarii/awesome-mental-models)** - Library of 249 mental models plus a skill that interviews you, picks the right framework for your situation, and walks you through it as a working session
+  - Covers decisions, problem-solving, strategy, planning, evaluation, sense-making, risk, and communication
+  - One markdown file per model (Overview / How to Use It / Example / Takeaway / Source)
+  - Installation: clone and run `./install.sh` to wire the skill into `~/.claude/skills/`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## What this adds

[**machinarii/awesome-mental-models**](https://github.com/machinarii/awesome-mental-models) — a library of 249 mental models plus a Claude Code skill that interviews the user, picks the right framework for their situation, and walks them through it as a working session (not a lecture).

Added under **Community Skills → Collections & Libraries**.

## Quality
- [x] Related to Claude Skills — bundles a Claude Code skill (`SKILL.md`) + a 249-model reference library
- [x] Non-promotional — fully open source (MIT), no SaaS dependency or paywall
- [x] Standalone value — works entirely offline/locally
- [x] Accurate, formatted entry matching the existing Collections & Libraries style

🤖 Generated with [Claude Code](https://claude.com/claude-code)