### PR TITLE
Add claude-code-for-non-coders to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Skills for working with complex file formats:
   - Install from `superpowers-marketplace` plugin
 
 
+- **[Arlenjim/claude-code-for-non-coders](https://github.com/Arlenjim/claude-code-for-non-coders)** - Governance method and three copy-ready method skills (work discipline, scientific debugging, framing vague requests) for directing Claude Code without being able to read the code it writes
+  - Includes session handoff rituals, guardrail templates, and a documented record of which guardrails were removed and why
+
 ### Individual Skills
 
 > These will be broken down into categories once there are enough community skills available to list


### PR DESCRIPTION
## What this adds

A new entry in Community Skills → Collections & Libraries:
claude-code-for-non-coders — a governance method with three copy-ready
method skills (work discipline, scientific debugging, framing vague
requests) for directing Claude Code without being able to read the code
it writes. Also includes session handoff rituals, guardrail templates,
and a documented record of which guardrails were removed and why.

## Social proof

- The method was distilled from months of building a real production app
  (React Native + Firebase, ~30 cloud functions, security rules tested
  in CI) by a non-developer.
- Launched publicly on r/ClaudeCode on July 6; first 24 hours: 45 unique
  visitors and 17 unique cloners (GitHub traffic data).
- MIT licensed, available in English and French.

Happy to adjust wording or placement if you prefer.