### PR TITLE
Add auto-skill-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Skills for working with complex file formats:
 
 ### Skill Creation
 
+- **[auto-skill-manager](https://github.com/VovikP/auto-skill-manager)** - Auto-discovers, installs, and activates the right skills for any task across Claude Code & Cowork. Cross-platform, zero manual steps.
+
 - **[skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator)** - Interactive skill creation tool that guides you through building new skills with Q&A
 
 ## 🌟 Community Skills


### PR DESCRIPTION
## Adds `auto-skill-manager`

A meta-skill that auto-discovers, installs, and activates the right skills for any task — **zero manual steps**.

- Works in **Claude Code** and **Claude.ai / Cowork**
- **Cross-platform**: Windows, macOS, Linux (ships a recursive, OS-aware skill scanner)
- MIT licensed, includes README + `.skill` bundle

Repo: https://github.com/VovikP/auto-skill-manager

Thanks for maintaining this list!