### PR TITLE
Add patentfig-skill (patent figure generation & conversion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[patentfig-skill](https://github.com/TopLocalAI/patentfig-skill)** | Generate USPTO/EPO-compliant patent figures from text via the PatentFig AI API — patent line art (PNG/SVG), vectorize drawings to SVG/DXF/PDF, upscale, and convert to filing-ready formats |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[patentfig-skill](https://github.com/TopLocalAI/patentfig-skill)** to Individual Skills.

Teaches agents to call the PatentFig AI REST API: generate USPTO/EPO-compliant patent figures from a text prompt (PNG or stroke-based SVG), vectorize raster drawings to SVG/DXF/vector PDF, AI-upscale, and convert to filing-ready formats. API key via env var; SKILL.md covers timeouts, credits, rate limits, and error handling. Docs: https://patentfig.ai/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpyRDM5rKG2VczzDYnkxzs