### PR TITLE
Add MFS to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[MFS](https://github.com/zilliztech/mfs)** | `mfs-find` / `mfs-ingest`: search, grep and read across your code, docs, chat (Slack/Gmail/Jira), databases and object stores as one file-like, searchable namespace — self-hosted with local ONNX embeddings |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[MFS](https://github.com/zilliztech/mfs)** (Apache-2.0). MFS ships two skills — `mfs-ingest` (register/sync data sources) and `mfs-find` (search/grep/cat across them) — that turn your code, docs, chat (Slack/Gmail/Jira), databases and object stores into one file-like, searchable namespace for Claude Code. Self-hosted with local ONNX embeddings; install with `npx skills add zilliztech/mfs`.