### PR TITLE
Add castep-dft skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[castep-dft](https://github.com/yiqingwen0828-dotcom/castep-dft)** | CASTEP DFT calculations for materials science — geometry optimization, convergence testing, phonons, NEB diffusion barriers, and electronic structure, with a troubleshooting guide built from real HPC mistakes |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds **[castep-dft](https://github.com/yiqingwen0828-dotcom/castep-dft)** to the Individual Skills table.

## Why it's a good fit

- A Claude Code skill for running and troubleshooting **CASTEP** DFT calculations (materials science): geometry optimization, convergence testing, phonons, NEB diffusion barriers, electronic structure.
- Grounded in a real HPC/SLURM workflow — includes working `.param`/`.cell`/submit templates, an energy-parsing script, and a troubleshooting guide built from mistakes that actually cost compute time (e.g. the default centre-of-mass constraint silently aborting every NEB run).
- Distributed as a plugin marketplace, installable with `/plugin marketplace add yiqingwen0828-dotcom/castep-dft`.
- MIT licensed, passes `claude plugin validate`.

To my knowledge this is the first skill targeting CASTEP specifically (existing materials-science skills wrap pymatgen/ASE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)