### PR TITLE
docs: add Claude Skills 中文市集 (Chinese skills resource) to Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[Claude Skills 中文市集](https://claudeskill.me)** - Chinese-language deep-dive library covering 100+ Claude Code Skills (superpowers, oh-my-claudecode, ecc, gstack, and more)
+  - One article per skill: use cases, internals, mermaid flowcharts
+  - AI-drafted, human-audited
+  - Source: [fanshanhong/claude-skills-cn](https://github.com/fanshanhong/claude-skills-cn)
+
 
 ### Individual Skills
 


### PR DESCRIPTION
This list is great for English readers; adding a Chinese-language counterpart so non-English Claude Code users can also navigate the Skills ecosystem.

- Site: https://claudeskill.me (104+ articles, growing)
- Each article walks through one Skill: when to use, internals, and a mermaid flow diagram
- Covers superpowers, oh-my-claudecode, ecc, gstack and other major suites listed in this README
- Open source: https://github.com/fanshanhong/claude-skills-cn
- Content is AI-drafted with a manual audit step before publish

Happy to adjust placement/wording if a different section fits better.