### PR TITLE
Add skills_library (Cleo Labs) to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[skills_library (Cleo Labs)](https://github.com/Cleo-Labs-IA/skills_library)** | 45 product-compliance skills (cosmetics, food, electronics, toys, textiles, supplements, medical devices, customs, recalls, claims, sustainability) — installable directly or via MCP server (`npx -y @cleo-labs/skills-mcp@latest`). MIT |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [Cleo-Labs-IA/skills_library](https://github.com/Cleo-Labs-IA/skills_library) to the Community Skills > Individual Skills table.

## What it is

45 production-grade product-compliance skills for small businesses selling physical products across multiple markets. Covers cosmetics, food, electronics, toys, textiles, supplements, medical devices, customs, recalls, claims, sustainability — across EU, US, UK, CA, JP, KR, CN, ASEAN.

## How to use

Two install paths:

1. **As Claude Code skills** — clone the repo and drop the skills into your `.claude/skills/` folder.
2. **As an MCP server** — `npx -y @cleo-labs/skills-mcp@latest` and the same 45 skills become MCP resources, prompts, and tools (`list_skills`, `find_skill`, `read_skill`).

## On the "no SaaS funnel" guideline

These skills are not gated behind a paid API. The skills work standalone — they describe regulations, walk through compliance workflows, cite primary legislation, and tell you what evidence to gather. They optionally use the Cleo Legal API (`mcp__claude_ai_CLEO_LEGAL_API__*`) for richer database lookups, but every skill has a clearly-marked "without MCP" fallback that uses web search and manual workflows. The npm package, the MCP server, and the skills themselves are all MIT.

License: MIT.