### PR TITLE
Add dashmotion (animated technical diagrams skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[dashmotion](https://github.com/csthink/dashmotion)** | Turns a description or Mermaid source into a self-contained animated diagram — one HTML file, no JavaScript, with flowing connectors and request dots travelling through the system |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **dashmotion** to the Individual Skills list.

An open-source (MIT) Claude skill that turns a plain-English description — or a Mermaid source — into a self-contained animated technical diagram: one HTML file, pure SVG/CSS, no JavaScript. Flowing connectors and request dots that travel through the system (flow + architecture modes). Installs via `npx skills add csthink/dashmotion`.

Live demo (real output, not a video): https://csthink.github.io/dashmotion/

Kept the table's existing format. Thanks for maintaining this.
