### PR TITLE
Add ui-craft to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[ui-craft](https://github.com/educlopez/ui-craft)** | Design engineering skill for AI coding agents — anti-slop UI rules, outcome recipes (dashboard / landing / auth), accessibility-first review, and a scoreable design critique. Stack-agnostic |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **ui-craft** to Community Skills → Individual Skills.

A design engineering skill for AI coding agents: anti-slop UI rules, outcome recipes (dashboard / landing / auth), accessibility-first review, and a scoreable design critique. Stack-agnostic; works across Claude Code, Codex, Cursor, Gemini, OpenCode and more via the Agent Skills spec.

- Repo: https://github.com/educlopez/ui-craft
- Install: `npx skills add educlopez/ui-craft`
- License: MIT