### PR TITLE
Add four Operator Skills to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ Skills for working with complex file formats:
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 
+| **[media-transcriber](https://github.com/z0157/claude-operator-skills/tree/master/skills/media-transcriber)** | Transcribe any audio or video through a three-tier fallback — captions, audio download, then browser-playback loopback capture into Whisper for sources with no downloadable audio |
+| **[youtube-research-miner](https://github.com/z0157/claude-operator-skills/tree/master/skills/youtube-research-miner)** | Mine an entire YouTube channel without the API and distil the transcripts into ranked findings; handles the rolling auto-caption format that duplicates every line |
+| **[local-lead-finder](https://github.com/z0157/claude-operator-skills/tree/master/skills/local-lead-finder)** | Find local businesses with no website in any city via OpenStreetMap, with opportunity scoring, franchise filtering, and phone/address enrichment |
+| **[govcon-scout](https://github.com/z0157/claude-operator-skills/tree/master/skills/govcon-scout)** | Research U.S. federal contract spending and live bid opportunities — what agencies buy, who wins, at what price (USAspending, SAM.gov) |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
Adds four MIT-licensed skills to the Individual Skills table, matching the existing row format.

- `media-transcriber` — three-tier transcription fallback (captions, audio download, browser-playback loopback capture into Whisper) for sources with no downloadable audio
- `youtube-research-miner` — channel-scale transcript mining without the YouTube API
- `local-lead-finder` — local businesses with no website in any city via OpenStreetMap, scored and franchise-filtered
- `govcon-scout` — U.S. federal contract spending and live bid opportunities

These come from pipelines in actual use, and each file documents the specific failure mode that makes the task non-obvious: auto-caption VTTs are rolling and silently triple the word count unless you parse only the cue carrying inline timing tags; OpenStreetMap's missing-website tag false-positives heavily on franchises, so a denylist is required or the results are national chains; SAM.gov's DEMO_KEY returns 404 rather than an explanatory error.

All four use the standard SKILL.md format with name/description frontmatter and load directly in Claude Code.

Repository: https://github.com/z0157/claude-operator-skills