### PR TITLE
Add CreatorSkills marketplace to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[CreatorSkills](https://creatorskills.co)** - Curated marketplace of 30+ downloadable AI skills purpose-built for content creators — YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Skills use the open SKILL.md format and are compatible with Claude, ChatGPT, and 20+ AI platforms.
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## Summary

Adds [CreatorSkills](https://creatorskills.co) to the **Collections & Libraries** section under Community Skills.

CreatorSkills is a curated marketplace of 30+ downloadable AI skills purpose-built for content creators — covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Skills are distributed using the open **SKILL.md format** (the same standard this repo documents) and work with Claude, Claude Code, ChatGPT, and 20+ other AI platforms.

This is a complement to the GitHub-hosted collections already listed — it's a browsable, curated marketplace for non-technical users who want to find and download skills without cloning repos.