### PR TITLE
Add html-collab to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[html-collab](https://github.com/ljn-hust/html-collab)** | Single-file HTML format for LLM-human collaborative document review - humans annotate and edit in Chrome, the skill reads the feedback and produces the next revision; no server or accounts (MIT) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **html-collab** to the Individual Skills table.

## What it is

A single-file HTML format for LLM-human collaborative document review. The LLM generates a self-contained `.html` file; a human opens it in Chrome to leave comments (with optional screenshot pastes) and inline edits with tracked diffs; the skill reads those annotations and produces the next revision. No server, no accounts, no build step.

- Live demo (the demo page is itself an html-collab document): https://ljn-hust.github.io/html-collab/
- License: MIT
- Tested on Claude Code and OpenClaw

Non-promotional: standalone open-source format, no paid product or SaaS dependency.

Repo: https://github.com/ljn-hust/html-collab