### PR TITLE
Add localization-skill — marketing transcreation for 6 languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Skills for working with complex file formats:
 ### Communication
 
 - **[brand-guidelines](https://github.com/anthropics/skills/tree/main/skills/brand-guidelines)** - Apply Anthropic's official brand colors and typography to artifacts
-- **[internal-comms](https://github.com/anthropics/skills/tree/main/skills/internal-comms)** - Write internal communications like status reports, newsletters, and FAQs
+- **[internal-comms](https://github.com/anthropics/skills/tree/main/skills/internal-comms)** - Write
+- * **[localization-skill](https://github.com/ilariaislwj-lang/localization-skill)** - Marketing transcreation for 6 languages (Chinese, Japanese, Korean, Spanish, French) — adapts idioms, cultural references, and platform tone, not just words internal communications like status reports, newsletters, and FAQs
 
 ### Skill Creation
 


### PR DESCRIPTION
Adds localization-skill to Communication sdds localization-skill to the Communication section.

A transcreation skill for marketing copy that goes beyond 
word-for-word translation — adapts idioms, cultural references, 
and platform norms for Chinese (Simplified+Traditional), 
Japanese, Korean, Spanish, and French.

Each language has a dedicated reference file. Output always 
includes literal + localized versions with notes explaining 
what was changed and why.

Not sure if Communication is the best fit — happy to move 
it if you'd prefer another section.ection