### PR TITLE
Add demo-video-factory to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[demo-video-factory](https://github.com/jonny-1812/demo-video-factory)** | Turns any SaaS URL into a ~26s branded product-demo video: brand-matched scenes, a recreated product-UI wow scene, real screenshots, and a soundtrack (Remotion + Playwright) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **demo-video-factory** under Community Skills → Individual Skills.

A Claude Code skill that turns any SaaS URL into a ~26s branded product-demo video. It scans the live site with Playwright for real brand colors, fonts, logo and screenshots, the agent writes a data-only brief, and Remotion renders the video with a recreated product-UI scene and a procedural soundtrack.

- Repo: https://github.com/jonny-1812/demo-video-factory
- License: MIT
- Install: `npx skills add jonny-1812/demo-video-factory` (also installable as a Claude Code plugin)

Entry added alphabetically-agnostic at the end of the Individual Skills table, matching the existing `| **[name](url)** | Description |` format.