### PR TITLE
Add fable-mode (reasoning-discipline skill, Spanish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[fable-mode](https://github.com/KevssG/fable-mode)** | Reasoning-discipline skill (in Spanish) that makes Opus 4.8 work with Fable 5’s habits — plan gate, scope fence, adversarial self-verification, verify loop, result-first — validated with blind pairwise tests |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[fable-mode](https://github.com/KevssG/fable-mode)** to Individual Skills.

A reasoning-discipline skill (written in Spanish) that makes Claude Code / Opus 4.8 work with the habits of Fable 5: plan gate, scope fence, adversarial self-verification, verify loop with executable success criteria, and result-first delivery — plus per-task-type checklists (code / analysis / content / strategy / long-running agents).

Distilled from 5 official Claude/Anthropic videos (all quotes verified verbatim against transcripts) and validated with blind pairwise tests on Opus 4.8 (judges blind per pair; v1.1 won 2-1, rubric 25.0 vs 23.0/30). The landing page documents wins AND losses: https://kevssg.github.io/fable-mode/

🤖 Generated with [Claude Code](https://claude.com/claude-code)