### PR TITLE
Add feynman-it project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[feynman-it](https://github.com/TadTheFisherman/feynman-it)** | Turns any topic into a hand-illustrated PDF using the Feynman technique -- plain language, an analogy diagram, and a misconceptions section |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds Feynman It, a Claude Code Skill that turns any topic into a hand-illustrated PDF using the Feynman technique (plain-language sentence, analogy diagram, misconceptions section, one-breath recap). MIT licensed, examples included in the repo.