### PR TITLE
Add rule-audit to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[rule-audit](https://github.com/xniperbuilds/rule-audit)** | Audits your CLAUDE.md and settings to show which rules are actually enforced and which are only advisory, then converts the enforceable ones into hooks and permission rules |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[rule-audit](https://github.com/xniperbuilds/rule-audit)** to Community Skills → Individual Skills.

### What it does

`CLAUDE.md` is advisory — rules in it are requests, not guarantees, and compliance drops further as the rule count grows. This skill inventories every rule across your `CLAUDE.md` files and `settings.json`, classifies each one as enforceable or advisory, generates the exact permission entry or hook config for the enforceable ones, and states plainly which rules can never be enforced by any mechanism.

It deliberately reaches for the smallest mechanism that works — a `permissions.deny`/`ask` entry before a hook, and a hook's `if` filter before a script.

### Meets the guidelines

- **More than a single `SKILL.md`** — ships a full hook reference (all 30 events, per-event exit-code semantics, JSON output shapes), a rule-pattern cookbook, and a read-only scanner.
- **Non-promotional** — MIT, no paid service, no API keys, no SaaS dependency. Python 3.8+ stdlib only; the scanner never writes to your config.
- **Tested** — the scanner was run against real multi-file configs on Windows; the hook mechanism details were verified against the official hooks reference and a working `settings.json` rather than written from memory, and the reference file is dated.
- **Documents its own limits** — the README states what it cannot do, including that rules about taste and judgment can never be enforced.

Happy to adjust the wording or placement.
