### PR TITLE
Add three research & documentation skills to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[llms-txt-writer](https://github.com/shimo4228/llms-txt-writer)** | Writes AI-facing documents (llms.txt, FAQ, glossary) optimized for citation by ChatGPT, Perplexity, and Gemini, following the Answer.AI llms.txt standard |
+| **[jsonld-knowledge-graph](https://github.com/shimo4228/jsonld-knowledge-graph)** | Designs and ships a companion JSON-LD knowledge graph next to llms.txt, encoding domain entities as schema.org triples for LLM citation |
+| **[release-doi](https://github.com/shimo4228/release-doi)** | Five-phase release workflow for DOI-registered research repositories — verifies CITATION.cff / CHANGELOG / llms.txt consistency before tag push and DOI minting |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Skills for working with complex file formats:
 | **[llms-txt-writer](https://github.com/shimo4228/llms-txt-writer)** | Writes AI-facing documents (llms.txt, FAQ, glossary) optimized for citation by ChatGPT, Perplexity, and Gemini, following the Answer.AI llms.txt standard |
 | **[jsonld-knowledge-graph](https://github.com/shimo4228/jsonld-knowledge-graph)** | Designs and ships a companion JSON-LD knowledge graph next to llms.txt, encoding domain entities as schema.org triples for LLM citation |
 | **[release-doi](https://github.com/shimo4228/release-doi)** | Five-phase release workflow for DOI-registered research repositories — verifies CITATION.cff / CHANGELOG / llms.txt consistency before tag push and DOI minting |
+| **[context-sync](https://github.com/shimo4228/context-sync)** | Audits project documentation for role overlaps and staleness — keeps CLAUDE.md, codemaps, ADRs, and README healthy with one command |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds four skills to the Individual Skills table:

- [llms-txt-writer](https://github.com/shimo4228/llms-txt-writer) — writes AI-facing documents (llms.txt / llms-full.txt / FAQ / glossary) following the Answer.AI llms.txt standard, with GEO-oriented static checks.
- [jsonld-knowledge-graph](https://github.com/shimo4228/jsonld-knowledge-graph) — designs a companion graph.jsonld next to llms.txt, encoding domain entities and relationships as schema.org triples for LLM citation.
- [release-doi](https://github.com/shimo4228/release-doi) — five-phase verify-and-deposit release runbook for DOI-registered research repositories (CITATION.cff / CHANGELOG / llms.txt consistency before tag push).
- [context-sync](https://github.com/shimo4228/context-sync) — audits project documentation for role overlaps and staleness; keeps CLAUDE.md, codemaps, ADRs, and README healthy with one command.

Each repo is a standalone skill following the SKILL.md convention. I am the author of all four.