### PR TITLE
add remote openclaw to collections & libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Skills for working with complex file formats:
   - Uses new techniques that are still being refined and tested (i.e. skills here may change over time)
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
+- **[Remote OpenClaw](https://www.remoteopenclaw.com/skills)** - directory of agent skills and mcp servers for OpenClaw, Hermes Agent, Claude Code and Codex, browsable by ecosystem and category
 
 
 ### Individual Skills


### PR DESCRIPTION
hey, thanks for maintaining this list. added remote openclaw under collections & libraries since it's a directory of claude code, openclaw, hermes and codex skills plus mcp servers, browsable by ecosystem and category. felt like a natural fit next to the other collections here. happy to move it if you'd prefer a different spot.