### PR TITLE
add obsidian-keeper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[obsidian-keeper](https://github.com/huini-dev/obsidian-keeper)** | Maintain Obsidian vault project checkpoints, milestone progress, daily work logs, and format governance |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds `obsidian-keeper` to the community skills list.

    - **Repo**: https://github.com/huini-dev/obsidian-keeper
    - **skills.sh**: https://skills.sh/huini-dev/obsidian-keeper/obsidian-keeper
    - **Description**: A Claude Agent Skill for maintaining Obsidian vault project checkpoints, milestone progress, daily
 work logs (from git commits or plain-language check-ins), and format/tag governance.