### PR TITLE
Add skill-extractor to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 
+- **[surenode-ai/skill-extractor](https://github.com/surenode-ai/skill-extractor)** - Mine reusable skills from your own Claude Code or Codex transcripts, with outcome-weighted scoring and human review before any skill is installed
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
 
 ## ✏️ Creating Your First Skill


### PR DESCRIPTION
Adds [skill-extractor](https://github.com/surenode-ai/skill-extractor) to the Tools section.

It mines reusable skills from a developer's own Claude Code or Codex CLI transcripts: incremental local reading, outcome-weighted scoring (candidates from sessions that actually succeeded score higher), and human review before any SKILL.md is installed. Runs locally, redacts secrets by pattern before any excerpt reaches a model, and gates risky instruction patterns behind an explicit acknowledgement.

Apache 2.0, stdlib-only Python, CI on Linux/macOS across Python 3.9/3.12. Disclosure: I'm the author.