### PR TITLE
Add humanizer-ru-uk — Russian & Ukrainian post humanizer with fact-lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[humanizer-ru-uk](https://github.com/arhappy777/humanizer-ru-uk)** | Removes AI writing patterns from Russian and Ukrainian social posts while preserving the author's facts and voice — separate catalogs per language, fact-lock against fabricated details, offline CLI auditor usable as a CI gate |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
### What this adds

**[humanizer-ru-uk](https://github.com/arhappy777/humanizer-ru-uk)** — an Agent Skill for editing Russian and Ukrainian social media posts. Removes AI writing patterns (bureaucratese, calques, empty engagement hooks, uniform rhythm, chatbot artifacts) while keeping the author's facts, numbers, and voice intact.

### Why it may be useful to the community

- Ukrainian support with a separate pattern catalog (checked against the 2026 Ukrainian orthography standard), not a translated English checklist
- Fact-lock: numbers, dates, names, and quotes are pinned before editing and never modified; the skill does not fabricate first-person experience or details
- Offline CLI auditor (`scripts/audit_text.py`, Python stdlib only, no API) with `--fail-on P0` exit codes for CI pipelines
- Explicitly does not claim detector bypass — it is an editorial tool, not an evasion tool

### Checklist

- SKILL.md present and valid (Agent Skills spec)
- MIT license
- GitHub Actions CI passing (Windows + Linux), 88 tests
- Works with Claude Code, OpenClaw, Codex; ChatGPT and claude.ai via a bundled `dist/` file
- Documentation: README (RU/UK/EN quickstart), pattern catalogs, worked before/after examples, eval corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)