### PR TITLE
Add windows-process-cleanup skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[windows-process-cleanup](https://github.com/g4vvj4n7z6-eng/windows-process-cleanup)** | Consent-gated Windows background-process cleanup — honest "why do I have 300 processes" triage, verified vendor/OEM bloat catalog, reversible tiered disables, and a post-update resurrection audit |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[windows-process-cleanup](https://github.com/g4vvj4n7z6-eng/windows-process-cleanup)** to Individual Skills.

A consent-gated Windows 10/11 background-process cleanup skill built for cautious users: read-only diagnosis first, a machine-validated catalog of vendor/OEM bloat (ASUS/Armoury Crate, NVIDIA App, Intel telemetry, Nahimic, remote-access tools) including a traps list of services debloat guides wrongly disable, reversible tiered disables applied behind UAC with per-item logging and revert commands, and a post-update resurrection audit that catches components that re-enable themselves (WPBT/BIOS-planted services, driver-refresh re-registrations). MIT licensed; includes the eval prompts and assertions it was benchmarked against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
