### PR TITLE
Add humanizer skill (53 AI-writing patterns, voice profiles, metrics CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[humanizer](https://github.com/Aboudjem/humanizer-skill)** | Detects 53 AI-writing patterns and rewrites text for burstiness and voice. 5 voice profiles, a 0-100 AI-tell score, detect/rewrite/edit modes, plus an optional metrics CLI with a CI quality-gate. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **humanizer** to the Individual Skills table.

[Aboudjem/humanizer-skill](https://github.com/Aboudjem/humanizer-skill) is a pure-Markdown Claude Code skill that detects 53 AI-writing patterns and rewrites text for burstiness and voice, rather than swapping synonyms. It ships 5 named voice profiles (casual/professional/technical/warm/blunt), a 0-100 AI-tell score, detect/rewrite/edit modes, and an optional zero-dependency metrics CLI with a CI quality-gate. MIT, zero-dependency Markdown core, installable via `npx skills add Aboudjem/humanizer-skill`.

Part of the humanizer lineage that starts with [blader/humanizer](https://github.com/blader/humanizer) (credited in our README); this is an actively maintained, differentiated descendant with the largest open pattern catalog, voice profiles, an edit mode, and the metrics/CI tooling.

Single-row addition, format matches the existing table.
