### PR TITLE
add solidifier — SOLID principles skill for Claude Code and multi-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[solidifier](https://github.com/FernandoJRR/solidifier)** | SOLID principles and design patterns for backend code — applied with restraint. Works with Claude Code, OpenCode, GitHub Copilot, and Codex. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding solidifier, a SOLID principles and design patterns skill for Claude Code, OpenCode, GitHub Copilot, and Codex. MIT licensed, validated against real backend code. I built this and have read the contribution guidelines.