### PR TITLE
Add Forward Deployed Selling — Claude skill for enterprise AI sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[forward-deployed-selling](https://github.com/vonarmen-wq/forward-deployed-selling)** | Claude skill for enterprise AI sales: ICP qualification, GTM strategy, stage diagnosis, and deal thesis generation. Free and open-source. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds [Forward Deployed Selling](https://github.com/vonarmen-wq/forward-deployed-selling) to the **Community Skills → Individual Skills** table.

## About the Skill

**Forward Deployed Selling** is a free, open-source Claude skill purpose-built for enterprise AI sales workflows. It covers:

- **ICP Qualification** — AI-driven scoring of Ideal Customer Profile fit
- **GTM Strategy** — Adaptive go-to-market strategy for complex enterprise deals
- **Stage Diagnosis** — Deal stage and health diagnostics
- **Deal Thesis Generation** — Structured deal narratives for internal alignment and champion enablement

Built by [Angel Armendariz](https://forwarddeployedselling.com), Principal at AWS and enterprise AI strategist.

## Why It Belongs Here

This is a genuinely useful open-source Claude skill for a specific professional domain (enterprise B2B sales) that doesn't yet appear in any curated list. It follows the Claude Skills format (SKILL.md + YAML frontmatter) and loads progressively.