### PR TITLE
Add padawan-no-more to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[padawan-no-more](https://github.com/seyonv/padawan-no-more)** | Audits how often Claude Code stopped to wait for human input, traces each stop to the config or skill gate that caused it, and presents an interactive map of approve/reject fix diffs to make Claude more autonomous |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [padawan-no-more](https://github.com/seyonv/padawan-no-more) — a skill that scans Claude Code transcripts locally for every point where Claude stopped and waited for human input (question dialogs, plan approvals, permission denials), traces each stop to the exact config/skill line that caused it, and builds an interactive local page with ready-to-apply fix diffs the user approves or rejects. MIT licensed, runs entirely locally.