### PR TITLE
Add claude-skills-doctor to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[gulmezeren2-byte/claude-skills-doctor](https://github.com/gulmezeren2-byte/claude-skills-doctor)** - Health-check your installed skills: measures the 15,000-character discovery budget over which Claude Code silently stops listing skills, validates frontmatter, and flags name/folder mismatches, duplicate names, colliding descriptions, and risky skill scripts
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
Adds **claude-skills-doctor** to the *Tools* section, next to Skill_Seekers.

It's a free, MIT-licensed CLI (`uvx claude-skills-doctor`, command `skilldoctor`) that health-checks the skills you already have installed. The reason it exists: as of Claude Code 2.0.70 every skill + slash-command description shares a ~15,000-character budget in the system prompt, and once you cross it Claude Code silently stops listing some skills — no error, no warning — so a perfectly-installed skill just never fires.

It measures that budget and shows the biggest descriptions to trim, validates frontmatter, and catches name/folder mismatches, duplicate names, and colliding descriptions. It also runs a light security scan (prompt-injection-style phrases, outbound network calls in a skill's scripts).

Fully deterministic — no model calls, no network, no telemetry, nothing to sign up for. It complements per-file SKILL.md linters by catching the whole-system, cross-skill failures a single-file check structurally can't see.
