### PR TITLE
Add Motion Graphics Skills to Design & Creative

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Skills for working with complex file formats:
 - **[algorithmic-art](https://github.com/anthropics/skills/tree/main/skills/algorithmic-art)** - Create generative art using p5.js with seeded randomness, flow fields, and particle systems
 - **[canvas-design](https://github.com/anthropics/skills/tree/main/skills/canvas-design)** - Design beautiful visual art in .png and .pdf formats using design philosophies
 - **[slack-gif-creator](https://github.com/anthropics/skills/tree/main/skills/slack-gif-creator)** - Create animated GIFs optimized for Slack's size constraints
+- **[Motion Graphics Skills](https://github.com/iart-ai/motion-skills)** - 50 skills across 14 installable packs for motion graphics, animation & video — kinetic typography, data-viz charts, explainers, TikTok/Reels, 3D WebGL, and Manim math animation
 
 ### Development
 


### PR DESCRIPTION
Adds [motion-skills](https://github.com/iart-ai/motion-skills) to **Design & Creative**.

- 50 open-source skills across 14 installable packs
- Covers kinetic typography, data-viz charts, explainers, TikTok/Reels, 3D WebGL, and Manim math animation
- Each skill ships a render → screenshot → self-check loop (video via Remotion/Manim, web via standalone HTML)
- Anthropic open Skill format — works with Claude Code, Cursor, Codex, and 40+ agents
- MIT licensed