### PR TITLE
Add mytradeledger skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[mytradeledger](https://github.com/trpsbill/skills)** | Access and manage MyTradeLedger journaled crypto trades via the REST API — ledger entries, account balances and realized P&L, CSV export, asset registry, and metadata. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds a skill for interacting with MyTradeLedger journaled crypto trades via its REST API.

- Ledger entries: list/create/update/delete/bulk-import, realized P&L recompute
- Accounts: balances, P&L, archive/unarchive
- Export to CSV, entry metadata, asset registry, token management
- Stdlib-only Python helper (mtl.py) — zero pip dependencies
- Auth via .env file (gitignored); secrets never enter the chat

Install:
/plugin marketplace add trpsbill/skills
/plugin install mytradeledger-skills@trpsbill-skills

Repo: https://github.com/trpsbill/skills