### PR TITLE
Add nbp-forge to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[nbpadilha/nbp-forge](https://github.com/nbpadilha/nbp-forge)** - Compose portable SKILL.md / command files from reusable "bricks" with a drift-gate that fails CI when generated output diverges from its recipe. Zero-dependency, MIT.
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
Adds **nbp-forge** to the Tools section.

It's a small zero-dependency CLI that composes portable `SKILL.md` / command files from reusable **bricks** — a recipe *includes* bricks, and a deterministic build emits a standard, self-contained skill (no proprietary syntax leaks into the output). A **drift-gate** (`check`) fails CI if any generated skill diverged from its recipe, and validates output against the SKILL.md `name`/`description` rules. Useful when the same fragment is shared across many skills: edit the brick once instead of every copy.

Repo: https://github.com/nbpadilha/nbp-forge · MIT · on npm.

_(Disclosure: this entry was prepared with AI assistance.)_
