### PR TITLE
Add de-slop (AI-slop removal skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[de-slop](https://github.com/isatimur/de-slop)** | Remove "AI slop" (hedging, listicle stems, filler) from prose without faking a voice — subtractive rewrites self-scored against a rubric; flags hollow spans instead of fabricating claims. Zero-dependency, MIT |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [de-slop](https://github.com/isatimur/de-slop) to the Individual Skills table.

It removes AI-flavored prose patterns (empty hedging, listicle stems, filler transitions) via subtractive rewrites, self-scores against an embedded rubric, and flags hollow spans instead of inventing claims to fill them. MIT-licensed, zero-dependency (stdlib-only Python 3.9–3.13), no SaaS or paid tier — works in Claude Code, Cursor, Copilot, Codex, Gemini, and Windsurf from one source.

Social proof: shipped on PyPI-ready CI with a labeled 220-sample real-world corpus and a public in-browser scorer; also submitted to VoltAgent/awesome-agent-skills and ComposioHQ/awesome-claude-skills.