### PR TITLE
Add ltx2-vidgen-skill (self-hosted LTX-2.3 video) to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[ltx2-vidgen-skill](https://github.com/patraxo/ltx2-vidgen-skill)** | Self-hosted LTX-2.3 (22B) AI video in Claude Code — deploys your own Modal serverless-GPU backend, then generates text/image/keyframe/video-to-video + canny/depth/pose control with synced audio |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[ltx2-vidgen-skill](https://github.com/patraxo/ltx2-vidgen-skill)** to the Community → Individual Skills table.

**What it is:** a Claude Code skill that deploys your *own* LTX-2.3 (22B) video backend to your Modal serverless-GPU account, then drives it from Claude Code — drop a photo, get a video. No SaaS, no per-clip meter; the GPU and bill are yours.

**Modes:** text-to-video, image-to-video, keyframe interpolation, video-to-video (retake/restyle), and IC-LoRA canny/depth/pose control — with synced audio. Batch (`--variations` / `--prompts-file`) and reel/YouTube/square format presets.

**Why list it:** it's an open (MIT-style), installable skill (`npx skills add patraxo/ltx2-vidgen-skill`), v1.0.0 tagged, CI-linted SKILL.md, and a working demo in the README. Optimized stack (resident pipeline + caches + torch.compile, bf16, ~1.96× faster, output bit-identical) — clips a few cents each on Modal's RTX PRO 6000.

Single-line addition to the Individual Skills table; follows the existing format. Author submission.