### PR TITLE
Add getregdata skills collection (KYC/AML, business registries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Skills for working with complex file formats:
   - Install from `superpowers-marketplace` plugin
 
 
+- **[Nolpak14/getregdata](https://github.com/Nolpak14/getregdata)** - 6 skills for KYC/AML, credit-risk, property, compliance and lead-gen over 29 official business registries (EU, US, UAE)
+  - Skills: `regdata`, `regdata-kyc-aml`, `regdata-credit-risk`, `regdata-property`, `regdata-compliance`, `regdata-lead-gen`
+  - Installation: `npx skills add Nolpak14/getregdata`
+
 ### Individual Skills
 
 > These will be broken down into categories once there are enough community skills available to list


### PR DESCRIPTION
Adds **getregdata** under **Community Skills → Collections & Libraries**.

A collection of 6 skills that give Claude access to official business-registry data across 11 jurisdictions (EU, US, UAE) for KYC/AML, credit-risk, property, compliance and lead-gen workflows:

- `regdata`, `regdata-kyc-aml`, `regdata-credit-risk`, `regdata-property`, `regdata-compliance`, `regdata-lead-gen`
- Repo: https://github.com/Nolpak14/getregdata
- Install: `npx skills add Nolpak14/getregdata`

Follows the existing Collections & Libraries format. Thanks for maintaining the list!