### PR TITLE
Add kdbx to Community → Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
-| **[kdbx](https://github.com/yarrasys/skills/tree/main/skills/kdbx)** | KeePassXC credentials manager — per-project/per-env secrets in key-file-only .kdbx vaults; replaces .env and injects secrets into commands without printing them |
+| **[kdbx](https://github.com/yarrasys/extensions/tree/main/skills/kdbx)** | KeePassXC credentials manager — per-project/per-env secrets in key-file-only .kdbx vaults; replaces .env and injects secrets into commands without printing them |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[kdbx](https://github.com/yarrasys/skills/tree/main/skills/kdbx)** | KeePassXC credentials manager — per-project/per-env secrets in key-file-only .kdbx vaults; replaces .env and injects secrets into commands without printing them |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **kdbx** to the Community Skills → Individual Skills table.

- **Skill:** [kdbx](https://github.com/yarrasys/extensions/tree/main/skills/kdbx) — a KeePassXC credentials manager for Claude Code.
- **What it does:** manages per-project/per-env secrets in key-file-only `.kdbx` vaults (KDBX4 + Argon2) as a managed replacement for `.env`, and injects them into commands via `kdbx run -- <cmd>` without printing them to the transcript, logs, or shell history.
- **Built for agents:** the agent handles entry paths and variable names only — it never authors or observes a secret value.
- **License:** MIT (repo). Installs via `npx skills add yarrasys/extensions@kdbx`.

One row added, alphabetical-agnostic (appended to the existing table like recent entries). No other changes.
