### PR TITLE
Add Quotor — home & auto insurance quotes skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[Quotor — home & auto insurance quotes](https://github.com/quotor/home-auto-insurance-quotes)** | Real, bindable home & auto insurance quotes (US/Texas) via the Quotor MCP at mcp.quotor.ai — carrier-masked options, human-completed bind |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **Quotor** under Community → Individual Skills — an Agent Skill (SKILL.md) that quotes real home & auto insurance (US/Texas, expanding) via the Quotor MCP at mcp.quotor.ai; carrier-masked options, human-completed bind.

- Skill repo: https://github.com/quotor/home-auto-insurance-quotes
- MCP endpoint: https://mcp.quotor.ai