### PR TITLE
Add humanizer-ru — Russian AI-writing cleanup skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru)** | Russian AI-writing cleanup: 38 style patterns, 35 deterministic regex markers, offline self-scan in CI |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What
Adds humanizer-ru to the Individual Skills table.

## About the skill
- Russian-specific AI-writing detection and cleanup
- 38 style patterns (content, language, structure, communication)
- 35 deterministic regex markers for copy-paste artifacts from ChatGPT, Gemini, Grok, Copilot, Perplexity, DeepSeek
- Offline self-scan in CI (3 workflows: regex-check, self-scan, no-anglicisms)
- MIT license, no dependencies, no network calls
- 61 GitHub stars, 266+ installs on skills.sh
- Compatible with Claude Code, Codex, Cursor, Gemini CLI, OpenCode

## Verification
- Repo: https://github.com/Vladimir-Human/humanizer-ru
- License: MIT (confirmed)
- Stars: 61 (above 10-star threshold)
- CI: 35/35 regex checks passing, self-scan clean, no-anglicisms clean
