### PR TITLE
Add four-agent-pipeline to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[four-agent-pipeline](https://github.com/whaojie797-design/Novera-AI-pipeline)** | Four-agent coding pipeline (Specifier, Coder, Refactorer, Architect) with Gherkin acceptance specs, steel-cage quality gates, and automatic failure routing |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[four-agent-pipeline](https://github.com/whaojie797-design/Novera-AI-pipeline)** to the Individual Skills table.

A single-skill repository (clone straight into a skills directory) that orchestrates a four-agent coding pipeline:

- **Specifier** compiles vague requirements into Gherkin acceptance criteria + boundary conditions + Definition of Done (the only output a human reviews)
- **Coder** turns all acceptance and unit tests green with a minimal implementation
- **Refactorer** improves structure without changing behavior and proves test strength with mutation testing
- **Architect** holds veto power: per-gate PASS/FAIL against hard metrics (coverage, cyclomatic complexity, duplication, mutation score), routing failures back upstream with measured reasons

Ships the four full system prompts in `references/`, spec/feature/report templates in `assets/templates/`, and a zero-dependency Python scaffolder (`scripts/init_pipeline.py`, stdlib only, compile-checked and run-verified). MIT licensed.