### PR TITLE
Add lld-flow-explorer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[lld-flow-explorer](https://github.com/SI-Jothee/lld-flow-explorer)** | Turns a Low-Level Design doc (sequence diagrams, state machines, pipelines) into one interactive, animated request-flow explorer — pick a flow and watch a request travel the system end-to-end |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **lld-flow-explorer** to *Community → Individual Skills*.

**What it does:** turns a Low-Level Design doc — Mermaid sequence diagrams, state machines, and pipeline charts — into one interactive, single-screen request-flow explorer. Pick a flow and watch a request travel the system end-to-end: the active path highlights, the on-the-wire message is named, a packet animates hop-by-hop, and the run/step state machines + pipeline stage track live.

- Repo: https://github.com/SI-Jothee/lld-flow-explorer
- Standard `SKILL.md` (frontmatter + instructions) plus a fully working, offline demo build in `references/`
- Animated demo GIF in the README; MIT licensed

It's my own skill. I checked the existing entries — there's no equivalent "design-doc → interactive flow visualizer" on the list. Thanks for maintaining this!
