### PR TITLE
Add liu-xiaoyan-skill (CET-4/6 & Kaoyan English)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[liu-xiaoyan-skill](https://github.com/tong666-bit/liu-xiaoyan-skill)** | Liu Xiaoyan-style CET-4/6 & Kaoyan English coaching skill with 2026.6 CET-6 three-set answer keys and writing/translation guidance |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds a community skill for CET-4/6 and Kaoyan English exam prep in a Liu Xiaoyan-style coaching tone (actionable, exam-focused).\n\n- Repo: https://github.com/tong666-bit/liu-xiaoyan-skill\n- Highlights: 2026.6 CET-6 three-set answer keys, writing/translation guidance, reading synonym-paraphrase method\n- License: MIT\n- Release: https://github.com/tong666-bit/liu-xiaoyan-skill/releases/tag/v1.1.0