### PR TITLE
Add hotclip — local AI video clipping skill (long video → vertical shorts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[hotclip](https://github.com/xixihhhh/hotclip)** | Local AI video clipping — turn long videos & livestream VODs into vertical shorts entirely on-device: word-level transcription, LLM highlight detection, 9:16 reframe, karaoke captions, and per-clip render QA with self-repair; skill drives the bundled headless CLI |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[hotclip](https://github.com/xixihhhh/hotclip)** to Community Skills → Individual Skills.

It's a free, open-source (AGPL-3.0) local AI clipping pipeline: drop in a long video or livestream VOD and it produces publish-ready 9:16 shorts — on-device word-level transcription, LLM highlight detection with an audiovisual evidence chain, frame-accurate cutting, face-tracked reframe, karaoke captions, and a per-clip render-QA report with a self-repair loop. Footage never leaves the machine.

The bundled Agent Skill ([skills/hotclip/SKILL.md](https://github.com/xixihhhh/hotclip/blob/main/skills/hotclip/SKILL.md)) lets Claude Code drive the same pipeline as the desktop app via a headless CLI (a local stdio MCP server is also included). Tested against the shipped desktop releases; 500+ unit tests in the repo.