### PR TITLE
Add idea-hunt skill (Individual Skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[idea-hunt](https://github.com/ANVEAI/idea-hunt-skill)** | Evidence-first AI business idea discovery and validation — mines real customer pain, applies kill-gates, runs the Mom Test, and forces a proof-of-wallet test before you build |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
### Adding: idea-hunt (Community → Individual Skills)

**Repo:** https://github.com/ANVEAI/idea-hunt-skill · MIT · single portable `SKILL.md`, no API key or paid dependency required.

**What it does:** Evidence-first AI business idea discovery & validation. It inverts the usual "invent an idea" prompt: it mines real customer pain (reviews, gigs, recent complaints), applies explicit kill-gates, runs the Mom Test, and forces a proof-of-wallet test before recommending anything — so most ideas get rejected instead of rationalized.

Follows CONTRIBUTING: actively maintained, documented, provides real value, and improves the DX of Claude Code without routing requests through any server.