### PR TITLE
Add flops-skill for GPU/compute price lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[flops-skill](https://github.com/zeroatflops/flops-skill)** | Look up and cite verifiable GPU/compute rental reference prices (spot, on-demand, DePIN) from the public FLOPS Index — price → verify → cite, key-free. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds flops-skill to the Community Skills > Individual Skills table.

flops-skill looks up and cites verifiable GPU/compute rental reference prices (spot, on-demand, and DePIN markets) from the public FLOPS Index. It works key-free and follows a price -> verify -> cite flow so the returned price always comes with a source the user can independently check. It ships a SKILL.md plus a scripts/flops.py helper.

- Repo: https://github.com/zeroatflops/flops-skill
- Category: Community Skills (Individual Skills)
- License and docs: see the repository README/SKILL.md

Single-line addition, matches the existing table format.