### PR TITLE
Add pm-claude-skills (1,153 professional Agent Skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
-- **[pm-claude-skills](https://github.com/mohitagw15856/pm-claude-skills)** - 771 professional Agent Skills across 35 professions — PRDs, postmortems, lease/medical-bill decoders, negotiation simulators, calculators — all SkillSpec-gated and security-scanned in CI
-  - Browser playground, searchable catalog, and pre-converted exports for ChatGPT, Gemini, Cursor & 8 more tools
+- **[pm-claude-skills](https://github.com/mohitagw15856/pm-claude-skills)** - 1,153 professional Agent Skills across 35 professions — PRDs, postmortems, lease/medical-bill decoders, negotiation simulators, calculators — all SkillSpec-gated and security-scanned in CI
+  - Browser playground, searchable catalog, and pre-converted exports for ChatGPT, Gemini, Cursor & 10 more tools
   - Installation: `/plugin marketplace add mohitagw15856/pm-claude-skills` or `npx pm-claude-skills add`
 
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[pm-claude-skills](https://github.com/mohitagw15856/pm-claude-skills)** - 771 professional Agent Skills across 35 professions — PRDs, postmortems, lease/medical-bill decoders, negotiation simulators, calculators — all SkillSpec-gated and security-scanned in CI
+  - Browser playground, searchable catalog, and pre-converted exports for ChatGPT, Gemini, Cursor & 8 more tools
+  - Installation: `/plugin marketplace add mohitagw15856/pm-claude-skills` or `npx pm-claude-skills add`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adds **[PM Skills](https://github.com/mohitagw15856/pm-claude-skills)** — 771 MIT-licensed professional Agent Skills (PRDs, postmortems, lease/medical-bill decoders, negotiation simulators, calculators) across 35 professions.

Why it may fit this list: every skill passes a structural gate (SkillSpec L3) and a security-pattern scan in CI, 200+ outputs are eval-scored in the open, and there is a free browser playground so entries can be tried before installing.

Formatted to match the surrounding entries — happy to adjust the wording, move sections, or close if it is not a fit for your bar.