### PR TITLE
Add vibe-creating skill to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[vibe-creating](https://github.com/Alisa0808/vibe-creating-skill)** | Bilingual EN/中文 skill that rewrites a rough idea or over-specified shot script into a model-ready text-to-video prompt (Seedance 2.0, Kling, Veo, Hailuo, Wan, Vidu); judgment-first; one SKILL.md; MIT |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add vibe-creating to Individual Skills

Adds one row to the **Community Skills → Individual Skills** table, following the format in `CONTRIBUTING.md`.

- **Repo:** https://github.com/Alisa0808/vibe-creating-skill
- **What it is:** A bilingual (EN/中文) Claude Agent Skill (single `SKILL.md`) that rewrites a rough idea or an over-specified shot script into a clean, model-ready text-to-video prompt. A faithful port of ByteDance's "Vibe Creating" paradigm (Seedance 2.0). Judgment-first: it declines requests outside its scope (UI demos, tutorials, exact dialogue-sync). Works with Seedance 2.0, Kling, Veo, Hailuo, Wan, Vidu.
- **Install:** `npx github:Alisa0808/vibe-creating-skill`
- **License:** MIT
- **Social proof:** ~26 GitHub stars (meets the 10-star guideline).

Not a SaaS wrapper — the skill is a standalone prompt-rewriting capability and works with any of the listed video models.

### Honest disclosure
In the interest of full transparency: this PR was prepared with AI assistance. I am aware `CONTRIBUTING.md` discourages AI-assisted PRs; I am disclosing it rather than hiding it, and leaving the decision to merge or close at the maintainer's discretion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
