### PR TITLE
Add cowork-to-code-bridge to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge)** | Connects Claude Cowork (or any sandboxed/cloud agent) to Claude Code running on your own Mac/Linux machine — run builds, tests, git push, docker, and system checks remotely via an async, idempotent, local-first bridge (no inbound ports) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge) to the **Individual Skills** table.

**What it is:** an async, file-based bridge that connects Claude Cowork — or any sandboxed/cloud agent — to Claude Code running on the user's own Mac or Linux machine. The agent queues a task; a local daemon runs it on the real machine (build, test, `git push`, docker, package installs, system health checks) and returns the result through a shared bind-mounted directory.

**Why it fits this list:** it ships as a proper Claude Code skill (`skill/cowork-to-code-bridge/SKILL.md`) that triggers whenever a Cowork user asks to do something needing their actual machine. It's MIT-licensed, idempotent, reboot-surviving, and needs no inbound ports or HTTPS tunnel.

Single-line table addition, alphabetment-agnostic (appended to the end of the section per the existing convention). Thanks for maintaining the list!