### PR TITLE
Add multi-stack-mcp — UI sections across Next.js, Flutter, WordPress, Vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Skills for working with complex file formats:
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 
+| **[multi-stack-mcp](https://github.com/VovikP/multi-stack-mcp)** | One MCP, every stack — generates native UI sections (hero, pricing, features, CTA) for Next.js, Flutter, WordPress, and Vue from a unified pattern catalog with shared design tokens. Ships a real security model (token + slot denylist, atomic safe-write, symlink-refusing walkers). |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to add **multi-stack-mcp** — a Claude Code skill that generates native UI sections for **Next.js, Flutter, WordPress, and Vue** from a unified pattern catalog with shared design tokens.

**Repo:** https://github.com/VovikP/multi-stack-mcp (MIT)
**Tag:** v0.1.3-alpha
**Differentiator:** Every other UI-section skill is locked to one stack. This one ships 4 hand-written stack realizations per pattern (hero / pricing / features / CTA so far), all driven by a single `tokens.json`. It also ships a real security model — token + slot denylist, atomic safe-write with O_EXCL, symlink-refusing walkers, base64-shaped-string detection — which none of shadcn / 21st.dev / BYQ ship.

**Audited:** four independent macro-rounds with 18 total agent passes. SECURITY.md threat model (T1-T7) all enforced; CI exercises 4×4 cross-product + adversarial smoke tests on every PR.

Happy to revise the wording or move to a different category — just let me know what works.
