### PR TITLE
Add delegate to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[delegate](https://github.com/yangkaiHandsome/claude-skill-delegate)** | Delegate tasks to local codex (OpenAI) and agy (Google Gemini) CLI agents, then collect and summarize their results — save your Claude quota by outsourcing work |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **delegate** to the Individual Skills table under Community Skills.

**Repo:** https://github.com/yangkaiHandsome/claude-skill-delegate

**What it does:** A Claude Code skill that delegates a task to your local `codex` (OpenAI) and `agy` (Google Gemini) CLI agents, then collects and summarizes their results. Useful for offloading work to other CLI agents when your Claude quota is tight, or for cross-validating an answer across two models.

- Picks the right executor (codex for code edits/debug/review, agy for quick Q&A/analysis), or runs both for cross-validation
- Enforces least-privilege (read-only vs write) per task to prevent agents from editing files unprompted
- Robust invocation (temp-file + stdin piping to avoid silent shell-escaping failures) and output validation

MIT licensed, documented with a full SKILL.md and README (中文 + English tagline).