### PR TITLE
Add android-adb-debloat and samsung-debloat skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[android-adb-debloat](https://github.com/g4vvj4n7z6-eng/android-adb-debloat)** | Debloat and de-Google any Android phone over ADB — no root, tiered removal with a never-touch list, round-trip-tested rollback, and honest measure-first performance claims |
+| **[samsung-debloat](https://github.com/g4vvj4n7z6-eng/samsung-debloat)** | Full Samsung Galaxy debloat, privacy setup (HeliBoard keyboard, Google-only contacts) and iPhone-style home-screen automation over ADB — reversible, root-free, validated on One UI |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds two companion Android skills:

**[android-adb-debloat](https://github.com/g4vvj4n7z6-eng/android-adb-debloat)** — Debloat and de-Google any Android phone over ADB: no root, tiered removal (zero-downside / ask-first / never-touch), `pm uninstall --user 0` with a round-trip-tested restore script (catches the Android ≤ 9 `cmd package install-existing` trap), safe WebView/keyboard replacement ordering, honest de-Googling trade-offs (GMS vs push notifications), and evidence-based battery health assessment.

**[samsung-debloat](https://github.com/g4vvj4n7z6-eng/samsung-debloat)** — The Samsung/One UI companion: validated Bixby/telemetry/partner-preload package tiers, the three Samsung removal methods (system vs omcagent preload vs Play app — each restores differently), HeliBoard privacy-keyboard swap verified by permission inspection, Google-only contacts, and iPhone-style home-screen layout built via UI automation with the launcher-drag gotchas documented.

Both are sibling skills to [windows-process-cleanup](https://github.com/g4vvj4n7z6-eng/windows-process-cleanup) (separate PR): measure first, consent-gated, always reversible. MIT licensed, validated on real devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
