### PR TITLE
Add krosos-mcp to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[krosos-mcp](https://github.com/Krosos/krosos-mcp)** | Operate a personal accounting ledger (Krosos): net worth, holdings, transaction history, EU capital-gains tax estimates, and trade logging over scoped API tokens |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [krosos-mcp](https://github.com/Krosos/krosos-mcp) to the Individual Skills table.

The skill lets Claude operate a personal accounting ledger (Krosos): net worth, holdings, transaction history, EU capital-gains tax estimates, and trade logging. Auth is a scoped API token the user mints themselves (read-only or read/write). The repo also ships a remote MCP server for the same surface.

Disclosure: I'm the founder of Krosos.