### PR TITLE
Add titlewise (conversation titler skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[titlewise](https://github.com/Battlelamb/claude-code-conversation-titler)** | Interactively titles, names, and labels the current conversation - multilingual (user language / EN / CHN), 13+ formats, plus a recommended pick, description, and tags |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **titlewise** - an interactive Claude Code skill that titles, names, and labels the current conversation.

- Multilingual: user language / English / Chinese
- 13+ title formats, a recommended pick, plus a description and tags
- Suggestion-only (never edits the session)
- MIT-licensed; install as a Claude Code plugin or a standalone skill

Repo: https://github.com/Battlelamb/claude-code-conversation-titler