### PR TITLE
Add unify-agent-docs to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[unify-agent-docs](https://github.com/shanemhamilton/unify-agent-docs)** | Unifies CLAUDE.md, AGENTS.md, and GEMINI.md into one canonical file per directory via symlinks, with a drift-proof pre-commit guard, so Claude Code, Codex, Cursor, and Gemini share one source of truth |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [unify-agent-docs](https://github.com/shanemhamilton/unify-agent-docs) under **Individual Skills**.

It consolidates `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` into one canonical file per directory via symlinks, with a pre-commit guard that prevents drift — so Claude Code, Codex, Cursor, and Gemini all read the same instructions. After unifying, it also runs a quality pass that tightens each canonical file (missing commands, gotchas, stale facts). MIT licensed; works on single-repo, monorepo, and multi-repo layouts. Installable as a Claude Code plugin (`/plugin marketplace add shanemhamilton/unify-agent-docs`) or as a plain skill.