### PR TITLE
Add d2-diagrams (D2 diagram-as-code with self-checking render loop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Skills for working with complex file formats:
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 
+| **[d2-diagrams](https://github.com/khollingworth/d2-diagram-skill)** | Professional D2 architecture diagrams (TALA/ELK) rendered to SVG with a self-checking loop — the agent views its own render and fixes layout defects before delivering |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
Adds d2-diagrams to Individual Skills.

Claude Code skill/plugin that writes D2, renders SVG with the best available layout engine (TALA when licensed, ELK fallback), then views its own render and fixes layout defects in a loop before delivering. Architecture, sequence, ERD, C4, network and state-machine diagrams. MIT licensed, CI-tested.