### PR TITLE
Add Borjablm/claude-skills to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[Borjablm/claude-skills](https://github.com/Borjablm/claude-skills)** - Five Claude Code skills built for sustainability consulting workflows: programmatic chart and image generation, a five-stage SEO content pipeline with adversarial writer/editor passes, a Google Search Console audit framework, multi-site WordPress REST publishing, and regulatory site-visit prep
+  - Includes a setup wizard for brand colors and uses progressive disclosure (metadata ~100 tokens, full skill body ~5,000 tokens loads only when relevant)
+  - [Hub page with skill descriptions and architecture rationale](https://azvai.com/en/claude-skills/)
+  - License: MIT
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adds a new entry under Community Skills > Collections & Libraries for **[Borjablm/claude-skills](https://github.com/Borjablm/claude-skills)**, a small library of five Claude Code skills for sustainability consulting workflows. The skills are MIT-licensed, open source, and used in real consulting practice (article workflow, SEO audits, multi-site WordPress publishing, regulatory site-visit prep).

The hub page at [azvai.com/en/claude-skills](https://azvai.com/en/claude-skills/) documents each skill's architecture rationale, including the progressive-disclosure pattern (metadata ~100 tokens, body ~5,000 tokens loads only when relevant) and sub-agent isolation between pipeline stages.

The entry follows the existing format used for other entries in the section (obra/superpowers, obra/superpowers-lab).

License: MIT. No paid tier, no SaaS dependency, no signup required to use.