### PR TITLE
Add first-principles-destructor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[first-principles-destructor](https://github.com/reshadat/first-principles-destructor)** | Strips any assumption, business model, or process down to its physics/math/logic floor. Calculates the convention tax. Rebuilds from reality. Works across Claude Code, Claude.ai, Codex CLI, Gemini CLI, Cursor, and Kiro. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [first-principles-destructor](https://github.com/reshadat/first-principles-destructor) to the Individual Skills table.

Strips any assumption, business model, or process down to its physics/math/logic floor. Calculates the **convention tax** (what you pay because of habit, not necessity). Rebuilds from reality via a 6-stage destruction process.

Works across Claude Code, Claude.ai, OpenAI Codex CLI, Gemini CLI, Cursor, and Amazon Kiro — single SKILL.md, platform-specific files for Cursor (.mdc) and Kiro (.kiro/steering), plus install.sh for one-command setup.