### PR TITLE
Add SkillMe (open-source skills catalog + MCP installer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[SkillMe](https://github.com/aouellets/skillme)** - Open-source catalog of Claude Agent Skills and skill packs with semantic search and one-command install via its MCP server (live at [skillme.dev](https://skillme.dev)). Independent project, not affiliated with Anthropic.
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adds **SkillMe** to Community Skills → Collections & Libraries.

SkillMe (https://skillme.dev) is an open-source (MIT) catalog for Claude Agent Skills and skill packs. Browse and search a curated, provenance-tracked catalog, get semantic recommendations for a task, and install individual skills or whole packs straight into a session via its MCP server. Source: https://github.com/aouellets/skillme.

This is an independent project and is **not affiliated with Anthropic**.