### PR TITLE
Add keyword-icons skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Skills for working with complex file formats:
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
+| **[keyword-icons](https://github.com/ruthless-coder-ai/keyword-icons)** | Turns a keyword into three presentation-ready PNG icon concepts — clean 1:1 line icons, transparent background, recolorable, for PowerPoint and docs |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |


### PR DESCRIPTION
Adds [keyword-icons](https://github.com/ruthless-coder-ai/keyword-icons) to the Individual Skills table.

It generates presentation-ready icons from a keyword: three distinct visual concepts per keyword (e.g. "hospital" → building+cross / cross badge / first-aid kit), rendered as 1:1 transparent PNGs in a consistent line style (uniform stroke, rounded caps). SVG sources use currentColor, so recoloring and resizing are lossless re-renders — handy for matching PowerPoint brand colors. Works with keywords in any language. MIT licensed, no external APIs or paid services — just Python + Playwright locally. Example outputs are in the repo README.