### PR TITLE
docs: add Wikify to community individual skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| [Wikify](https://github.com/Misaka16384/Wikify) | An AI agent skill to automatically transform unstructured academic literature (PDF/LaTeX) into a structural Obsidian Markdown knowledge graph with self-healing capabilities. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Hi @travisvn,

I'd love to contribute Wikify to the `Individual Skills` section.

Wikify is an open-source agentic workflow/skill designed for AI assistants like Claude Code. It automates the ingestion of academic literature (PDFs and LaTeX), extracts core mathematical concepts, and parses them into a deduplicated, twin-linked Obsidian Markdown knowledge graph. It also features autonomous self-healing for LLM syntax/YAML formatting errors.

I have added it to the `Individual Skills` table. Thank you for maintaining this awesome list!
