### PR TITLE
Add collage-design to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[collage-design](https://github.com/polgarp/collage-design)** | Cut-and-layer collage art from real, open-licensed archive imagery — sourced, cut and composed into a finished .svg plus .png, with a full licence ledger for every fragment |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [collage-design](https://github.com/polgarp/collage-design), a skill that makes cut-and-layer collage art from real, open-licensed archive imagery.

- Sources only open-licensed material and writes a full attribution ledger (URL, creator, licence) for every fragment
- Outputs a self-contained `.svg` plus `.png`, alongside the parametric build script that made the piece
- Apache-2.0; installable as a Claude Code plugin or a plain skill
- README shows four finished pieces with the one-line briefs that produced them

Requires ImageMagick/Inkscape/librsvg locally, so it is Claude Code only — flagged in the README.