### PR TITLE
Add learning-retrospective (retry-loop prevention skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[learning-retrospective](https://github.com/Yingqi-Han/learning-retrospective-skill)** | Stops repeated trial-and-error and preserves verified lessons; optional retry-loop detector hooks for Claude Code and Codex |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [learning-retrospective](https://github.com/Yingqi-Han/learning-retrospective-skill) to Individual Skills.

An agent-agnostic skill that stops repeated trial-and-error and preserves verified lessons across sessions. Optional runnable retry-loop detector hooks for Claude Code (PostToolUse/PostToolUseFailure) and Codex (PreToolUse), with an evidence-bound semantic reviewer protocol. MIT licensed, 76 tests, CI on 3 OS x Python 3.10-3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)