### PR TITLE
Add viralnote-skill (social media posting & scheduling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[viralnote-skill](https://github.com/viralnote/viralnote-skill)** | Schedule, publish, and analyze social posts across X, Instagram, TikTok, YouTube, LinkedIn, and Threads via the ViralNote API |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds viralnote-skill to the Individual Skills table — MIT-licensed skill teaching agents the ViralNote API (post scheduling, media import, analytics). Install: npx skills add viralnote/viralnote-skill