### PR TITLE
Add skill-doctor to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[skill-doctor](https://github.com/ssamba1/skill-doctor)** | Audits your installed skill library: per-turn token-cost tax, never-fired skills (from transcript history), trigger collisions, duplicates, and reversible `disable-model-invocation` fixes |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [skill-doctor](https://github.com/ssamba1/skill-doctor) to the Individual Skills table.

**What it does:** audits your *installed* skill library — measures the per-turn token cost of always-on skill descriptions, mines transcripts to find skills that never fire, detects trigger collisions and likely duplicates, flags stale model references, and emits reversible `disable-model-invocation` fixes with projected savings.

Fills a gap most skills don't: managing/trimming the library you already have rather than adding more. Stdlib-only Python, MIT, CI-tested (Linux + Windows, py3.11/3.12).