### PR TITLE
Add a-share-skill to community skills list

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[a-share-skill](https://github.com/shouldnotappearcalm/a-share-skill)** | Agent Skills for China A-share (Shanghai/Shenzhen) market: real-time quotes, K-line history, technical indicators, events, capital flows, and paper trading. Works with Claude Code, Cursor, Codex, and Qoder. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **a-share-skill** to the Community Skills → Individual Skills table.

**What it is:** A set of Agent Skills for China's A-share (Shanghai/Shenzhen) market — `a-share-data` (real-time quotes, K-line history, technical indicators, events, capital flows, sector heatmaps) and `a-share-paper-trading` (account management, order placement, positions, backtesting).

**Standalone value (not a SaaS wrapper):** Core data is pulled via the open-source `akshare` library and public endpoints (Tencent/Sina/EastMoney/Xueqiu). No paid subscription or proprietary API is required to use the skills.

**Works across tools:** Claude Code, Cursor, Codex, and Qoder (any tool with a skills directory).

**Social proof:** 160+ stars, documented install/usage guides, and a publicly tracked paper-trading account.

Added a single row to the Individual Skills table following the existing format. Thanks for maintaining this list!