### PR TITLE
Add remote-server skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[remote-server](https://github.com/kengerlwl/remote-server-skill)** | SSH-based remote toolkit CLI wrapping Claude Code-style primitives (bash/read/write/edit/ls/grep/glob/download/upload) to operate remote servers over SSH with predictable, escaping-safe behavior |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What it is

`remote-server` is an SSH-based remote toolkit CLI that wraps Claude Code-style primitive tools — bash, read, write, edit, ls, grep, glob, download, upload — and executes them over SSH on a remote server.

## What problem it solves

Driving a remote server by having an agent hand-write `ssh host "..."` is fragile: quoting/encoding hell, no line-numbered reads, no atomic edits, no structured output. This skill transfers every payload via base64 (no escaping issues) and reproduces Claude Code's tool contracts (unique-match edit, ripgrep-style grep with content/files/count modes, mtime-sorted glob, background bash with log tailing).

## Who uses it

Anyone driving remote servers from an AI coding agent (Claude Code / Codex / Cursor / Gemini CLI), or as a standalone CLI. Multi-target config supports direct host/user/port, `~/.ssh/config` aliases, and Windows (PowerShell) targets.

## Details

- Repo: https://github.com/kengerlwl/remote-server-skill
- Zero dependencies (pure Node.js + system `ssh`/`scp`), MIT licensed.
- Tested across real Linux servers.
- Category: Security & Systems (added in alphabetical order).
