### PR TITLE
Add power-coding to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[power-coding](https://github.com/APareek89/power-coding)** | "Five Forces of Mindful Coding" framework: session handoffs, 5-whys learning log, eval loops with golden sets that graduate into tests, Mermaid vibe-debugging diagrams, FMEA failure scans, and consent-gated automation — LLM-agnostic (Claude Code, Codex, Gemini CLI) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What this adds

One row in the **Individual Skills** table: [power-coding](https://github.com/APareek89/power-coding) — a skill I built and maintain.

## What it does

Implements "the Five Forces of Mindful Coding": one invoke configures session handoffs (Handoff.MD + magic phrase), a 5-whys learning log, eval loops drafted from the project's own brief (with golden sets for agentic apps — paid API evals never run without per-run approval), Mermaid vibe-debugging diagrams with an HTML viewer, FMEA failure scans (S×O×D→RPN→P0/P1/P2), and a consent model so automation helps without nagging or spending silently. Plain-markdown mechanism, no daemons/hooks; LLM-agnostic (Claude Code, Codex, Gemini CLI). MIT-licensed, borrows its disciplines from FMEA (aerospace), the Toyota Production System (5-whys, Poka-Yoke, Andon, Jidoka, Muda), and OEE.

## Social proof note

Being upfront per the contribution guidelines: this framework was published publicly today, so it has no stars or user base yet — the repo's commit history shows the design evolution. Entirely understand if you'd prefer to wait for traction before merging; happy to return later if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)