### PR TITLE
Add bullshit-detector to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[bullshit-detector](https://github.com/SerhiiKorniienko/bullshit-detector)** | Fact-checks any YouTube video, article, tweet, or PDF: extracts every claim, verifies each against independent sources via web search, and returns per-claim verdicts with a 0-10 BS score |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [bullshit-detector](https://github.com/SerhiiKorniienko/bullshit-detector) to **Community Skills → Individual Skills**.

Point an agent at a YouTube video, article, tweet or PDF. It extracts every discrete claim, verifies each against independent sources via web search, and returns per-claim verdicts with a 0-10 BS score.

What separates it from search-and-summarise: sources are ranked into tiers with empirical and primary evidence on top, and it counts **independent origins rather than URLs** — ten reprints of one press release shouldn't read as ten confirmations.

- Five complete example reports in [`examples/`](https://github.com/SerhiiKorniienko/bullshit-detector/tree/main/examples), on real content including a 2.36M-view video and an unedited audit of its own README
- Works in Claude Code CLI, the desktop Code tab, and other harnesses via the skills.sh installer; also ships as a Claude Code plugin
- Portable by design — no agent-specific tool names in skill bodies, subagents referenced conditionally
- Read-only: fetches and searches, writes only the report
- MIT

It also publishes its [negative results](https://github.com/SerhiiKorniienko/bullshit-detector/tree/main/experiments), including the finding that 16 major news organisations block the crawler it relies on. A fact-checking tool that only publishes its wins has the problem it exists to detect.