### PR TITLE
Add renwei (book-length Chinese de-AI editor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[renwei](https://github.com/dbhosbu-dotcom/renwei)** | Book-length Chinese de-AI editor. 51 rules across AI tells, Euro-Chinese syntax, and whole-book consistency (contradictions, unresolved setups, metaphor collisions). Ships a token-free lint CLI. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Skill Information
- **Skill Name:** renwei (人味)
- **Repository:** https://github.com/dbhosbu-dotcom/renwei
- **I am the author:** Yes

## What it does

Removes AI writing patterns from Chinese book manuscripts. Unlike paragraph-level humanizers, it targets errors that only appear across a whole book — a supplement dosed at 100mg in chapter 2 and 30mg in chapter 7; an intro promising "no biochemistry" followed by 20 pages of it; a gene described as a "blueprint," then a "switch," then a "symphony."

51 rules across 9 dimensions, 5 of them dedicated to long-context consistency.

## Notes

- **Dual channel:** countable metrics (em-dash density, colons, rule-of-three, anthropomorphism) run as plain regex with no token cost; only judgment calls go to the model.
- **Profile system:** `--profile fiction` disables rules that would damage literary prose (personification is a defect in popular science, a technique in fiction) and adds 10 fiction-specific rules.
- **Eval included** with published results. The baseline column is deliberately empty — a proper with/without comparison needs an independent model that hasn't loaded the rules, and fabricating those numbers would violate the project's own hallucination-check rule.
- Works via AGENTS.md, so it also runs in Codex, Cursor, Grok CLI, Hermes, etc.
- MIT licensed. Browser demo runs fully client-side.

## Quality Checklist
- [x] Has working SKILL.md file with YAML frontmatter
- [x] Clear documentation
- [x] Active maintenance
- [x] Relevant to Claude workflows
- [x] No security issues (no network calls, no code execution beyond a local regex linter)
- [x] Follows format requirements