### PR TITLE
Add NaCl — full-SDLC Claude skill suite (Collections & Libraries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[NaCl](https://github.com/ITSalt/NaCl)** - Full-SDLC suite of 57 skills for Claude Code & Codex — business analysis, system architecture, TDD development, review, QA, and release — with requirements stored in a queryable Neo4j graph for end-to-end traceability. MIT.
+  - Installation: `/docs/quickstart.md`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adding NaCl to Community Skills → Collections & Libraries.

NaCl is a suite of 57 agent skills for Claude Code and Codex covering the entire
SDLC: business analysis → system architecture → TDD development → code review → QA
→ release. BA/SA artifacts (processes, entities, roles, rules) live in a Neo4j graph,
so every requirement is queryable and traceable via Cypher instead of scattered Markdown.

- Repo: https://github.com/ITSalt/NaCl
- License: MIT, fully open source
- 18 GitHub stars (meets the 10-star threshold)
- Core dependency (Neo4j) is open source; Docmost/YouGile integrations are optional
  and not required to use the skills — this is not a SaaS wrapper or commercial funnel.

It belongs with other suites like obra/superpowers — an integrated
development framework rather than a single skill.

I've read CONTRIBUTING.md and this submission complies with the guidelines. NaCl is an open-source project I actively maintain (MIT, 18★) — not a low-effort or auto-generated submission.
