### PR TITLE
Add report-workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[report-workflow](https://github.com/0Smallcat0/report-workflow)** | Turn source files and one sentence into a submission-ready DOCX, with deterministic gates that block any claim not traceable to the sources |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds `report-workflow` to Individual Skills. The skill drives a local deterministic pipeline: it parses your sources into an evidence ledger, Claude writes the claims and the prose against that ledger, and the pipeline then refuses to render anything whose numbers, quotes or citations are not in the evidence. Output is a real DOCX — table of contents, page numbers, Word tables, charts drawn from your data, your own template if you have one — plus a QA pack recording, per sentence, why it was allowed to ship.

Offline, no API key, no model call in the checker. Installs with `pip install report-workflow` plus copying `agent_skill/` into `~/.claude/skills/`.
