### PR TITLE
Add buyer-lens and skill-doctor to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[buyer-lens](https://github.com/ujjwalks/buyer-lens)** | Synthetic purchase-intent panels for any website or product concept — builds attribute-conditioned buyer personas and runs the SSR survey method from arXiv:2510.08338 (free-text reactions mapped to Likert distributions), with a deterministic panel scorer, workflow-gap map, and competitive read |
+| **[skill-doctor](https://github.com/ujjwalks/skill-doctor)** | Evaluates a Claude Code skill and prescribes concrete fixes — deterministic static checks plus a judgment rubric, and a paired-eval harness that measures trigger rate and pass rate separately |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adding two MIT-licensed skills, both built around measurable quality rather than vibes:

**[buyer-lens](https://github.com/ujjwalks/buyer-lens)** — runs synthetic purchase-intent panels against any website or product concept. It implements the SSR method from [arXiv:2510.08338](https://arxiv.org/abs/2510.08338) (LLM panels reproduce human purchase intent when personas are attribute-conditioned and react in free text first — direct 1–5 ratings collapse variance), with a stdlib-only deterministic panel scorer, an isolated-context respondent runner, a workflow-coverage gap map, and a competitive/incumbent read. Paired-eval measured: 15/15 trigger rate, 0/6 false fires, 100% assertion pass with-skill vs 0% baseline (spec included in the repo so anyone can re-run it).

**[skill-doctor](https://github.com/ujjwalks/skill-doctor)** — evaluates a Claude Code skill and prescribes concrete fixes: deterministic static checks (frontmatter, description length, body bloat, weak pointers, secrets, portability) plus the judgment rubric from *The Art of Writing Skills*, and a paired-eval harness (`eval.py`) that measures trigger rate and pass rate separately — the two numbers that fail differently. buyer-lens was itself evaluated and iterated with skill-doctor.

Both follow the format spec (folder + SKILL.md + scripts/references), stdlib-only scripts, tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)