### PR TITLE
Add signs-of-ai — bilingual (EN/ES) AI-writing de-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[signs-of-ai](https://github.com/peopleworks/SignsofAI)** | De-slop AI writing in English & Spanish (rewrite or detect) — the front end of a scored, privacy-first writing-integrity engine, also available as a CLI and MCP server |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **signs-of-ai** to Community → Individual Skills.

A drop-in skill that removes the tells of AI-generated writing — or judges whether text reads as AI-written — in **English and Spanish** (the Spanish rule-pack is derived from scratch, not translated). It's the human-judgment front end of a real, open-source (MIT), privacy-first writing-integrity engine, and can hand off to a scored analyzer via web app, CLI, or MCP server.

- Skill: `skill/signs-of-ai/SKILL.md` (YAML frontmatter, two modes: edit + detect).
- Repo: https://github.com/peopleworks/SignsofAI — actively maintained.

Thanks for maintaining this list!
