### PR TITLE
Add pentest-report-skill to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[pentest-report-skill](https://github.com/KonstiJo/pentest-report-skill)** | Compile pentest findings into audit-ready reports (DE/EN) with compliance checks for BSI, OWASP, PCI-DSS, DiGA, and OSCP; ingests nmap/Burp/Nuclei/Nessus/BloodHound/Trivy output and renders Markdown, PDF, and SysReptor JSON |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds `pentest-report-skill` to the Individual Skills table.

A standards-compliance layer for pentest reports: takes findings or raw scanner output (nmap, Burp, Nuclei, Nessus, BloodHound, Trivy) and produces an audit-ready report in German or English, validated against a chosen standard (BSI, OWASP WSTG/ASVS, PTES, NIST 800-115, PCI-DSS v4, DiGA/BfArM, OSCP). Renders Markdown, PDF, and SysReptor import JSON. MIT-licensed.

Repo: https://github.com/KonstiJo/pentest-report-skill