### PR TITLE
Add fable5-mode to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[fable5-mode](https://github.com/cozytab/fable5-mode)** | Work-discipline protocol plus Claude Code guard hooks (plan gate, evidence-checked task ledger, model-tier ceiling, failure-attribution reminders) that make a non-frontier model plan, self-verify, and route sub-agents before delegating |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[fable5-mode](https://github.com/cozytab/fable5-mode)** to the Individual Skills table.

What it is: a Claude Code skill plus guard hooks that enforce a work-discipline protocol — a plan gate, an evidence-checked task ledger, a model-tier ceiling, and a failure-attribution reminder — so a non-frontier model plans, self-verifies, and routes sub-agents before delegating. MIT licensed, POSIX hooks (macOS/Linux/WSL), Python stdlib only, with a passing test suite.

Social proof: ~108 stars; bilingual README (EN/简体中文); actively maintained.