### PR TITLE
Add animated-sketch-diagram to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[animated-sketch-diagram](https://github.com/OLDyade/animated-sketch-diagram)** | Hand-drawn animated architecture diagrams — ink-sketch style, flowing dots along the real topology, one self-contained SVG+CSS HTML, seamless-loop GIF export (CJK-ready) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [animated-sketch-diagram](https://github.com/OLDyade/animated-sketch-diagram) as a new row in the Individual Skills table (existing format).

Hand-drawn "ink on beige paper" **animated** architecture diagrams: flowing dots trace the real topology (branches, merges, feedback loops); output is one self-contained SVG+CSS HTML, exportable to pixel-perfect seamless-loop GIFs. CJK-ready via bundled OFL handwriting font with auto-subsetting.

Real demo GIFs (unretouched exports) in the repo README. MIT licensed; installable via `/plugin marketplace add OLDyade/animated-sketch-diagram`, `npx skills add`, or git clone.