### PR TITLE
Add AnalystAIPack security skills library

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[AnalystAIPack](https://github.com/meltedinhex/analyst-ai-pack)** | 118 depth-first malware analysis, reverse engineering, and threat hunting skills; each ships a tested, static-only (never-executes) analysis script mapped to MITRE ATT&CK, D3FEND, and CAR |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |


### PR DESCRIPTION
Adds AnalystAIPack to Community Skills > Individual Skills: an open, depth-first library of 118 malware analysis, reverse engineering, and threat hunting skills. Every skill is agentskills.io-format and ships a tested, static-only (never-executes) analysis script mapped to MITRE ATT&CK, D3FEND, and CAR. Apache-2.0.