### PR TITLE
Add new hunting skill to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
-| **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
+| **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation
+| **[hunting-skill](https://github.com/Johnhart811/hunting-skill)** | Gives Claude a 7-rung escalation ladder (source → issues/PRs → forks → adjacent fields → named practitioners) so it stops at the best answer instead of the first one ||
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |


### PR DESCRIPTION
Adds hunting-skill — gives Claude a 7-rung source-escalation ladder (web → repo source → issues/PRs → forks → adjacent fields → spec/paper → named practitioners) instead of stopping at the first search result.