### PR TITLE
Add pitch-video skill — automated product pitch video pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[pitch-video](https://github.com/Dhevenddra/pitch-video)** | Automated product pitch video — TTS narration (edge-tts), Playwright footage of the real running app, HTML title cards, ffmpeg assembly. No camera or screen recording needed. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Skill

**[pitch-video](https://github.com/Dhevenddra/pitch-video)** by [@Dhevenddra](https://github.com/Dhevenddra)

## What it does

Produces a fully automated product pitch video (≤3 min MP4) without any on-camera recording. The pipeline is narration-first:

1. Splits a written pitch script into named beats and generates TTS audio with `edge-tts` (free, no API key)
2. Screenshots HTML title cards styled in the product's design language via Playwright
3. Records the **real running app** via Playwright Chromium with named scene marks
4. Assembles everything with `ffmpeg` — each video segment is cut to match its narration duration exactly

## Install

```bash
claude skills install Dhevenddra/pitch-video
```

## Category

Community Skills → Individual Skills

## Checklist

- [x] Public GitHub repository
- [x] `skills/pitch-video/SKILL.md` with frontmatter (`name`, `description`)
- [x] `README.md` with install instructions and prerequisites
- [x] MIT License