### PR TITLE
Add ja-zh-max translation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[ja-zh-max](https://github.com/3060226349kk-cmd/ja-zh-max)** | Japanese-to-Chinese translation skill for Claude Code with 20 distilled skills from Gao Ning's textbook, 9-stage workflow + 4-layer verification chain |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add ja-zh-max

**ja-zh-max** — Japanese-to-Chinese translation and polish skill for Claude Code, with 20 distilled skills from Gao Ning's textbook.

- **Category**: Community Skills > Individual Skills
- **Repo**: https://github.com/3060226349kk-cmd/ja-zh-max
- **Version**: 3.2.0