### PR TITLE
Add claude-code-vision-skill to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[claude-code-vision-skill](https://github.com/xiincs/claude-code-vision-skill)** | Routes screenshots to external vision APIs (Doubao, Qwen, GPT-4o, or custom OpenAI-compatible endpoints) so Claude Code sessions on text-only models like DeepSeek can analyze images; auto-detects native vision support via a SessionStart hook to skip the extra call when it isn't needed |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds vision capability to Claude Code sessions running on text-only backing models (e.g. DeepSeek) by routing screenshots to an external vision API (Doubao, Qwen, GPT-4o, or any OpenAI-compatible endpoint) and returning the analysis as text.

- Auto-detects whether the active session already has native vision support via a `SessionStart` hook, so the external call is skipped when it isn't needed
- Real-world use case: running Claude Code on a proxied/text-only model but still wanting to paste screenshots for UI review, error diagnosis, or chart analysis

Repo: https://github.com/xiincs/claude-code-vision-skill

## Checklist

- [x] Entry added to the "Individual Skills" table under Community Skills, following the existing row format
- [x] Description is one line, no emojis, consistent with neighboring entries