### PR TITLE
Add bitbucket-jira-cli skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[bitbucket-jira-cli](https://github.com/Spenhouet/bitbucket-jira-cli)** | gh-style CLI for Bitbucket (pull requests, repos, pipelines) and Jira (issues), with branch-name-as-Jira-key automation. Self-installs the bj CLI; no MCP server needed |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds `bitbucket-jira-cli` to Community > Individual Skills.

It is a gh-style CLI for Bitbucket (pull requests, repos, pipelines) and Jira (issues), with branch-name-as-Jira-key automation. The bundled skill teaches agents to drive the `bj` CLI (which mirrors `gh`), and self-installs `bj` if it is missing, so no MCP server or API wiring is needed.

- Repo: https://github.com/Spenhouet/bitbucket-jira-cli
- Skill: https://github.com/Spenhouet/bitbucket-jira-cli/blob/main/skills/bitbucket-jira-cli/SKILL.md
- Installable as a plugin: `/plugin marketplace add Spenhouet/bitbucket-jira-cli`