### PR TITLE
Add gtm-engine to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Skills for working with complex file formats:
   - Install from `superpowers-marketplace` plugin
 
 
+- **[gtm-engine](https://github.com/himanshusaleria/gtm-engine)** - 8 slash-command sales skills for 0-to-1 founders: pipeline tracking, daily rituals, call analysis, lead scoring, and cold outreach
+  - Includes 15 sales frameworks the skills apply to real deals (discovery, positioning, qualification, revenue visibility)
+  - Installation: `/plugin marketplace add himanshusaleria/gtm-engine`
+
 ### Individual Skills
 
 > These will be broken down into categories once there are enough community skills available to list


### PR DESCRIPTION
## What this adds

[GTM Engine](https://github.com/himanshusaleria/gtm-engine): a suite of 8 slash-command skills that run a founder's sales workflow in Claude Code: pipeline tracking (Linear as CRM but you can change), daily briefing/wrap-up rituals, call transcript analysis, lead scoring against an ICP, and signal-based cold outreach. Backed by 15 sales frameworks the skills actively apply.

## Checklist

- **Real use case:** I built this to run my own company's GTM motion (QAbyAI) and used it daily for months before open-sourcing it.
- **Tested:** All 8 skills in daily production use; installable via the manual copy method or as a Claude Code plugin (`/plugin marketplace add himanshusaleria/gtm-engine`).
- **Well-documented:** Full README with per-skill usage, setup guide, framework guide, and a config wizard (`/setup`). MIT licensed.
- **No duplicate:** Checked the list — no existing sales/GTM skill suite.
- Entry placed alphabetically in *Business & Marketing*, formatted to match the existing external-repo entries (author credit suffix).