### PR TITLE
Add Agentic Learning Studio skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[Agentic Learning Studio](https://github.com/APareek89/agentic-learning-skill)** | Turn any topic into a personalized, interactive lesson — learn AI (or anything) in your own context: mental-map first, with examples and a knowledge check, instead of long videos |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **Agentic Learning Studio** to Community > Individual Skills — turns any topic into a personalized, interactive lesson (mental-map first, with examples and a knowledge check), so you can learn AI (or anything) in your own context instead of long videos.

Repo: https://github.com/APareek89/agentic-learning-skill