### PR TITLE
Add llm-wiki-manager and prompt-architect to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** | Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. 8 operating modes. |
+| **[prompt-architect](https://github.com/sametbrr/prompt-architect)** | Turns any rough idea into a domain-classified, quality-reviewed expert prompt — 25-domain taxonomy, 8 quality gates, TR and EN support. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What this adds

Two Claude Code community skills to the Individual Skills table:

### [llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)
Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
- ⭐ 37 stars | 7 forks | MIT

### [prompt-architect](https://github.com/sametbrr/prompt-architect)
Turns any rough idea into a domain-classified, quality-reviewed expert prompt — 25-domain taxonomy, 8 quality gates, works in TR and EN.
- MIT