### PR TITLE
Add humanizer-ru skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[humanizer-ru](https://github.com/ilyautov/humanizer-ru)** | Removes signs of AI writing from Russian text: 52 patterns, 20 hard bans, three modes (rewrite / audit / targeted fix), with a deterministic offline scanner shipped inside the skill |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding humanizer-ru, a skill that removes signs of AI writing from Russian text. 79 stars, MIT. More than a bare SKILL.md: ships a deterministic offline scanner, slash commands, and an eval harness. No SaaS dependency, runs locally. Works in Claude Code, claude.ai, and Codex CLI (same Agent Skills format).