### PR TITLE
Add RunAPI MCP Server to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[RunAPI MCP Server](https://github.com/runapi-ai/mcp)** | 130+ AI models for image, video, music, audio, and LLM generation from 18 providers. MCP server with free catalog tools. `npx @runapi.ai/mcp` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds RunAPI MCP Server — 130+ AI models for image, video, music, audio, and LLM from 18 providers. Free catalog tools. npm: @runapi.ai/mcp. GitHub: https://github.com/runapi-ai/mcp