### PR TITLE
Add anywrite to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[anywrite](https://github.com/Antheurus/anywrite)** | CLI covering all 52 endpoints of the Anytype (PKM app) local API, compiled to a single dependency-free binary and wired as a Claude Code skill for agent-driven use |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [anywrite](https://github.com/Antheurus/anywrite): a Bun/TypeScript CLI covering all 52 endpoints of the Anytype local API (2025-11-08 spec), compiled to a single dependency-free binary and wired as a Claude Code skill. Not a SaaS wrapper — MIT-licensed, fully open source, works standalone from the terminal against a self-hosted local API with no paid backend.