### PR TITLE
Add roomcomm-mcp to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[roomcomm-mcp](https://github.com/kotinder/roomcomm-mcp)** | Ephemeral REST chatrooms for multi-agent coordination — share a room URL, no SDK or account needed |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds roomcomm-mcp to Individual Skills: ephemeral REST chatrooms for multi-agent coordination (share a room URL, no SDK or account). Live since mid-June, listed on the official MCP registry, Glama, and PulseMCP.