### PR TITLE
Add Mastering Claude Skills Library to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[Mastering Claude Skills Library](https://mastering-claude.com/skills/)** - Searchable, categorized directory of 500+ Claude Code skills spanning official Anthropic skills, community collections (superpowers, ECC), and marketplace picks, each listed with its source, category, and install command
+  - Free, no signup; includes a built-in vetting checklist for auditing third-party skills before installing
+
 
 ### Individual Skills
 


### PR DESCRIPTION
### Resource
[Mastering Claude Skills Library](https://mastering-claude.com/skills/)

### Section
Community Skills > Collections & Libraries

### What it is
A searchable, categorized directory of 500+ Claude Code skills. It aggregates skills from across the ecosystem: official Anthropic skills, the main community collections (superpowers, ECC), and marketplace picks, each listed with its source, category, and install command. It also includes a built-in vetting checklist for auditing third-party skills before installing.

### Why include it
It fits the Collections & Libraries section as a discovery resource that helps people find and compare skills across sources in one place. It is free, requires no signup, and is not a SaaS wrapper or a paid product. Formatting matches the section's existing entries.

Not affiliated with Anthropic; built and maintained independently.