### PR TITLE
Add screenshot-to-html skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[screenshot-to-html](https://github.com/sevzq/screenshot-to-html)** | Clone any UI screenshot into one faithful, fully interactive single-file HTML page via a render → screenshot → compare loop in real Chrome, with verified interactivity |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds **[screenshot-to-html](https://github.com/sevzq/screenshot-to-html)** to Community Skills → Individual Skills.

It's a coding-agent skill that rebuilds any UI screenshot as one self-contained, interactive HTML file. Instead of a one-shot guess, the agent runs a **render → screenshot → compare → refine** loop using your local Chrome (`playwright-core`), then wires up real hover/focus/click states and audits them (`shot.mjs --verify` fails on dead controls).

## Why it fits

- It's a Claude Code / agent skill — installs via `npx skills add sevzq/screenshot-to-html`; `SKILL.md` lives at the repo root.
- Single self-contained HTML output, zero dependencies, MIT licensed.
- Live gallery of verified-interactive replicas (Cloudflare, Stripe, Spotify, Airbnb, ElevenLabs, Tesla…): https://sevzq.github.io/screenshot-to-html/

One item, added to the Individual Skills table; links tested.

Made with [Cursor](https://cursor.com)