### PR TITLE
Add off-by-none skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[off-by-none](https://github.com/NTCHz/off-by-none)** | Spec-faithful implementation: spec-derived tests, mandatory boundary coverage, and an evidence-gated done-report; every rule TDD-tested against baseline failures on Opus, Sonnet, and Haiku |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [off-by-none](https://github.com/NTCHz/off-by-none) to Individual Skills.

A skill for spec-faithful implementation: spec-derived tests written before code, mandatory boundary-value coverage, and an evidence-gated done-report (Verified / Assumed / Seen-but-not-touched).

What makes it different: every rule in SKILL.md was added via TDD-for-skills — only when a baseline agent actually failed a hidden grader without it. Validated across 8 rounds on Opus 4.8, Sonnet 5, and Haiku 4.5, including clean bare-model baselines with 3-5 runs per cell (e.g. adjacent-bug reporting: 0/5 baseline → 5/5 with the skill on Sonnet and Haiku). The eval harness is published in the repo (`eval/`) for reproducibility.