### PR TITLE
Add rpgmaker-mv-mcp skill to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[rpgmaker-mv-mcp](https://github.com/DiegoLopez0208/RpgMakerMVUltimate-MCP)** | Build & edit RPG Maker MV games through the RpgMakerMVUltimate MCP — procedural maps, NPCs, shops, chests, doors, troops/encounters, with engine-validated tiles and assets |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **rpgmaker-mv-mcp** to the Community → Individual Skills table.

It's a skill for driving the [RpgMakerMVUltimate MCP server](https://github.com/DiegoLopez0208/RpgMakerMVUltimate-MCP) — building and editing real RPG Maker MV games (procedural maps, NPCs, shops, chests, doors, troops/encounters) with engine-validated tiles and assets so the output actually runs in-engine. The skill teaches the correct high-level workflow (get project context first, generate maps + use event presets, never hand-paint tiles or invent IDs).

- Skill: `skill/rpgmaker-mv-mcp/SKILL.md` in the repo
- Public repo with SKILL.md and full docs