### PR TITLE
Add double-check skill (AI self-review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[double-check](https://github.com/LouisLin0723/double-check)** | Forces the AI to rigorously self-review its own work before shipping — catches the bugs, holes & hallucinations it missed the first pass (bidirectional review + reverse rebuttal + 13/21/18 domain checklists) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **double-check** to Individual Skills.

A skill that forces the AI to rigorously self-review its own output before you ship — bidirectional reasoning (0→100 + 100→0), reverse rebuttal (the AI argues against its own work), and domain-specific checklists (13 for features / 21 for code / 18 for algorithms). Goal: catch the bugs and hallucinations the first pass missed.

MIT licensed, open source. Thanks for maintaining this list! 🙏