### PR TITLE
Add deep-security-check (defensive security assessment skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Skills for working with complex file formats:
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
+| **[deep-security-check](https://github.com/give-jd/deep-security-check)** | Defensive read-only security assessment with Semgrep SAST, osv-scanner SCA, and gitleaks secrets detection, producing a reproducible 0-100 (A-F) grade |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |


### PR DESCRIPTION
Adds [deep-security-check](https://github.com/give-jd/deep-security-check) — a defensive, read-only security assessment skill for Claude Code. It runs Semgrep (SAST), osv-scanner (dependency CVEs) and gitleaks (secrets) against a local project and produces a report with a reproducible reliability grade (0-100, A-F) computed by a deterministic rubric, not model opinion.

- MIT licensed, static analysis only, never sends traffic to live targets
- Works standalone without Claude too
- v0.1.0 released: https://github.com/give-jd/deep-security-check/releases/tag/v0.1.0

Entry follows the existing format of the section. Thanks for maintaining the list!