### PR TITLE
Add mailtrap/mailtrap-skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[mailtrap/mailtrap-skills](https://github.com/mailtrap/mailtrap-skills)** | Agent skills for Mailtrap covering email sending, sandbox testing, domain setup, and contacts |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds mailtrap/mailtrap-skills, an official collection of Agent Skills from the Mailtrap team covering email sending via API/SMTP, sandbox testing for dev/staging, domain setup (SPF/DKIM/DMARC), and contacts management.