### PR TITLE
Add skill: floe

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[floe](https://github.com/Floe-Labs/agent-skills/tree/main/skills/floe)** | Unified billing ledger for voice AI — one key across every voice tool and model (STT, TTS, LLM, telephony), with server-side budget caps |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **floe** to Individual Skills.

- **Skill:** https://github.com/Floe-Labs/agent-skills/tree/main/skills/floe (public, MIT; `SKILL.md` + 5 reference docs)
- **What it does:** the unified billing ledger for voice AI — one Floe key across every voice tool and model a voice agent uses (STT, TTS, LLM, telephony, plus search/data), metered per call with server-side budget caps. Teaches Claude Code / Cursor the whole workflow.
- **Install:** `npx skills add floe-labs/agent-skills`