### PR TITLE
Add awesome-gamedev-agent-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+ - **[gamedev-skills/awesome-gamedev-agent-skills](https://github.com/gamedev-skills/awesome-gamedev-agent-skills)** - 66 game dev skills plus a router that loads the right ones for your engine and task. Covers Godot, Unity, Unreal and web engines. Open source and version pinned.
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adding my project under Community Skills > Collections & Libraries.

It's a set of 66 game dev skills plus a router, all open source (Apache 2.0). You install it once, and when you ask your agent something like "add a double jump to my Godot player" the router figures out the engine and loads just the skills that fit instead of stuffing everything into context.

I noticed there's nothing game dev focused on the list yet, so I figured it could be a useful add. It covers Godot, Unity, Unreal and the web engines (Phaser, PixiJS, three.js), plus a few others like Bevy and pygame.

Every skill is written from the official docs (nothing copied from other lists) and pinned to a specific engine version. There's also a validator script that checks all 67 files, and each skill has its own folder with references, so it's more than just one SKILL.md.

It's been up about a week and has around 16 stars from sharing it with the gamedev community. 

Happy to reword it or move it if another spot fits better.
