### PR TITLE
Add Prism

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[Prism](https://github.com/xtompie/prism)** | A deep mode that runs a task through reusable thinking lenses and surfaces the key decisions instead of a direct answer |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds Prism to Community → Individual Skills.

Prism is a Claude Code skill invoked with `/prism <task>`. Instead of answering directly, it runs the task through a few reusable thinking lenses (like `inversion`) and lays out the key decisions first. It never runs on its own.