### PR TITLE
Add XMemo memory skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Skills for working with complex file formats:
 | --- | --- |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
+| **[xmemo-memory](https://github.com/yonro/memory-os-cli)** | Persistent, user-owned memory for AI agents over hosted MCP. Remember decisions, recall project context, manage TODOs, and govern memory lifecycle across sessions |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |


### PR DESCRIPTION
| **[xmemo-memory](https://github.com/yonro/memory-os-cli)** | Persistent, user-owned memory for AI agents over hosted MCP. Remember decisions, recall project context, manage TODOs, and govern memory lifecycle across sessions |

XMemo is a hosted MCP memory service at https://xmemo.dev/mcp. Already on the official MCP Registry, Smithery, and Cursor Directory. 12+ GitHub stars.