### PR TITLE
Add audio-tldr to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Skills for working with complex file formats:
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 
+| **[audio-tldr](https://github.com/AugustusW/audio-tldr-skill)** | Summarize videos, audio files, and podcasts into key takeaways — local Whisper transcription with cached transcripts |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
Adds [audio-tldr](https://github.com/AugustusW/audio-tldr-skill) — summarize videos, audio files, and podcasts into key takeaways. Transcription runs locally (Whisper / mlx-whisper) and transcripts are cached, so repeat requests skip re-transcription. MIT, tagged releases (v0.4.0), bilingual docs, cross-platform (macOS/Linux/Windows).