### PR TITLE
Add en-zh-translation-polish skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Skills for working with complex file formats:
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 
+| **[en-zh-translation-polish](https://github.com/HoraceLuBFA/en-zh-translation-polish)** | Translate English into idiomatic, translationese-free Chinese with paragraph-by-paragraph English-Chinese bilingual output; methodology distilled from a classic translation textbook |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
Adds **en-zh-translation-polish** to *Community Skills → Individual Skills*.

English→Chinese translation skill that produces idiomatic, translationese-free Chinese plus paragraph-by-paragraph English-Chinese bilingual output. The methodology is distilled from a classic translation textbook into a 0–7 stage workflow (register typing → de-translationese → accuracy QA → punctuation normalization → bilingual output).

- Repo: https://github.com/HoraceLuBFA/en-zh-translation-polish
- Install: `npx skills add -g HoraceLuBFA/en-zh-translation-polish`
- License: MIT