### PR TITLE
Add Zero to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[Zero](https://zero.xyz)** | Claude Code plugin (`zero@zero-plugins`) that gives Claude access to thousands of tools and services to use and pay for per use, right from a prompt - no config, no API keys |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Zero is a Claude Code plugin (`zero@zero-plugins`) that gives Claude access to thousands of tools and services to use and pay for per use, right from a prompt - no config and no API keys required. It fits the Individual Skills table as a community skill that extends Claude Code with on-demand external services. The entry follows the same two-column format as the surrounding rows.

Disclosure: I work on Zero's go-to-market - happy to tweak the wording, move the section, or close this if it is not a fit.