### PR TITLE
Add claude-math skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[claude-math](https://github.com/vladimirrott/claude-math)** | Renders math as terminal-safe Unicode (∑, ≤, ℝ, x², matrices) instead of LaTeX the terminal cannot display |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds one row to **Individual Skills**.

`claude-math` makes mathematical notation legible where it currently is not: a
terminal. Claude Code, Codex CLI and plain shells render neither `$...$` nor
`\frac{a}{b}`, so quantitative answers arrive as markup. The skill emits inline
Unicode instead, so the notation survives copy, paste and grep:
`Q = { (s,r) : n ≥ 6 ∧ p < 0.9 }` rather than a LaTeX block.

- Repo: https://github.com/vladimirrott/claude-math, MIT, 11 stars
- Skill: `skills/math-unicode/SKILL.md`, alongside an installer, docs and tests,
  so there is more to it than a single `SKILL.md`
- No SaaS, no API keys, no network calls, nothing behind a subscription

Disclosure, since CONTRIBUTING asks about this: the PR was prepared with AI
assistance (Claude Code) acting on my instructions, on my own project. I would
rather flag that than have you guess. If it disqualifies the submission, close it
and I will redo it by hand.