### PR TITLE
Add ai-meeting skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[ai-meeting](https://github.com/bin1874/ai-meeting-skill)** | Structured multi-agent decision reviews with Codex, Claude Code, and adapter-based CLI agents |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
## Summary

Adds `ai-meeting`, a structured multi-agent decision review skill for Codex, Claude Code, and adapter-based CLI agents.

## Notes

The repository currently has 0 GitHub stars, so it may not meet the guideline in CONTRIBUTING.md that skills should normally have at least 10 stars. Submitting for maintainer review because it is a tested multi-file skill rather than a single prompt.

## Link

https://github.com/bin1874/ai-meeting-skill