### PR TITLE
Add Vexilo — visual field guide to Claude Code (Field Guides section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ The easiest way to create a skill is to use the built-in `skill-creator`:
 - [anthropics/skills](https://github.com/anthropics/skills) - Official public repository for Skills
 - [Claude Cookbooks - Skills](https://github.com/anthropics/claude-cookbooks/tree/main/skills) - Example notebooks and tutorials
 
+## 🗺️ Field Guides & Visual Indexes
+
+Interactive, visual indexes that help users navigate Claude Code's growing ecosystem.
+
+- [Vexilo · A field guide to Claude Code](https://vexilo.app/?lang=en) — 31 agents · 99 commands · 123 skills · 13 rules, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). One-click "Teach Claude this handbook" feeds the whole guide into a local Claude session in 30 seconds. Browser-based, zero install. ([companion repo](https://github.com/lilhawk7077/claude-code-resources))
+
 ## 📅 Recent Updates
 
 ### November 2025


### PR DESCRIPTION
## Adds Vexilo — visual field guide to Claude Code

Adds a new section **🗺️ Field Guides & Visual Indexes** right before the "Recent Updates" section.

**Vexilo** is a live, interactive, visual index of **31 agents · 99 commands · 123 skills · 13 rules**, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). The killer feature is a one-click **"Teach Claude this handbook"** that feeds the whole guide into a local Claude session in 30 seconds.

### Why a new section?
The current sections cover skills, MCP, documentation, tutorials, and articles. None cover **visual / interactive indexes**. Vexilo fills that gap — it sits between "Tutorials" and "Official Documentation" as a navigation aid, not a tutorial.

### Entry details
- URL: https://vexilo.app/?lang=en
- Companion repo: https://github.com/lilhawk7077/claude-code-resources (MIT)
- Active maintenance: v1.1.9, weekly updates
- Zero install, browser-based

### Checklist
- [x] New section (not duplicate)
- [x] Placed naturally in the README flow
- [x] Active and maintained project
- [x] Directly relevant to Claude Code
- [x] No pricing/paywall