### PR TITLE
Add Attention Control to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[Attention Control](https://github.com/aaddrick/attention-control)** | Air traffic control discipline for agent output: the action first, the background last, one meaning per word |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Attention Control borrows two disciplines from air traffic control and applies them to what a coding agent writes back. Fixed message shape puts the action first and the background last. Controlled vocabulary gives each word one meaning.

It fits Community Skills because it ships as a SKILL.md and installs the same way as the rest of the section. Claude Code also has a native output style slot, so the style can load there instead.

I adapted the shape layer from the i-have-adhd skill by Ayoub G. (MIT), and the language layer from L1nefeed's asd-ste100 output style, itself condensed from ASD-STE100 Issue 9. MIT licensed, 30 stars.