### PR TITLE
Add novel-rpg-hogwarts to Community Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[novel-rpg-hogwarts](https://github.com/siegelmaik-sketch/novel-rpg-hogwarts)** | Child-safe, story-driven Hogwarts RPG with a reusable safety layer — fail-closed output moderation, age/tone hardening, a divergence cap, and persistent world-memory (German content) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[novel-rpg-hogwarts](https://github.com/siegelmaik-sketch/novel-rpg-hogwarts)** to Community → Individual Skills.

A child-safe, story-driven Hogwarts RPG skill for Claude Code / OpenClaw. Beyond the game itself, it ships a **reusable child-safety layer** that may be useful to other skill authors:

- **Fail-closed output moderation** (pluggable backends: LLM classifier, OpenAI `/moderations`, or an offline wordlist) — every scene/fact is checked before it's shown or stored.
- **Age/tone hardening** that can't be overridden by player input.
- **Divergence cap** + sandbox location-whitelist to keep the story on rails.
- **Persistent world-memory** with moderation on write.

MIT licensed, 45 passing tests, German content. Non-commercial fan project (no book text — metadata + model knowledge only; disclaimer in the README).