### PR TITLE
Add pm-trace-eval: PM conversation trace evaluation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[pm-trace-eval](https://github.com/Nyota-tree/pm-trace-eval)** | PM-facing AI conversation trace evaluation: user-defined north-star metrics, 1–5 scores, red/yellow/green signals, and per-turn good/bad original quotes |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [pm-trace-eval](https://github.com/Nyota-tree/pm-trace-eval) - a generic PM-facing skill for evaluating AI agent conversation traces with user-defined north-star metrics, 1-5 scores, red/yellow/green signals, and per-turn good/bad original quotes.

Install: `npx skills add Nyota-tree/pm-trace-eval -g -y`