### PR TITLE
Add manifest-dev skill collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Skills for working with complex file formats:
   - Uses new techniques that are still being refined and tested (i.e. skills here may change over time)
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
+ 
+- **[doodledood/manifest-dev](https://github.com/doodledood/manifest-dev)** - Manifest-driven workflow skills: adversarial /figure-out understanding, acceptance-criteria manifests via /define, and /do execution verified per criterion by independent subagents
+
 
 
 ### Individual Skills


### PR DESCRIPTION
Added a link to manifest-dev which is a plugin/skill collection that helps you first thoroughly understand the problem space, then encodes into a format “manifest” (success criteria) and executes in a verification loop. 

Been using it for a few months and found it extremely useful for my own work 