### PR TITLE
Add OpenTikZ to community skills list

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[OpenTikZ](https://github.com/opentikz/opentikz)** | Generate and edit TikZ diagrams for academic papers — discovers copyable icons and parametric architecture/pipeline/flow templates. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
OpenTikZ is a community library of TikZ resources for academic conceptual diagrams, offering:
- copyable single-concept icons
- editable, parametric architecture/pipeline/flow templates 
- AI Agent skill to cope with modification and generation

All graphic content is CC0-licensed for frictionless reuse in papers. 

Repo: https://github.com/opentikz/opentikz

Site: https://opentikz.org