### PR TITLE
Add HyperShots — App Store screenshot skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[HyperShots](https://github.com/hypersocialinc/hypershots)** | App Store screenshots perfect to Apple's specs — deterministic HTML panels with a hard validator (dims/alpha/ICC/count), one-pass localization with auto-fit, optional AI sticker art and style passes, fastlane submission |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [HyperShots](https://github.com/hypersocialinc/hypershots) to Individual Skills: an MIT skill for Claude Code/Codex that generates App Store screenshots perfect to Apple's specs — deterministic HTML panels rendered by headless Chrome with a fail-closed validator (dimensions/alpha/ICC/count/8MB), one-pass localization with auto-fit headlines, optional AI sticker art + spec-preserving style passes, and fastlane submission. Two shipped app sets and a live gallery at https://hypershots.dev.