### PR TITLE
Add anti-slop skill to Communication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Skills for working with complex file formats:
 
 ### Communication
 
+- **[anti-slop](https://github.com/DavidMusijenko/anti-slop)** - Strips AI-speak and corporate filler ("leverage", "seamlessly", "cutting-edge") from any text before it goes out. Returns the cleaned version only.
 - **[brand-guidelines](https://github.com/anthropics/skills/tree/main/skills/brand-guidelines)** - Apply Anthropic's official brand colors and typography to artifacts
 - **[internal-comms](https://github.com/anthropics/skills/tree/main/skills/internal-comms)** - Write internal communications like status reports, newsletters, and FAQs
 


### PR DESCRIPTION
## New skill: anti-slop

**What it does:** Strips AI-speak and corporate filler from any text before it goes out. Returns only the cleaned version — no preamble, no list of changes, just the clean text.

**Removes:** "leverage", "seamlessly", "cutting-edge", "empower", "unlock", "revolutionize", "game-changing", "in today's fast-paced landscape", "it's important to note", padding phrases, and filler hedges.

**Example:**

Input: "We leverage cutting-edge AI to seamlessly empower solopreneurs to unlock their full potential in today's fast-paced landscape."

Output: "We use AI to help solopreneurs move faster."

**Repo:** https://github.com/DavidMusijenko/anti-slop  
**Install:** `curl -o ~/.claude/skills/anti-slop.md https://raw.githubusercontent.com/DavidMusijenko/anti-slop/main/anti-slop.md`  
**License:** MIT  
**Free on Gumroad:** https://soloskills.gumroad.com/l/jltxgf