### PR TITLE
Add design-counsel to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Skills for working with complex file formats:
 | Skill | Description |
 | --- | --- |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
+| **[design-counsel](https://github.com/Aakreit/design-counsel)** | Evidence-grounded product design & UX review — prioritized findings with severity anchors, state-matrix coverage, and accessibility checks, for Claude Code and Codex |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |


### PR DESCRIPTION
Adds **[design-counsel](https://github.com/Aakreit/design-counsel)** — an evidence-grounded product design & UX review skill for Claude Code and Codex.

What makes it distinct from existing entries: it reviews designs rather than generating them, with evidence discipline (every finding tagged Observed/Inferred/Standard/Research/Precedent), severity anchors with adjacent-band reasoning, full state-matrix coverage, and a 37-page sourced design wiki (WCAG 2.2, DTCG, Material 3, ~44 primary sources). Ships its own regression harness with 22 gate-validated eval records and a public miss log.

Installable as a Claude Code plugin (`/plugin marketplace add Aakreit/design-counsel`), via `npx skills add`, or as a Codex skill.