### PR TITLE
Add brandmd to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[yuvrajangadsingh/brandmd](https://github.com/yuvrajangadsingh/brandmd)** - Extract any website's design system into a spec-valid `DESIGN.md` plus a brand-style skill, so Claude generates on-brand UI instead of generic screens
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
adds brandmd under Tools.

it extracts a live website's design system (palette, type scale, spacing, shadows, components) into a DESIGN.md that passes the official @google/design.md linter at 0 errors / 0 warnings, and its --agent flag writes a brand-style skill for Claude Code alongside it.

repo has ~30 pre-generated examples (stripe, linear, vercel, github) to judge output quality directly. MIT, on npm since march.