### PR TITLE
Add skill: atexy4ba/talisman-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[talisman](https://github.com/atexy4ba/talisman-skill)** | Turn a codebase into a brand-styled PDF guide (LaTeX→PDF) — designed cover, your real colors & logo, and native TikZ diagrams |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **talisman** to the Individual Skills table.

- **Repo:** https://github.com/atexy4ba/talisman-skill
- **What it does:** turns a codebase into a polished, brand-styled PDF guide (LaTeX → PDF) — a designed cover page, the product's real colors and logo, a subtle branded background, and native TikZ diagrams (domain models, flows, state machines).
- **Docs:** SKILL.md + AGENTS.md at the repo root; works with any coding AI agent (installable via `npx skills add atexy4ba/talisman-skill`).
- Not a SaaS wrapper — it's a self-contained LaTeX/Python playbook, MIT-licensed.

Follows the entry format (single table row, author-prefixed name, short description).