### PR TITLE
Add character-card-skills (roleplay character card authoring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[character-card-skills](https://github.com/foreverse-app/character-card-skills)** | Roleplay character card authoring: 47 genre playbooks, a rule-based AI-flavor detector with public gold regression, chat-quality triage with per-model symptom profiles, and 15 original cards shipped as SillyTavern-ready v2 JSON / v3 PNG |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **character-card-skills** to Individual Skills.

Two SKILL.md-convention skills for roleplay character card authors: `character-card-author` (four-axis positioning, 47 genre playbooks, five opening-message paradigms, prose discipline with hard sentence-pattern quotas) and `chat-quality-doctor` (symptom-to-fix triage, 8 per-model RP profiles). The repo also ships 15 original cards (card.md + chara_card_v2 JSON + v3 PNG each), a rule-based AI-flavor detector with its gold regression public, and a zero-dependency converter; CI re-scores every card on each commit.

Tested in Claude Code, Cursor and Codex (folder-copy install). Code MIT, content CC BY 4.0. Disclosure: we build Foreverse; the repo is standalone and works without it.
