### PR TITLE
Add seo-translator (SEO-aware translation skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[seo-translator](https://github.com/Skillproofdev/seo-translator)** | SEO-aware translation for localizing sites and content — per-market registers, protected product names and code, anti-AI-pattern pass; ships with a measured 10-language benchmark |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [seo-translator](https://github.com/Skillproofdev/seo-translator) to Individual Skills.

SEO-aware translation skill: classifies SEO fields vs marketing copy vs UI strings, applies per-market registers, protects product names/code from translation, runs an anti-AI-pattern pass. The README includes a measured 10-language benchmark (tokens + wall time per language) from localizing a 4,500-page site.

Disclosure: we're the authors (SkillProof — the tested Claude skills directory).