### PR TITLE
Add gh-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[gh-image](https://github.com/drogers0/gh-image)** | Upload local images to GitHub and get back user-attachments URLs; lets Claude Code attach screenshots to PRs, issues, and comments via the gh CLI |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[gh-image](https://github.com/drogers0/gh-image)** as a row in the *Community Skills → Individual Skills* table.

`gh-image` ships a packaged Agent Skill (SKILL.md) that lets Claude Code upload local images to GitHub and get back `user-attachments` URLs, so it can attach screenshots to PRs, issues, and comments from the terminal. GitHub has no public image-upload API; this fills that gap.

- Public repo, MIT, 102★, actively maintained.
- Install the extension: `gh extension install drogers0/gh-image`.
- Skill lives at `skills/github-image-upload/SKILL.md`.

Matches the existing 2-column table format; appended to the end of the table.