### PR TITLE
Add Claude SEO GEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Skills for working with complex file formats:
   - Install from `superpowers-marketplace` plugin
 
 
+- **[Claude SEO GEO](https://github.com/Thibaultbm/claude-seo-geo)** - 15 SEO and GEO skills built from 115+ real agency audits: full site audit, technical SEO, content for every page type, link building, local SEO, social amplification, AI visibility and tracking (ChatGPT, Perplexity, AI Overviews)
+  - Includes an Obsidian company-knowledge layer that grounds every skill and logs SEO actions back to the vault
+  - Installation: `/plugin marketplace add Thibaultbm/claude-seo-geo`
+
 ### Individual Skills
 
 > These will be broken down into categories once there are enough community skills available to list


### PR DESCRIPTION
Adds [Claude SEO GEO](https://github.com/Thibaultbm/claude-seo-geo) to Collections & Libraries.

15 SEO + GEO skills for Claude Code, MIT licensed, zero dependencies (one optional stdlib Python script). Covers the full stack: site audit, technical SEO, content skills for every page type (blog, product, service, collection), internal linking, schema, link building, local SEO, social amplification, AI visibility and AI traffic tracking, plus an Obsidian company-knowledge layer that grounds every skill. Each skill ships with evals; format and house style are enforced by CI. Every quantitative claim is sourced; field heuristics are labeled as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)