### PR TITLE
Add frontend-design-research-zh: 中文前端设计调研方法论 Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[frontend-design-research-zh](https://github.com/0505ttt/frontend-design-research-zh)** | 中文母语前端设计调研方法论 — 反 AI 味陷阱（Tailwind 紫色根因）+ 三文档输出 + v0/bolt/lovable 协作 + 中文 AI 生图生态（即梦/通义万相/可灵/豆包 + Codex 工程化） |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What skill are you adding?

**[frontend-design-research-zh](https://github.com/0505ttt/frontend-design-research-zh)** — 中文母语前端设计调研方法论 Claude Code Skill

### Core features
- 反 AI 味陷阱（5 大陷阱 + Tailwind indigo-500 紫色根因）
- 三文档输出铁律（design_research + image_prompts + implementation_plan）
- v0/bolt/lovable 协作模板 + 多轮调教技巧
- 中文 AI 生图生态（即梦/通义万相/可灵/豆包 + Codex）
- 反馈分类精确迭代（8 类策略）
- Tier 0 快速路径（< 2h 项目）

### Why here
- 中文社区缺少结构化前端设计方法论 skill
- 反 AI 味是 2025-2026 设计圈热点（[AITNT](https://m.aitntnews.com/newDetail.html?newId=17685) / [火山引擎](https://developer.volcengine.com/articles/7537170135619600426)）
- 与英文 frontend-design 互补（教方法 vs 执行）

### Checklist
- [x] Public on GitHub
- [x] MIT licensed
- [x] Follows existing table format