### PR TITLE
Add aligned-delivery to Community > Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[aligned-delivery](https://github.com/ahnbingbing/aligned-delivery)** | PM/EM operating + coaching skill: runnable DORA/flow/Monte-Carlo delivery analytics + framework-grounded coaching (WSJF, Team Topologies, Radical Candor), with a measured eval. Bilingual EN/KO |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **aligned-delivery** under Community Skills → Individual Skills.

An installable PM/EM operating + coaching skill. Unlike most skills (a single SKILL.md prompt), it bundles **5 runnable stdlib-Python analytics scripts** — sprint predictability, health-check + 1:1 correction, workload/silo, SP-free **DORA** flow metrics, and **Monte Carlo** forecasting — plus a **documented eval** (rubric + with-skill-vs-baseline benchmark, incl. adversarial cases). Coaching/operating rules are grounded in named frameworks (DORA, WSJF/Cost of Delay, Team Topologies/Conway, Radical Candor, Thomas-Kilmann, Lean BML). Bilingual EN/KO, MIT, no dependencies.

Installable via marketplace:
```
/plugin marketplace add ahnbingbing/skills-marketplace
/plugin install aligned-delivery@ahnbingbing
```

- [x] Public repo, link works
- [x] MIT licensed
- [x] Added one row in Individual Skills, format preserved

Thanks for maintaining this list!