### PR TITLE
Add korean-marketing-skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[gugdongbag-eng/korean-marketing-skills](https://github.com/gugdongbag-eng/korean-marketing-skills)** - 9 citation-backed Korean marketing skills (Naver, Kakao, Baemin, 당근) that pin down local marketing facts general LLMs get wrong, each sourced to law and official docs
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adds **korean-marketing-skills** — an MIT-licensed pack of 9 Claude Code skills for Korean marketing (Naver, Kakao, Baemin, 당근, 정보통신망법 / Network Act).

Each skill pins down facts that general LLMs commonly get wrong for the Korean market, with every claim sourced to statutes and official vendor docs. Works with Claude Code / Codex / Cursor.

Added under **Community Skills → Collections & Libraries**.

Repo: https://github.com/gugdongbag-eng/korean-marketing-skills
