### PR TITLE
Add app-it to Community → Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[app-it](https://github.com/Christian-Katzmann/app-it)** | Turns a local web project into an installed macOS desktop app with a native WebKit window, app icon, and clean start/stop lifecycle — no Electron or Tauri; Windows in beta |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **app-it** to the Individual Skills table.

app-it is a Claude Code / Codex skill that turns a local web project into an installed macOS desktop app — native WebKit window, real app icon, clean start/stop lifecycle — without Electron, Tauri, or a rewrite. Local-only (no network calls, no telemetry), additive, and reversible. macOS is stable; Windows is in beta. MIT licensed.

Repo: https://github.com/Christian-Katzmann/app-it