### PR TITLE
Add humanizer-multilingual to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[humanizer-multilingual](https://github.com/finestructure-ai/humanizer-multilingual)** | Removes AI-writing tells in Spanish, Portuguese, French, German, Italian, Hebrew, Arabic, Russian, Japanese and Chinese, with per-language calque, typography, register and syntax patterns graded P0/P1/P2 |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds one row to Individual Skills.

[humanizer-multilingual](https://github.com/finestructure-ai/humanizer-multilingual) removes AI-writing tells in Spanish, Portuguese, French, German, Italian, Hebrew, Arabic, Russian, Japanese and Chinese.

One install covering ten languages, built on the observation that models do not write bad Spanish, they write English wearing Spanish. So the patterns are calques, imported typography, register flattening and English syntax showing through, researched per language rather than translated from the English list.

- MIT, no telemetry, plain Markdown
- Findings graded P0/P1/P2, so a single weak signal is not reported as a verdict
- Test corpus includes counter-samples (legal, academic, literary, native Russian dashes) that must NOT be flagged
- Credits blader/humanizer and Wikipedia's Signs of AI writing, and links to marmbiz/humanizer-de and jurigis/avoid-ai-writing-multilingual where those are the better choice