### PR TITLE
Add hunch to Community Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[hunch](https://github.com/schenkei-code/hunch)** | A quiet second mind — a self-contained, local-first proactive partner that watches your own activity, builds its own knowledge graph, and sends subtle, well-timed nudges via Telegram. No cloud; your data stays local |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **hunch** to Community > Individual Skills.

A self-contained, local-first proactive partner that watches your own activity, builds a knowledge graph, and surfaces subtle, well-timed nudges. Privacy-first (no cloud).

Repo: https://github.com/schenkei-code/hunch