### PR TITLE
Add OpenClacky to Tools — open-source Claude Code alternative with 93.8% cache hit rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[OpenClacky](https://github.com/clacky-ai/open-clacky)** - Open-source AI coding agent alternative to Claude Code. Achieves 93.8% Prompt Cache hit rate and ~0.8× API cost via frozen 16-tool schema, dual cache markers, and Insert-then-Compress context management. BYOK (Claude/GPT/DeepSeek/Gemini/OpenRouter), MIT license. [Website](https://openclacky.com)
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
## What's being added

**[OpenClacky](https://openclacky.com)** — open-source AI coding agent, placed under the **Tools** section as a Claude Code alternative.

**GitHub**: https://github.com/clacky-ai/open-clacky

## Why it fits here

The Tools section lists utilities that extend or complement the Claude Code ecosystem. OpenClacky is a drop-in alternative to Claude Code with a distinct technical advantage: it achieves **93.8% Prompt Cache hit rate** (7-day global average) and costs **~0.8x what Claude Code costs per session** — making it a practical tool for developers who want Claude-quality coding assistance at lower API cost.

## Technical differentiators

| | OpenClacky | Claude Code |
|---|---|---|
| Prompt Cache hit rate | **93.8%** | ~0% |
| Cost per session | **~0.8x** | 1.0x (baseline) |
| Open source | MIT | No |
| BYOK multi-model | Yes | No |
| IM integration | Yes | No |

How cache efficiency is achieved:
- Frozen 16-tool schema that never changes between sessions
- Dual cache markers on system block and tool definitions
- Insert-then-Compress context management (summarize, do not drop)
- No tool-order churn that would bust Anthropic's cache

License: MIT
Website: https://openclacky.com
GitHub: https://github.com/clacky-ai/open-clacky