### PR TITLE
Add trace-my-code to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[trace-my-code](https://github.com/kgohil/trace-my-code)** | Keeps a living trace of your codebase — domain language, architecture, and reuse patterns — current via a drift hook, so the agent reads it and reuses what already exists instead of rebuilding it |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **trace-my-code** to the Individual Skills table.

- **Repo:** https://github.com/kgohil/trace-my-code (public, MIT, valid `SKILL.md`)
- **What it does:** keeps a living trace of your codebase — domain language, architecture, and reuse patterns — current via a drift hook, so a coding agent reads it and reuses what already exists instead of rebuilding it. Reuse-first on by default; installs as a skill or a Claude Code / Codex plugin.
- One row added under **Individual Skills**; factual / non-promotional per CONTRIBUTING.