### PR TITLE
feat: add sparda-skills (Proof-Carrying Code for Agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[sparda-skills](https://github.com/zyx77550/sparda-skills)** | Connects AI coding agents to the SPARDA Security Gate to validate agent edits against invariants before applying them. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds sparda-skills, a skill that connects AI coding agents to the SPARDA Security Gate to validate agent edits against runtime invariants before applying them.