### PR TITLE
Add sysmap-to-miro (system map → editable Miro board)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[sysmap-to-miro](https://github.com/songstack/sysmap-to-miro)** | Turn a codebase or system map into editable Miro objects — provider icons (AWS/GCP/Azure), connectors, and titled white zones — via the Miro MCP. Install: `npx skills add songstack/sysmap-to-miro` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **sysmap-to-miro** under Community → Individual Skills.

Converts an [archify](https://github.com/tt-a1i/archify) system-map IR into native, editable Miro objects — components become provider icons (AWS/GCP/Azure) or plain shapes, connections become connectors, boundaries become titled white zones — via the Miro MCP. `--iconset aws|gcp|azure|custom|none`.

Social proof / completeness:
- Working converter + SKILL.md with documented rendering rules
- 4 runnable examples (url-shortener; ecommerce-checkout in AWS/GCP/Azure), each with input IR and converted board plan
- 3 demo board screenshots in the README; provider icon paths verified (HTTP 200)
- MIT licensed, v0.1.0 tagged

Install: `npx skills add songstack/sysmap-to-miro`