### PR TITLE
Add enterprise-architect skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[enterprise-architect](https://github.com/rafalr100/enterprise-architect-skill)** | Makes Claude operate as a world-class, organisation-agnostic Enterprise Architect — discovery-first, capability-first, names the trade-off and commits to one recommendation. TOGAF/Zachman/C4/Wardley/DDD as silent lenses; produces ADRs, reference/target architectures, capability maps, and audience-tiered architecture decks |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds the **enterprise-architect** skill to **Community Skills → Individual Skills**.

- **Repo:** https://github.com/rafalr100/enterprise-architect-skill
- **License:** MIT
- An organisation-agnostic Claude Skill that makes Claude operate as a world-class Enterprise Architect: discovery-first (asks the questions that change the answer before designing), capability-first, always names the trade-off, commits to one recommendation. TOGAF/Zachman/C4/Wardley/DDD applied as silent lenses rather than recited.
- Produces real EA artifacts (ADRs, reference/target architectures, capability maps, options analyses) and audience-tiered decks (board / solution-architect / engineering). `SKILL.md` has valid YAML frontmatter and loads its reference files on demand.

Single-line table entry, matches the existing Individual Skills format.