### PR TITLE
Add skill: ios-app-agentic-engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[ios-app-agentic-engineering](https://github.com/markus-smile/ios-app-agentic-engineering)** | Guides a non-programmer from iPhone app idea to a secure App Store release through 8 gated phases — threat modeling, stack/backend decision matrices, secret scanning before first commit, adversarial security audit |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What this adds

**[ios-app-agentic-engineering](https://github.com/markus-smile/ios-app-agentic-engineering)** — an end-to-end workflow skill that guides a **non-programmer** from iPhone app idea to a secure App Store release through 8 gated phases: discovery interview → data classification + plain-language threat model → stack/backend decision matrices (SwiftUI/RN/Flutter, CloudKit/Supabase/Firebase) with logged rejected alternatives → project setup with secret scanning **before** the first commit → per-stack secure coding rules → deny-by-default backend rules → a 3-lens adversarial security audit → App Store submission checklist.

## Checklist per contribution guidelines

- **Purpose/use case**: fills a gap — existing iOS skills sharpen one phase for developers (SwiftUI review, App Store rejection checks); this covers the whole idea-to-shipped path for beginners, with security gates the agent won't silently skip.
- **Documentation**: SKILL.md router + 12 reference files (progressive disclosure) + examples of produced artifacts (brief, decision log) + EN/PL README.
- **Substance**: 13 documentation files; built with documentation-TDD (baseline failure tests → content → pressure tests) and a three-track external audit whose findings shipped as [v0.2.0](https://github.com/markus-smile/ios-app-agentic-engineering/blob/master/CHANGELOG.md).
- **Non-promotional**: MIT licensed, no SaaS, no paid dependencies, standalone value.
- **Prerequisites**: a Mac + Xcode for the build phases (the skill handles the no-Mac conversation honestly); no other dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)