### PR TITLE
Add novu-connect skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[novu-connect](https://github.com/iampearceman/novu-connect-skill)** | Connect a customer-facing AI agent to the messaging channels users already use (Slack, Email, Telegram, WhatsApp, MS Teams) with Novu Connect (`npx novu connect`) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding the **novu-connect** skill to Community > Individual Skills.

It teaches Claude to connect a customer-facing AI agent to the messaging channels users already use (Slack, Email, Telegram, WhatsApp, MS Teams) with Novu Connect, via `npx novu connect`. Grounded in Novu's published agent onboarding (https://novu.co/agents.md).

Skill repo: https://github.com/iampearceman/novu-connect-skill