### PR TITLE
Add airtight to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[airtight](https://github.com/Zyoffsec/airtight-secure-coding)** | Secure-coding gates applied while the assistant writes: 67 numbered checks mapped to OWASP Top 10 and CWE, catching the safeguards that get silently omitted such as rate limits, lockout, and audit logging |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [airtight](https://github.com/Zyoffsec/airtight-secure-coding) to Individual Skills.

A free, MIT licensed skill that applies 67 numbered secure-coding gates **while the assistant is writing**, rather than scanning after the fact. Gates are mapped to OWASP Top 10 and CWE. It stays silent on non security work like styling or layout, so it adds no overhead to ordinary edits.

Works with Claude Code, Cursor and Codex. Happy to adjust the description or move it if you would prefer a different placement.