### PR TITLE
Add kavel-image-studio skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[kavel-image-studio](https://github.com/hanshs474/kavel-mcp)** | Turn a photo into a specific AI look (hairstyle, figurine, royal pet portrait, wedding, 90s yearbook, sticker, HD restore) or a dance video via [Kavel](https://www.kavel.ai) — gives the right tool, a model-tuned prompt, and the generate link |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **kavel-image-studio** under Community Skills → Individual Skills.

Turn a photo into a specific AI look (hairstyle, figurine, pet portrait, wedding, 90s yearbook, HD restore) or a dance video via Kavel — the skill picks the right generator, crafts a model-tuned prompt, and hands off the link.

- Repo: https://github.com/hanshs474/kavel-mcp
- Install: `npx skills add hanshs474/kavel-mcp` or `/plugin marketplace add hanshs474/kavel-mcp`