### PR TITLE
Add inplan to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[inplan](https://github.com/melly-lgtm/inplan)** | Plan with your coding agent in a Markdown doc — comment on any line, discuss it in a thread, and review the agent's edits like a PR |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds inplan to Community Skills → Individual Skills. It's a Markdown editor where you plan with your coding agent — comment on a specific line, discuss it in a thread, and review the agent's edits like a PR. Installs as a Claude Code / Codex / Pi skill; free and open source (AGPL-3.0).
