### PR TITLE
Add eu-ai-act skill (EU AI Act / Article 50 compliance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[eu-ai-act](https://github.com/dankofly/eu-ai-act-skill)** | EU AI Act compliance advisor: Article 50 labeling duties (applicable since Aug 2, 2026), every written exemption as a no-label decision path, provider vs. deployer analysis, enforcement risk; legal text quoted verbatim from EUR-Lex; ships SKILL.md (Claude) and AGENTS.md (Codex) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[eu-ai-act](https://github.com/dankofly/eu-ai-act-skill)** to Individual Skills.

**What it does:** EU AI Act compliance advisor. Walks the agent through the Article 50 decision path: scope check, provider vs. deployer role, all five transparency duties, and every written exemption (commercial text is out of scope; human review + editorial responsibility exempts even news-like text; stylized visuals are not deepfakes). Hard guardrails against watermark stripping and fake human-authorship claims.

**Social proof / why now (per your submission note):** Article 50 became applicable on **August 2, 2026**, so this is the exact week EU content teams need the decision path. The skill is fresh (launched Aug 1) so it has no star history yet; what I can offer instead: the legal text is quoted verbatim from EUR-Lex (CELEX 32024R1689), the July 20, 2026 Commission Guidelines and the final Code of Practice are incorporated, it ships both SKILL.md and AGENTS.md (works in Claude Code and Codex), and I use it in production for my agency's daily publishing. There is also a paying user base via the companion product built on the same research. If the missing star count is a blocker, happy to resubmit later.

Transparency: I am the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)