### PR TITLE
Add browser-search to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills for working with complex file formats:
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[browser-search](https://github.com/Johell1NS/browser-search)** | Search, browse and bypass anti-bot protections for any AI agent: SearXNG multi-engine search, Camofox fast browsing, CloakBrowser stealth for Cloudflare/DataDome-protected sites. Self-hosted, free, unlimited |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |


### PR DESCRIPTION
## What

Adds [browser-search](https://github.com/Johell1NS/browser-search) to the **Individual Skills** table.

## Why

browser-search is a skill for AI agents (OpenCode, Claude Code, Cursor, OpenClaw) that gives them deterministic web access: SearXNG for multi-engine search, Camofox for fast structured browsing, and CloakBrowser to walk through anti-bot protected sites (Cloudflare, DataDome, Akamai). Fully self-hosted, free, unlimited, MIT licensed. Installable via `npx skills add Johell1NS/browser-search`.