### PR TITLE
Add octopus-skill (long-horizon agent skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[octopus-skill](https://github.com/levi-qiao/octopus-skill)** | Long-horizon agent skill for Claude Code / Cursor / Codex / Grok — durable ledger, clean-context supervisor, and verified gates. Markdown prompt library (loop-graph · quest), not a runtime framework |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Why

Long-horizon Claude Code / agent work often drifts: self-reported "done", lost early decisions after context compaction, no independent verifier.

**octopus-skill** is a curated Markdown prompt library (not a runtime) that wires executor + clean-context supervisor + optional scout through durable files (`ledger.md`, `directives.md`). Arms: `quest` (single goal) and `loop-graph` (gated multi-milestone). Hosts: Claude Code plugin, Cursor, Codex, Grok.

## Links

- Repo: https://github.com/levi-qiao/octopus-skill
- Install (Claude Code):
  ```
  /plugin marketplace add levi-qiao/octopus-skill
  /plugin install octopus@octopus-skill
  ```

## Checklist

- [x] Public GitHub repo with MIT license
- [x] Clear README with install + when to use / when not
- [x] Distinct from orchestration frameworks (Markdown skills only)
