### PR TITLE
Add ditto to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[ditto](https://github.com/ohad6k/ditto)** | Mines your local Claude/Codex/Cursor session logs into a personal `you.md` agent profile |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding Ditto to the Individual Skills table.

Ditto mines your local Claude/Codex/Cursor session logs into a `you.md` profile your agent reads before every task: what you reject, what "done" means to you, how you actually work when you're heads-down. It reads the raw transcripts, not your `CLAUDE.md`, and redacts secrets before anything is written to disk.

It's one zero-dependency Python file, MIT licensed, with docs in the README and SKILL.md. Currently 88 stars, 9 forks, a few merged community PRs. Installable with `npx skills add ohad6k/ditto`.

Not a SaaS, no account, no paid API. Runs local.
