### PR TITLE
Add two YouTube transcript skills (Apify-powered)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[apify-youtube-transcript-api](https://github.com/johnisanerd/claude-skill-youtube-transcript-api)** | Fetch YouTube transcripts as structured JSON, SRT, or VTT via a hosted YouTube transcript API on Apify |
+| **[apify-youtube-transcripts-llm-training-data](https://github.com/johnisanerd/claude-skill-youtube-transcripts-llm-training-data)** | Build LLM training data from YouTube transcripts in bulk, with provenance metadata per video |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds apify-youtube-transcript-api (transcripts as JSON, SRT, or VTT) and apify-youtube-transcripts-llm-training-data (bulk transcript corpora with provenance metadata) to the community skills table, matching the existing row format. Both live in per-skill repos with the agentskills.io layout and install via npx skills add.