### PR TITLE
Add SkillsIndex (Claude Skills directory with security scores) to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[SkillsIndex](https://skillsindex.dev/ecosystem/claude_skill/)** - Searchable directory of 1,200+ Claude Skills, each scored 0-100 for security, utility, and maintenance so you can vet a skill before installing it
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
Adds SkillsIndex to the Tools section.

It's a searchable directory of 1,200+ Claude Skills where each skill carries a 0-100 score across security, utility, and maintenance. Given the README's own "Vetting Skills" guidance (only install from trusted sources, review scripts first), it's a handy way to check a skill's security signals before installing.

- One entry, alphabetical-friendly, same `- **[Name](url)** - desc` format as the existing Tools entry.
- Link: https://skillsindex.dev/ecosystem/claude_skill/

Thanks for maintaining this list.