### PR TITLE
Add skillscope under Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[kabylesystem/skillscope](https://github.com/kabylesystem/skillscope)** - Local dashboard for your skill bank: every skill on your machine, real usage mined from Claude Code transcripts, cleanup advice for duplicates and dead weight
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
Adds [skillscope](https://github.com/kabylesystem/skillscope): a local-first dashboard that lists every Claude skill on the machine (global, per-project, plugins), mines real usage from Claude Code transcripts (counts, last used, 12-week sparkline), and gives cleanup advice (duplicates, dead references, never-used, oversized SKILL.md). Also lets you read, edit, create and share skills. MIT licensed.