### PR TITLE
Add agent-affect-skills (whine / cringe / protect) to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[Ansvar-Systems/agent-affect-skills](https://github.com/Ansvar-Systems/agent-affect-skills)** - End-of-task emotional feedback channels: whine (friction and bugs), cringe (works but shouldn't ship), protect (load-bearing code a cleanup pass would delete), plus a combined check-in - one finding or an explicit null per channel
+  - [Blog: Whine, cringe, protect](https://ansvar.eu/blog/agent-affect-channels-whine-cringe-protect) - why emotion-framed prompts catch what neutral review misses
+  - Installation: `/plugin marketplace add Ansvar-Systems/agent-affect-skills`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adds [Ansvar-Systems/agent-affect-skills](https://github.com/Ansvar-Systems/agent-affect-skills) — four skills that end substantial agent tasks with one subjective finding per emotional channel (or an explicit null): whine for friction/bugs, cringe for things that work but shouldn't ship, protect for load-bearing code a cleanup pass would delete, plus a combined check-in.

- CC BY 4.0, no account or service needed; findings land in a local NDJSON log + the turn summary
- Installable as a plugin (`/plugin marketplace add Ansvar-Systems/agent-affect-skills`) or by copying the skill folders
- Background: https://ansvar.eu/blog/agent-affect-channels-whine-cringe-protect

Entry follows the Collections & Libraries format (bold repo link, sub-bullets, install line).