### PR TITLE
Add Feature Track to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[feature-track](https://github.com/JunsW/feature-track)** | Repo-native shared memory for AI coding agents that keeps feature status, source-of-truth documents, decisions, risks, and recent changes aligned across Claude Code, Codex, and other coding agents |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **feature-track** to the Community Skills → Individual Skills table.

**What it does:** Helps AI coding agents retain feature context across sessions and tools by maintaining a repository-native feature index and living feature tracks for current status, source-of-truth documents, decisions, risks, and recent changes.