### PR TITLE
Add pdp-audit — ecommerce product page UX audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[pdp-audit](https://github.com/llizell/pdp-audit)** | Audits ecommerce product detail pages against 82 research-backed UX and conversion guidelines — captures the live page at desktop and mobile widths via Playwright and produces a prioritized, evidence-based report with severity and effort ratings |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [pdp-audit](https://github.com/llizell/pdp-audit) to Individual Skills.

**What it does:** audits ecommerce product detail pages against a knowledge base of 82 UX/conversion guidelines (organized by page zone: gallery, buy box, shipping, reviews, mobile, accessibility…). With Playwright MCP it captures the live page at 1440px/390px, tests interactions, and inspects the DOM; without browser tooling it degrades to screenshot mode. Output is a single prioritized report — max 12 findings with severity, observed evidence, dev-ready recommendations, and S/M/L effort — plus a "verify manually" list. Guidelines are compiled from freely accessible public sources; MIT licensed, with a [sample report](https://github.com/llizell/pdp-audit/blob/main/examples/sample-report.md) from a real audit in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)