### PR TITLE
Add Generative-Media-Skills — multi-modal image/video/audio skills for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Skills for working with complex file formats:
   - Install from `superpowers-marketplace` plugin
 
 - **[SamurAIGPT/Generative-Media-Skills](https://github.com/SamurAIGPT/Generative-Media-Skills)** - Multi-modal generative media skills for AI agents (Claude Code, Cursor, Gemini CLI). 100+ AI models for image, video, and audio — FLUX, Midjourney, Veo3, Kling, Suno, and more. Includes expert library skills for Cinema Director, UI Designer, Logo Creator, and Nano-Banana image generation.
-  - Powered by [muapi.ai](https://muapi.ai) and [muapi-cli](https://github.com/SamurAIGPT/muapi-cli)
+  - Powered by [muapi.ai](https://muapi.ai?utm_source=github&utm_medium=readme&utm_campaign=awesome-claude-skills) and [muapi-cli](https://github.com/SamurAIGPT/muapi-cli)
   - Install: `/plugin marketplace add SamurAIGPT/Generative-Media-Skills`
 
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[SamurAIGPT/Generative-Media-Skills](https://github.com/SamurAIGPT/Generative-Media-Skills)** - Multi-modal generative media skills for AI agents (Claude Code, Cursor, Gemini CLI). 100+ AI models for image, video, and audio — FLUX, Midjourney, Veo3, Kling, Suno, and more. Includes expert library skills for Cinema Director, UI Designer, Logo Creator, and Nano-Banana image generation.
+  - Powered by [muapi.ai](https://muapi.ai) and [muapi-cli](https://github.com/SamurAIGPT/muapi-cli)
+  - Install: `/plugin marketplace add SamurAIGPT/Generative-Media-Skills`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## New addition: SamurAIGPT/Generative-Media-Skills

Adding to the **Collections & Libraries** section.

**Repo:** https://github.com/SamurAIGPT/Generative-Media-Skills  
**Stars:** 3,500+  
**Description:** Multi-modal generative media skills for AI agents — Claude Code, Cursor, Gemini CLI.

### What it includes

- **Core primitives** — thin wrappers around muapi-cli for raw API access (image edit, video, file upload)
- **Expert library skills:**
  - `Cinema Director` — technical film direction & cinematography for video generation
  - `Nano-Banana` — reasoning-driven image generation (Gemini 3 style)
  - `UI Designer` — high-fidelity mobile/web mockups (Atomic Design)
  - `Logo Creator` — minimalist vector branding (Geometric Primitives)
  - `Seedance 2` — Doubao video generation with director-level control
- **Social & workflow skills** — automated media pipelines

Covers 100+ AI models: FLUX, Midjourney v7, Veo3, Kling 3.0, HunyuanVideo, Suno, MMAudio, and more — all via [muapi.ai](https://muapi.ai).

Install:
```
/plugin marketplace add SamurAIGPT/Generative-Media-Skills
```