### PR TITLE
Add Clearfront OSINT skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[clearfront-osint](https://github.com/scottmartinanderson/clearfront/tree/main/skills/clearfront-osint)** | Open-source intelligence on your digital footprint. Scans 3,400+ public data sources locally. An AI security analyst and an evidence graph explain what is exposed |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Clearfront is a free, open-source OSINT tool. Give it an email, username, phone number, domain, IP or name. It runs 30 collection tools across 3,400+ public data sources, connects the findings into an evidence graph, and an AI security analyst writes a report with a source, confidence rating and severity on each finding.

It runs locally with your own API keys and sends nothing to us. There is no Clearfront server.