### PR TITLE
Add attester (verification oracle) to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Skills for working with complex file formats:
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 
+| **[attester](https://github.com/maminihds/attester-mcp/tree/main/skills/attester)** | Verification oracle for agents: package/symbol existence checks for PyPI and npm, citation verification, rubric grading, and counterparty checks before paying. Free quota via X-Payer header, signed receipts on every verdict |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
## What

Adds the **attester** skill ([maminihds/attester-mcp/skills/attester](https://github.com/maminihds/attester-mcp/tree/main/skills/attester)) as a row in the Individual Skills table.

## What the skill does

attester.dev is a paid verification oracle for agents. The SKILL.md teaches when to verify facts and gives exact, runnable calls per endpoint:

- **Package/symbol existence** for PyPI and npm ($0.002/$0.005), built from real wheels and tarballs. Negative answers ship signed proof (artifact sha256 + source URL), the part retrieval engines structurally cannot do.
- **Citation verification** ($0.25), **rubric grading** ($0.10), **counterparty checks** ($0.005) before paying an unfamiliar service, and a signed **SLA watchtower report** ($0.05).

Free quota works with any wallet address in the X-Payer header, so the skill works with zero setup. Every verdict carries an EIP-191 signed attestation that verifies offline or via the free /receipts/verify endpoint.

## Notes

- Follows the Agent Skills spec: frontmatter with required name + description, instructions, examples, and a stdlib+httpx helper script.
- Two real transcripts included in skills/attester/examples/ (package check with typosquat flag; citation verify with per-source evidence).
- The free path was exercised against https://attester.dev while authoring (live 200 responses).

Disclosure: I operate attester.dev (hello@attester.dev).