### PR TITLE
Add Hivemind to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 
+- **[activeloopai/hivemind](https://github.com/activeloopai/hivemind)** - Auto-generate skills from past coding agent sessions by distilling session traces into SKILL.md files that load in later sessions
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
 
 ## ✏️ Creating Your First Skill


### PR DESCRIPTION
This adds Hivemind (activeloopai/hivemind, ~1.5k stars) to the Tools section next to Skill_Seekers, since it is a skill generator rather than an individual skill. It watches coding agent sessions via hooks and distills the traces into SKILL.md files under .claude/skills/, so lessons from past sessions load in later ones. Open source, no SaaS account needed to run it, and it works with Claude Code, Codex, and Cursor.

To be upfront about your AI-assisted submissions note in CONTRIBUTING: I used Claude Code to prepare this one-line entry, and I reviewed the placement and wording myself. The project itself clears the social proof bar. If that still rules it out, no hard feelings, feel free to close.