### PR TITLE
Add Alter — digital persona skill (local-first, self-benchmarking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[alter](https://github.com/alter-persona/alter)** | Build and run a digital persona of the user — interviews them through chat and voice memos, learns from their documents and AI chat exports, then chats and drafts messages in their voice. Local-first (Postgres + whisper.cpp + Ollama), improves from every correction, and benchmarks itself against sealed hold-out questions |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What this adds

One row in **Community Skills → Individual Skills** for [Alter](https://github.com/alter-persona/alter) (Apache-2.0).

Alter builds a digital persona of the user from a chat interview (voice memos transcribed locally via whisper.cpp), their documents, and their exported AI chats — then chats and drafts messages/emails in their voice. It keeps improving from corrections; when new information contradicts stored facts it asks instead of overwriting. Eight sealed validation questions are held out of memory so the persona can benchmark itself against the real person and report the gaps.

## Social proof / signals

- Live on skills.sh: https://skills.sh/alter-persona/alter (`npx skills add alter-persona/alter` — the pack follows the agentskills.io layout, `skills/alter/SKILL.md`, validated with `skills-ref validate`)
- Cross-platform: same SKILL.md loads as `ready` on OpenClaw and installs into Claude Code via the skills CLI symlink; also runs on Hermes (`hermes skills tap add alter-persona/alter`)
- Released v0.1.1 with protected release tags; full local-first setup documented (Docker Postgres + pgvector, whisper.cpp, Ollama; ElevenLabs optional for voice replies)
- Young project (released this month) — happy to have it re-categorized or held to whatever bar you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)