### PR TITLE
Add offer-helper — Chinese job-hunting skill (resume tailoring + mock interview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[offer-helper](https://github.com/dominciyue/resume_skill)** | Chinese-language job-hunting skill: ingests your resume, GitHub repos, and docs into a persistent experience library, tailors STAR/XYZ-quantified resumes to any job description with strict anti-fabrication, and runs big-tech-style progressive ("由浅及深") mock interviews grounded in your actual resume |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What it is
**offer-helper** is a Chinese-language Agent Skill for job seekers (students & early-career). It covers the full loop:

1. **Ingest** — pull your resume, GitHub repos, and other docs into one persistent, incrementally-updatable experience library.
2. **Tailor resume** — analyze a job description, rewrite matching experiences in quantified STAR/XYZ form against top-tier resume standards, and output an A4 HTML resume + a match report.
3. **Mock interview** — a big-tech interviewer that anchors on the technical points in *your* resume and drills progressively (由浅及深) until it finds your knowledge boundary.

## Why it's a good fit (per CONTRIBUTING)
- **Standalone value, no SaaS wrapper**: free, open-source, MIT. No paid API/subscription required to function.
- **Strict anti-fabrication**: every bullet must trace back to real source material; missing numbers stay blank rather than being invented. Verified by 4 end-to-end acceptance scenarios in `tests/`.
- Cross-runtime aware (Claude Code / Claude.ai / Cursor); pure Markdown + one HTML template, no network code — auditable in minutes.
- Includes `SKILL.md` with name/description frontmatter and full documentation.

## Link
- Repo: https://github.com/dominciyue/resume_skill (MIT)

Added one row to the **Individual Skills** table following the existing pattern.