### PR TITLE
Add Suede Creator Skills to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - 23-skill pack for Claude Code and Codex: agent orchestration with WIP collision detection and rollback trees, a Codex CLI worker fleet, code review with an A-F ship grade, AI eval scaffolding, plus design, copy, and SEO/AEO/AI-EO audits. MIT licensed.
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## What's being added

[Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) — a 23-skill pack for Claude Code and Codex.

## What it includes

Agent orchestration with WIP collision detection and rollback trees, a Codex CLI worker fleet (Claude orchestrates parallel OpenAI Codex CLI workers), code review with an A-F ship grade across evidence-backed lanes, AI eval scaffolding, plus design, copy, and SEO/AEO/AI-EO audits. MIT licensed, runs locally.

## Why Collections & Libraries

It's a multi-skill collection (23 skills), the same shape as `obra/superpowers` already listed in this section, rather than a single skill.

## Note on this update

This PR previously targeted the Design & Creative section (for official Anthropic skills only) with a stale skill count and a music-only framing. Recategorized to Collections & Libraries under Community Skills, and updated the description to match the pack's current, broader scope.