### PR TITLE
Add InferSports skill — live Asian odds & scores (read-only, keyless)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[InferSports](https://github.com/infersports/infersports-skill)** | Live Asian-priced football & basketball odds, scores, sharp betting lines, and odds-format conversion over a read-only, keyless API |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **InferSports** under Community Skills → Individual Skills.

Live Asian-priced football & basketball odds, scores, sharp betting lines, and odds-format conversion over a read-only, **keyless** REST API (no account or API key needed). Installable in Claude Code as a plugin (`/plugin marketplace add infersports/infersports-skill` then `/plugin install infersports@infersports`) or as a portable skill folder for any agent.

- Repo: https://github.com/infersports/infersports-skill
- License: MIT
- Read-only & informational — it reports odds/scores/lines and never places, recommends, or sizes a bet.

Verified: offline mock (`INFERSPORTS_MOCK=1`) and live keyless both work.