### PR TITLE
Add AILmanac skill packs to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[derob98/ailmanac](https://github.com/derob98/ailmanac)** - Seven MIT-licensed skill packs tailored to different user types: writing, developer workflow, research, data analysis, business, student learning, and everyday productivity
+  - Part of [AILmanac](https://derob98.github.io/ailmanac/), a community almanac for getting the most out of Claude — level-tagged docs on prompting, Claude Code, MCP, and agents
+
 
 ### Individual Skills
 


### PR DESCRIPTION
## What this adds

[AILmanac](https://github.com/derob98/ailmanac) ships seven MIT-licensed skill packs (`skills/` directory), each a standard `SKILL.md` folder targeting a different kind of user: writing/content, developer workflow, research analyst, data analyst, business & marketing, student learning, and everyday productivity.

The repo is also a Docusaurus almanac site covering prompting, Claude Code, MCP, and agents, with level-tagged pages and a freshness-verification workflow (each page states when it was last checked against official sources).

## Social proof

- Live site: https://derob98.github.io/ailmanac/
- Dual-licensed (MIT code / CC BY 4.0 content), CI link-checking, i18n (English + Italian), releases tagged since v0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)