### PR TITLE
Add digital-preservation-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[digital-preservation-skill](https://github.com/matthewbrutonall/digital-preservation-skill)** | Professional digital preservation guidance for archivists and records managers — OAIS, DPC RAM, NDSA Levels, DROID, BagIt, PREMIS, retention schedules, web archiving, and more |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [`digital-preservation-skill`](https://github.com/matthewbrutonall/digital-preservation-skill) to the Individual Skills table.

This is a professional-grade skill for archivists, records managers, museum staff, and heritage professionals. It covers digital preservation theory and practical operations — OAIS, DPC RAM, NDSA Levels, DROID/Siegfried/PRONOM, BagIt, PREMIS, retention schedules, legal holds, web archiving (WARC), and more. Includes jurisdiction notes for UK, Ireland, USA, Australia, and EU.

**Install:**
```
claude skills install https://github.com/matthewbrutonall/digital-preservation-skill
```

The skill has been independently reviewed before publication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)