### PR TITLE
Add Agent Skills Hub to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 
+- **[Agent Skills Hub](https://agentskillshub.top/)** - Searchable directory of 130,000+ open-source Claude skills and MCP servers, each with a quality score and a SAFE/CAUTION/UNSAFE security grade to review before installing (free, no login)
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
 
 ## ✏️ Creating Your First Skill


### PR DESCRIPTION
Adds [Agent Skills Hub](https://agentskillshub.top/) to the Tools section — a searchable directory of 130,000+ open-source Claude skills and MCP servers, where every entry carries a quality score and a SAFE/CAUTION/UNSAFE security grade so users can vet a skill before installing it.

Re: the non-promotional guidelines — it's free with no login or paywall, the code is MIT, and the underlying graded dataset is released openly (CC-BY-4.0 on Hugging Face: jasonzhuyansen/agent-skills-security-grades). It complements this curated list rather than competing with it (broad automated coverage vs. hand-picked entries), and the security grades align with the Vetting Skills guidance in this README.

Happy to adjust wording or placement. Thanks for maintaining the list!