### PR TITLE
Add vaara-governed-tool-call under Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[vaara-governed-tool-call](https://github.com/vaaraio/vaara/tree/main/examples/skills/vaara-governed-tool-call)** | An EU AI Act Article 14 human-oversight checkpoint and Article 12 audit record in front of a high-risk tool call: gate to allow / escalate / deny, route escalations to a human, and export a signed, hash-chained record a regulator can verify offline |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |


### PR DESCRIPTION
Adds one row under Community Skills > Individual Skills, linking to the skill in its own repo (same external-link pattern as the other entries).

What it does: it puts a human-oversight checkpoint and an auditable record in front of a high-risk tool call, the kind of action a human should be able to stop and a regulator should be able to verify later (writing to a clinical or genomic database, submitting to a regulator, moving money, deleting data). It gates the call to allow, escalate, or deny, routes escalations to a human review queue, and appends every decision, escalation, resolution, and outcome to a hash-chained trail that exports to a signed package and verifies offline. It wraps the open-source vaara package (pip install vaara), no server needed.

Real use case: EU AI Act Article 14 (human oversight) and Article 12 (record-keeping) for agents running consequential actions. It drops in next to capability skills, a clinical or genomic database skill ships the action, this ships the oversight and the record. Tested in Claude Code against the package, and used to govern the development of the package itself.