### PR TITLE
Add proof to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[proof](https://github.com/EricFinland/proof)** | Stop hook + independent verifier that fact-checks an agent's completion claims ("tests pass", "it works", "deployed") and returns PASS/FAIL/INCONCLUSIVE with receipts |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[proof](https://github.com/EricFinland/proof)** to Community > Individual Skills.

Proof is a Claude Code Stop hook + independent verifier that fact-checks an agent's completion claims ("tests pass", "it works", "deployed"). When the agent claims a task is done, an independent verifier runs the real checks (tests, build, http, repro, and more) and returns a strict PASS/FAIL/INCONCLUSIVE verdict with the actual command output as receipts.

- Pure Python standard library, no dependencies
- Cross-platform CI (Linux + Windows, Python 3.11-3.13), 71 tests
- MIT licensed

Repo: https://github.com/EricFinland/proof