### PR TITLE
Add humanify-deobfuscate (Community → Individual Skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[humanify-deobfuscate](https://github.com/ajsb85/humanify-deobfuscate)** | Scope-safe AST deobfuscation of minified/obfuscated JavaScript — un-minify webpack/TypeScript bundles by safely renaming bindings, webpack export-ids, and TypeScript class constructors |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **humanify-deobfuscate** under _Community Skills → Individual Skills_.

A Claude Code skill that makes minified/obfuscated JavaScript readable again by
renaming identifiers **scope-safely with an AST** while the model supplies the names —
a from-scratch take on [humanify](https://github.com/jehna/humanify)'s technique.

- **Repo:** https://github.com/ajsb85/humanify-deobfuscate (MIT, public, CI on Ubuntu + Windows)
- **Install:** `npx skills add ajsb85/humanify-deobfuscate -g`
- Handles single files and **webpack/browserify bundles** (module-by-module), plus the
  parts plain renaming can't reach: webpack export-ids (`.a`/`.b`) and TypeScript
  class-IIFE constructors.
- Validated end-to-end on a real 1 MB / 124-module / ~10k-identifier bundle.

Single table row added; alphabetical-agnostic section (appended to the list). Thanks for maintaining this!
