### PR TITLE
Add BunnyScholar API Skill (academic rewrite & AI humanizer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[bunnyscholar-api-skill](https://github.com/bunnyscholar/bunnyscholar-api-skill)** | Academic rewrite (paraphrasing / plagiarism reduction) and AI humanizer for any AI agent — 11 languages, tuned for CNKI, Wanfang, Weipu, Gezida and Turnitin |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds the **BunnyScholar API Skill** — a standard `SKILL.md` that lets any AI agent call two APIs from the BunnyScholar Open Platform: academic rewrite (paraphrasing / plagiarism reduction, 11 languages) and AI humanizer (remove AI footprint, tuned for CNKI / Wanfang / Weipu / Gezida / Turnitin).

- Repo: https://github.com/bunnyscholar/bunnyscholar-api-skill
- SKILL.md: https://bunnyscholar.cn/skills/bunnyscholar-api.md
- License: MIT
