### PR TITLE
Add code-humanizer (Development skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Skills for working with complex file formats:
 - **[web-artifacts-builder](https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder)** - Build complex claude.ai HTML artifacts using React, Tailwind CSS, and shadcn/ui components
 - **[mcp-builder](https://github.com/anthropics/skills/tree/main/skills/mcp-builder)** - Guide for creating high-quality MCP servers to integrate external APIs and services
 - **[webapp-testing](https://github.com/anthropics/skills/tree/main/skills/webapp-testing)** - Test local web applications using Playwright for UI verification and debugging
+- **[code-humanizer](https://github.com/LeonardNJU/code-humanizer)** - Removes AI-generated code slop (duplicated helpers, try-import fallbacks, broad excepts, single-implementation abstractions) via a 16-pattern catalog with test-gated, behavior-preserving fixes
 
 ### Communication
 


### PR DESCRIPTION
## What

Adds **[code-humanizer](https://github.com/LeonardNJU/code-humanizer)** to the Development section.

It is "[humanizer](https://github.com/blader/humanizer), but for code": a single-SKILL.md agent skill that removes AI-generated *code* slop — duplicated reimplementations of existing helpers, `_v2` clones, unjustified try-import fallbacks, broad exception swallowing, single-implementation abstractions, dead "for future use" code — via a 16-pattern catalog (severity 0–4 with justified-exemption rules) and a test-gated workflow: behavior preservation is absolute (including error types), no tests → report-only, one pattern-class per commit.

## Why it qualifies

- Fills a gap: existing entries cover prose de-slopping and generic review; this targets repo-context structural debt (reimplementing *this repo's* helpers), which linters and diff-scoped prompts miss.
- Battle-tested: developed TDD-style (baseline agents silently changed a public error type without it) and field-tested on a 13.4k-LOC research repo (24 findings, incl. one helper pasted into 20 of 22 scripts that had already semantically drifted). Details in the README.
- MIT, no dependencies, works in any SKILL.md-compatible harness.

## Social proof note

Freshly published (this week) — launching via the linux.do open-source community. Happy to wait / update this PR once traction accumulates if you prefer.