### PR TITLE
Add outbound-pipeline-playbook to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[outbound-pipeline-playbook](https://github.com/SRKrukowski/outbound-pipeline-playbook)** | Turns an ICP definition into personalized, research-backed cold-email drafts in Gmail (Exa research + Apollo enrichment + Claude drafting), human-reviewed before send, with a free dry-run |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **outbound-pipeline-playbook** to the Community Skills > Individual Skills table.

An open-source Claude Code skill + install playbook that turns an ICP definition into personalized, research-backed cold-email drafts staged in Gmail for human review. One command runs Exa research, Apollo enrichment, and Claude drafting.

- Standalone value: it is a full pipeline (research, draft, stage), not a wrapper for a single commercial API, and it runs on free tiers (Exa free tier + Apollo free credits + a free dry-run mode).
- Non-promotional: links to the open-source repo, MIT licensed.
- Documented: step-by-step `playbook.md`, a `SKILL.md`, and example output in the README.
- Safe: drafts only, nothing sends without a human clicking Send.

Repo: https://github.com/SRKrukowski/outbound-pipeline-playbook