### PR TITLE
Add delta-engage skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[delta-engage](https://github.com/newan2001/delta-engage)** | Finds high-fit Reddit & LinkedIn posts to engage with — buyers voicing the pain you solve, not competitors — and drafts a comment for each in your voice. Cookieless, BYOK. |
+
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **delta-engage** — an open-source (MIT) Claude Code skill: https://github.com/newan2001/delta-engage

It finds high-fit Reddit & LinkedIn posts to engage with — the people *voicing the pain you solve*, not competitors — classifies intent (buyer/peer/KOL), and drafts a comment for each in your voice. Cookieless LinkedIn discovery, BYO Apify token, and you always post manually from your own account.