### PR TITLE
Add BankBridge skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[BankBridge](https://github.com/bankbridge-money/bankbridge-skills)** | 19 read-only personal-finance slash commands wrapping a hosted MCP server — balances, monthly cashflow, subscriptions audit, tax prep, budget draft, fraud check, portfolio health, and more. Reads from real bank accounts via Plaid. |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
Adds **BankBridge** to the Community Skills → Individual Skills table.

19 read-only personal-finance slash commands wrapping a hosted MCP server. Reads real bank accounts via a secure bank link flow; nothing cached. Commands cover balances, monthly cashflow, subscription auditing, recurring detection, tax prep, budget drafting, fraud checks, portfolio health.

- Skills repo: https://github.com/bankbridge-money/bankbridge-skills
- Plugin: https://github.com/bankbridge-money/bankbridge-plugin
- Site: https://bankbridge.money
- Also on the Official MCP Registry as \`money.bankbridge/server\`

Pricing: \$5/month per connected bank, first month free.
