### PR TITLE
Add nib (editorial illustration skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[nib](https://github.com/caezium/nib)** | Turns an idea or a whole article into original white-background, hand-drawn editorial illustrations that all star a recurring character you supply (or a bundled one); free on a ChatGPT/Codex subscription or an OpenRouter key, 7 print looks |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **nib** under Community → Individual Skills.

Nib turns an idea or a whole article into original white-background, hand-drawn editorial illustrations that all star a recurring character you supply (or one from its bundled library). Free on a ChatGPT/Codex subscription (via the Codex CLI) or an OpenRouter key. 7 print looks. MIT.

Repo: https://github.com/caezium/nib