### PR TITLE
Add claude-real-video to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Skills for working with complex file formats:
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
+| **[claude-real-video](https://github.com/HUANGCHIHHUNGLeo/claude-real-video)** | Lets Claude actually watch videos — extracts scene-aware keyframes and a timestamped transcript from any video URL or file, all processed locally |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |


### PR DESCRIPTION
Adds claude-real-video to Individual Skills.

What it is: a Claude Code skill + CLI that lets Claude actually watch videos — scene-aware keyframe extraction with dedup, plus a timestamped transcript from local Whisper. 100% local processing, MIT.

Social proof: 1,468 GitHub stars in two weeks; Hacker News front page (165 points) — https://news.ycombinator.com/item?id=48766005

Submitted by the author.