### PR TITLE
Add unity-cli-skill (Unity Editor automation via the official Unity CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[unity-cli-skill](https://github.com/ZHAO0424/unity-cli-skill)** | Unity Editor automation via the official Unity CLI — 140+ editor commands for scene editing, tests, headless builds, and C# eval, with a screenshot self-verification loop |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[unity-cli-skill](https://github.com/ZHAO0424/unity-cli-skill)** to Individual Skills.

A field-tested skill that drives the Unity Editor through the **official Unity CLI** (`unity` command + `com.unity.pipeline`) — no third-party editor plugins, no MCP server:

- 140+ built-in editor commands (scenes, GameObjects, components, materials, prefabs, console, packages)
- EditMode/PlayMode tests and headless batch builds
- Arbitrary C# via `eval` for sub-second batched operations (no domain reload)
- Screenshot self-verification loop: the agent captures the Game view, reads the image, and iterates
- Every command, parameter format, and pitfall verified against a live Unity 6 project; ships a generated 140-command reference and an eval snippet library

Bilingual README (EN/中文), MIT licensed.