### PR TITLE
feat: add TWZRD Agent Intel — Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Skills for working with complex file formats:
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 
+| **[twzrd-agent-intel](https://intel.twzrd.xyz)** | Solana-native x402 MCP server for AI agent trust scoring. 4 free tools score any wallet; `get_trust_receipt` pays via HTTP 402 + USDC. Zero-install: `claude mcp add twzrd-agent-intel --transport http https://intel.twzrd.xyz/mcp` |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
## Summary

Adds **TWZRD Agent Intel** to the Individual Skills table under Community Skills.

**Name**: [twzrd-agent-intel](https://intel.twzrd.xyz)
**Description**: Solana-native x402 MCP server for AI agent trust scoring. 4 free tools score any wallet; `get_trust_receipt` pays via HTTP 402 + USDC. Zero-install.

**Zero-install config**:
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

Or via CLI: `claude mcp add twzrd-agent-intel --transport http https://intel.twzrd.xyz/mcp`

**Tools available**:
- `resolve_agent` — resolve wallet address to known agent identity
- `score_agent` — compute trust score (free)
- `preflight_check` — preflight before transacting with an agent (free)
- `verify_trust_receipt` — verify a signed V5 trust receipt (free)
- `get_trust_receipt` — issue a signed V5 trust receipt (paid via x402 / HTTP 402 + USDC)

**Available on**: PyPI as `twzrd-agent-intel`, Streamable HTTP endpoint at https://intel.twzrd.xyz/mcp

Fits alongside the existing MCP-builder skill entry in the Development section and complements the Skills vs MCP section in the README.