### PR TITLE
Add tracedocs to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[tracedocs](https://github.com/wxggzz/tracedocs)** | Evidence-grounded project docs that cite their sources, plus an AI-ready index.json; never invents deployment steps |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[tracedocs](https://github.com/wxggzz/tracedocs)** to the Community Skills table.

tracedocs is a Claude Code skill that turns any codebase into an evidence-grounded Markdown documentation package plus a machine-readable `index.json`. Every operational/deployment claim cites its source file and carries a confidence label (Verified / Inferred / Unknown / Needs confirmation); it never invents deployment steps and records gaps instead.

- Repo: https://github.com/wxggzz/tracedocs
- License: MIT
- Validated sample output committed at `examples/study-docs/`
- Installable as a Claude Code plugin (`/plugin install`) or by copying the skill

Thanks for maintaining the list!