### PR TITLE
Add markitdown-skill (read Office docs as Markdown)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[markitdown-skill](https://github.com/raccioly/markitdown-skill)** | Read Office and structured documents (docx, pptx, xlsx, csv, epub, msg, zip, URLs) as token-lean Markdown via Microsoft MarkItDown — local conversion, zero-install uvx fallback |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [markitdown-skill](https://github.com/raccioly/markitdown-skill) to the Individual Skills table.

It teaches Claude Code (or any agent supporting the open Agent Skills format) to read Office and structured documents — docx, pptx, xlsx, csv, html, epub, msg, zip archives, and URLs — by converting them locally to token-lean Markdown with [Microsoft MarkItDown](https://github.com/microsoft/markitdown), instead of improvising per-file extraction scripts.

Notable details:
- Zero-install fallback via `uvx "markitdown[all]"` when the CLI isn't on PATH
- Deliberately excludes PDFs/images (Claude reads those natively with layout) and file creation/editing (dedicated skills own that)
- Large-file discipline: converts to a temp file and reads selectively instead of dumping into context
- MIT licensed, single SKILL.md, no dependencies beyond the MarkItDown CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)