### PR TITLE
Add fable-maestro to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[fable-maestro](https://github.com/zivreich/fable-maestro)** | Quality-first model delegation for Fable 5 sessions — Fable plans and reviews every diff, Opus subagents write the code, Sonnet runs read-only errands |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [fable-maestro](https://github.com/zivreich/fable-maestro) to the **Individual Skills** table.

Quality-first model delegation for Claude Fable 5 sessions: Fable plans, briefs, and reviews every diff; Opus subagents write all code that lands; Sonnet runs read-only errands only. Escalates upward on high-stakes/ambiguous work and skips delegation entirely for trivial edits. MIT licensed, standard SKILL.md, installable via `npx skills add zivreich/fable-maestro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)