### PR TITLE
Add ai-shortfilm-prompts to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[ShellWard Security Guide](https://github.com/jnMetaCode/shellward/tree/main/skills/security-guide)** | AI agent security middleware — 8-layer defense with prompt injection detection (32 rules), DLP data flow tracking, dangerous command blocking, PII scanning. Install: `npx clawhub install shellward-security-guide` |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[ai-shortfilm-prompts](https://github.com/jnMetaCode/ai-shortfilm-prompts)** | Cinematic AI video prompts via a 5-stage director's structure (transformations, multi-shot narratives, weapon-charge/combat) — model-agnostic across Seedance, Sora, Kling, Veo, with a negative-prompt prefab, failure→fix gallery, and per-model compatibility notes |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[ai-shortfilm-prompts](https://github.com/jnMetaCode/ai-shortfilm-prompts)** to the Individual Skills table.

It's a Claude Code skill (`shortfilm-prompt`) that generates cinematic AI-video prompts using a 5-stage director's structure (core theme → character/scene → atmosphere+camera/lens → camera rules → per-second/per-shot storyboard). Model-agnostic across Seedance 2.0, Sora, Kling, Veo, Hailuo, Wan, Runway, Pika.

Beyond the skill itself the repo ships a methodology writeup, an IP-stripped template library, a reusable negative-prompt prefab, a failure→fix gallery, and a machine-readable prompt index — all bilingual EN/中文. MIT-licensed. Dead-link CI is green.

One-line entry only; appended to the end of the Individual Skills table to match the existing format.