### PR TITLE
Add BuilderStudio Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Skills for working with complex file formats:
 
 ### Development
 
+* [BuilderStudio Skills](https://github.com/wundercorp/builderstudio-skills) - WunderCorp's public BuilderStudio skillset catalog with reusable agent skills for repeatable AI development workflows that pair with Pathways, MCP integrations, Hermes-powered contained execution, and Agentic Swarms.
+
+
 - **[frontend-design](https://github.com/anthropics/skills/blob/main/skills/frontend-design)** - Instructs Claude to avoid "AI slop" or generic aesthetics and to make bold design decisions. Works very well for React & Tailwind.
 - **[web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder)** - Build complex claude.ai HTML artifacts using React, Tailwind CSS, and shadcn/ui components
 - **[mcp-builder](https://github.com/anthropics/skills/tree/main/skills/mcp-builder)** - Guide for creating high-quality MCP servers to integrate external APIs and services


### PR DESCRIPTION
## Description

Adds BuilderStudio by WunderCorp to this curated list.

BuilderStudio is a native macOS agentic coding workspace for builders and teams that want to create software locally and securely without being locked into a single AI provider. It combines AI coding agents, reusable Skills, guided Pathways, MCP integrations, local/cloud execution, terminal workflows, app previews, packaging/deployment support, Hermes-powered contained execution, Agentic Swarms for parallel specialized agents, and flexible routing across 380+ AI models.

## Why it fits

- Native macOS workspace for local-first agentic development.
- Hermes-powered contained execution for safer local agent runs.
- Agentic Swarms for running multiple specialized Hermes lanes in parallel through Colima/Docker.
- Reusable Skills and guided Pathways for repeatable AI development workflows.
- MCP integrations, workflow creator UI, app previews, source editing, terminal workflows, packaging, and deployment support.
- Flexible routing across 380+ AI models instead of locking teams into one provider.

## Verification

This is a Markdown/list-entry-only contribution. I checked that the entry uses public BuilderStudio links and follows the target repository's existing curated-list style as closely as possible.

## Checklist

- [x] This PR is a Markdown/list-entry-only BuilderStudio submission.
- [x] The entry uses public links for BuilderStudio and BuilderStudio Skills.

## Links

- Website: https://builderstudio.dev
- Skills catalog: https://github.com/wundercorp/builderstudio-skills
- WunderCorp on X: https://x.com/wundercorp

## Links

- Website: https://builderstudio.dev
- Skills catalog: https://github.com/wundercorp/builderstudio-skills
- WunderCorp on X: https://x.com/wundercorp
