### PR TITLE
Add corpspeak skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[corpspeak](https://github.com/giorgiozamboni/corpspeak)** | Rewrites any text into corporate, C-suite, or business register at three intensity levels while removing AI-writing tells; bilingual English and Italian |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **corpspeak** to Community Skills > Individual Skills.

corpspeak rewrites any text into corporate / C-suite / business register at three intensity levels (light, medium, extreme), while removing the structural patterns typical of AI-generated writing (em dashes, forced rule-of-three, significance inflation). It is genuinely bilingual, with specific tuning for Italian corporate "aziendalese" / itanglese.

- Repo: https://github.com/giorgiozamboni/corpspeak (MIT)
- SKILL.md with YAML frontmatter, IT/EN lexicons, and an anti-AI gate
- One item per PR, format matches the existing Individual Skills table

By @giorgiozamboni (PlayMind Studio).
