### PR TITLE
Add readme-skill to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[readme-skill](https://github.com/evol1228/readme-skill)** | Designs and writes professional, hand-crafted README.md files — reads the repo first so every command and env var is real; no badge walls, no emoji headings |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [readme-skill](https://github.com/evol1228/readme-skill) — a Claude Code skill that designs and writes professional README.md files.

- Reads the actual repo (manifest, scripts, .env.example, LICENSE) before writing, so every command and env var in the output is real and copy-pasteable
- Anti-slop style rules: no badge walls, no emoji headings, concrete claims over superlatives
- Adapts structure per project type (app, library, CLI)
- `npx skills add evol1228/readme-skill` · listed on [skills.sh](https://www.skills.sh/evol1228/readme-skill) · MIT licensed

Follows the existing table format.