### PR TITLE
Add claude-briefing-cards to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[claude-briefing-cards](https://github.com/vincent-wen789/claude-briefing-cards)** | Turns agent reports into interactive in-chat cards on the Claude Code desktop app — decision options with buttons that send your choice back, progress boards with blocker alerts, one-click batch sign-offs (EN/中文/日本語) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [claude-briefing-cards](https://github.com/vincent-wen789/claude-briefing-cards) — a skill that turns agent reports into interactive in-chat cards on the Claude Code desktop app (rendered via its built-in widget tools).

What it does:
- Decision cards: options with trade-offs and a stated recommendation; each option is a button that sends the choice back into the chat as a structured message
- Progress cards: multi-workstream status with a highlighted blocker bar
- Confirmation cards: batch sign-off with approve/reject/defer toggles, submitted as one message
- T0-T3 granularity routing (decides when NOT to draw a card) and anti-spam throttling
- Graceful plain-text fallback in terminals; README and card UI in English, Chinese, and Japanese

🤖 Generated with [Claude Code](https://claude.com/claude-code)