### PR TITLE
Add baldurs-gate-3-claude-skills - gaming skill pack for BG3

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Skills for working with complex file formats:
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 
+| **[baldurs-gate-3-claude-skills](https://github.com/atasayugras/baldurs-gate-3-claude-skills)** | 14 skills for Baldur's Gate 3: boss tactics, build planner, quest tracker, achievement checker, loot advisor, and camp inventory manager |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
## Description

14 Claude Code skills for Baldur's Gate 3 gameplay.

**Skills included:** boss tactics, build planner, quest tracker, achievement checker, loot advisor (structured question flow), and camp inventory manager.

**Architecture:** Skills reference each other's local data files - no web fetching during play. Data lives in `references/` subdirectories, separate from skill logic so community can update patch-changed data without touching behavior.

**Repo:** https://github.com/atasayugras/baldurs-gate-3-claude-skills