### PR TITLE
Add fulcru skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[fulcru](https://github.com/gsmmediaro/fulcru/tree/master/skills/fulcru)** | Get named by AI search engines. Finds the buyer questions where ChatGPT, Gemini and Perplexity name a competitor instead of you, writes the page that closes the gap, and re-measures after publishing |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds the `fulcru` Claude Skill: it audits a domain, finds the buyer questions where AI search names a competitor instead of you, writes the page that closes the biggest gap, and re-measures after publishing. Free and standalone: it needs web access only, no account and no API key.

Source: https://github.com/gsmmediaro/fulcru/tree/master/skills/fulcru