### PR TITLE
Add Poppify Skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[Poppify Skills](https://github.com/Poppify/poppify-claude-plugin)** | 4 skills (`poppify-build-reel`, `poppify-render-debug`, `poppify-troubleshoot`, `poppify-schema-introspect`) for photo to TikTok / Instagram Reels / YouTube Shorts / Facebook video. Drives a 27-tool MCP server for the full agentic creative pipeline — \$0.06/render, 50 free seeds, no subscription |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds the [Poppify plugin](https://github.com/Poppify/poppify-claude-plugin)'s 4 Claude Code skills to the **Community Skills → Individual Skills** table.

## The 4 skills

- **\`poppify-build-reel\`** — canonical photo-led / topic-led flow (free customize loop, single paid confirm)
- **\`poppify-render-debug\`** — download finished MP4, run ffprobe, extract frames, surface verdict
- **\`poppify-troubleshoot\`** — symptom → root-cause → action decision tree (missing audio, wrong colors, caption drops)
- **\`poppify-schema-introspect\`** — verify deployed MCP schema vs docs when a parameter looks silently dropped

## What they drive

A 27-tool MCP server for photo to TikTok / Instagram Reels / YouTube Shorts / Facebook video. Upload 1–10 photos, get a captioned 15/30/60s reel with motion, library-matched music, optional voiceover. \$0.06 base render, 50 free seeds on signup, no subscription. Built for SMBs and solo service providers.

## Files changed

- \`README.md\`: 1 line added to the Community Skills > Individual Skills table

🤖 Generated with [Claude Code](https://claude.com/claude-code)