### PR TITLE
Add seldonframe-agent-business (build → sell → get paid for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[seldonframe-agent-business](https://github.com/seldonframe/seldonframe/tree/main/skills/seldonframe-agent-business)** | Build, eval-gate, deploy, and sell revenue-generating AI agents for real businesses from your IDE via the SeldonFrame MCP — the full build → test → deploy → sell → get-paid loop. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
`seldonframe-agent-business` teaches an IDE agent (Claude Code, Cursor, Codex) the complete agent-business loop on SeldonFrame: build an AI agent for a real business from one sentence, test it against the 8-scenario eval suite that gates publishing at ≥ 87.5%, deploy it to a real channel with the human-only connect step handled honestly, list it on the marketplace with per-call or per-outcome usage pricing, and withdraw the earnings. Every tool name is grounded in the real `@seldonframe/mcp` tool surface — no invented tools — including a table of the names agents typically guess wrong. Guardrails: the agent never collects secret keys in chat and never moves real money (payouts, phone provisioning, price changes) without an explicit human ask. First workspace is free with no API key; keys are requested progressively only when a verb needs them.