### PR TITLE
Add optibot skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[optibot](https://github.com/Optimal-AI/optibot-skill)** | AI code review for GitHub & GitLab — review changes, compare branches, run on-demand security scans, and manage API keys from Claude Code |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **optibot** to Community → Individual Skills.

[optibot](https://github.com/Optimal-AI/optibot-skill) is a Claude Code skill for AI code review on GitHub & GitLab — review local changes, compare branches, run on-demand security scans, and manage API keys without leaving your session. Public repo with a valid `.claude-plugin/marketplace.json`.

Installable via: `/plugin marketplace add Optimal-AI/optibot-skill`