### PR TITLE
Add paranoid-qa (QA skill pack) to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[akovalion/paranoid-qa](https://github.com/akovalion/paranoid-qa)** - QA skill pack that enforces evidence discipline: every Pass/Fail verdict must cite an observed artifact (screenshot, network payload, log)
+  - Testing framework with ~1,000 checks, Playwright test review (49 checks), test-case generation with Zephyr CSV export, Jira bug reports
+  - Reproducible demo where the agent catches a payload bug invisible in the UI; skills ship in English and Russian
+  - Installation: `/plugin marketplace add akovalion/paranoid-qa` then `/plugin install paranoid-qa`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adding paranoid-qa - an MIT-licensed QA skill pack that enforces evidence discipline on testing agents: every Pass/Fail verdict must cite an observed artifact (screenshot, network payload, log). Includes a testing framework with ~1,000 checks, Playwright test review, test-case generation (Zephyr CSV), and Jira bug reports. Skills ship in English and Russian, installable as a plugin.

Social proof, per the contribution guidelines: launched this week with a write-up on Habr that is currently at +15 with 30+ bookmarks (https://habr.com/ru/articles/1058134/), the repo is gathering its first stars and community feedback (feature requests from readers are already turning into roadmap issues). The README demo is a replay of a real, reproducible run - the seeded-bug form ships in the repo.

Followed the entry format of the Collections & Libraries section (bold repo link, short description, sub-bullets, installation command).