### PR TITLE
Add proven-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[proven-python](https://github.com/shanwije/proven-python)** | Enforces Python TDD, strict typing, clean code, and a green ruff/mypy/pytest toolchain before done |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **proven-python** to Community Skills > Individual Skills.

[proven-python](https://github.com/shanwije/proven-python) is a Claude Code skill that enforces Python engineering discipline (TDD, strict typing, clean code, PEP 257 docs, and a green ruff/mypy/pytest toolchain) before a task is called done. Model-invoked, MIT-licensed, and agent-agnostic.