### PR TITLE
Add claude-video-plus skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[claude-video-plus](https://github.com/abe238/claude-video-plus)** | Ask a video a question — retrieves only the chapters, numeric facts, and on-screen moments that answer it instead of sampling the whole timeline. Attributed MIT fork of [claude-video](https://github.com/bradautomates/claude-video). |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **claude-video-plus** to the Community Skills → Individual Skills table.

**What it does:** Lets you ask a video a specific question and retrieves only the chapters, numeric facts, and on-screen moments that answer it, instead of sampling the whole timeline.

**Install**

```
npx skills add abe238/claude-video-plus -g
```

Claude Code:

```
/plugin marketplace add abe238/claude-video-plus
/plugin install watch@claude-video-plus
```

**Why it fits this list's bar**

- More than a single `SKILL.md`: ships 338 deterministic tests.
- A sealed, receipt-gated benchmark matched the original's blind-judged answer quality (8.83 vs 8.80) at ~56% fewer reader tokens.
- Fails open: reverts to the original pipeline on no captions, a local file, a short video, or any error.
- MIT licensed, no SaaS dependency: it runs entirely within Claude / Claude Code.

**Attribution:** This is an attributed MIT fork of [bradautomates/claude-video](https://github.com/bradautomates/claude-video); upstream authorship is preserved in the repo.

One item, one PR. All links tested (200).
