### PR TITLE
Add fullstack-ts-scaffold to Community > Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[fullstack-ts-scaffold](https://github.com/shaantanu9/fullstack-ts-scaffold)** | Scaffolds a production-shaped full-stack TypeScript monorepo (Next.js 15 + Express with three swappable DB backends, JWT rotating-refresh auth, background worker, PWA, tests, CI) and verifies it builds green in ~1-3 min |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **fullstack-ts-scaffold** as a row in Community Skills > Individual Skills.

A Claude Code skill that regenerates a production-shaped full-stack TypeScript monorepo — Next.js 15 client + Express API with three swappable DB backends (Postgres/Prisma, MongoDB/Mongoose, Supabase), JWT rotating-refresh auth, a BullMQ worker, PWA, OpenAPI docs, a full testing pyramid (unit + API-contract + e2e), and CI — and verifies it builds green in ~1-3 minutes. Has a `--fast` mode.

- Repo: https://github.com/shaantanu9/fullstack-ts-scaffold (MIT)
- Installable as a Claude Code plugin (`.claude-plugin/marketplace.json`) or a plain skill, and `npx`-ready.
- Re: the social-proof note — this is a newly published skill; the repo ships a validated plugin manifest, a v1.0.0 release, and a green-verified template across all three backends.