### PR TITLE
Add Vox Director (Vox-style collage video skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[Vox Director](https://github.com/Alisa0808/vox-director)** | Turn one topic into a finished Vox-style paper-collage explainer/ad video — script, collage art, motion, voice-over, music & captions, automated on Atlas Cloud + ffmpeg |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **Vox Director** under Community Skills → Individual Skills.

An open-source (MIT) agent skill that turns one topic into a finished Vox-style paper-collage explainer/ad video — script, collage keyframes, motion, voice-over, music and captions — automated end to end (Atlas Cloud API + local ffmpeg). Works with Claude Code and any SKILL.md agent.

Repo: https://github.com/Alisa0808/vox-director