### PR TITLE
Add multi-llm-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[multi-llm-plugin](https://github.com/beastlabai/multi-llm-plugin)** | Multi-LLM orchestration plugin for Claude Code: parallel plan review, task generation, implementation, and code review across 12 coding harnesses (Codex, Cursor, opencode, pi, aider, Antigravity…) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What this adds

One row in the **Community Skills → Individual Skills** table for [multi-llm-plugin](https://github.com/beastlabai/multi-llm-plugin):

> Multi-LLM orchestration plugin for Claude Code: parallel plan review, task generation, implementation, and code review across 12 coding harnesses (Codex, Cursor, opencode, pi, aider, Antigravity…)

## Why it's valuable

It turns Claude Code into an orchestrator over the other CLI coding agents the user already has installed: fan out a plan review, task generation, an implementation run, a code review, or a free-text question to up to 12 harnesses in parallel, then get a consolidated comparison back. It goes well beyond a single `SKILL.md`: the skill ships provider adapter scripts, a providers config system, and an e2e test harness, and it is documented in the repo README (with a full video walkthrough).

- **Prerequisites**: Claude Code plus whichever of the supported harness CLIs (and their API keys/subscriptions) you want to fan out to — it uses your locally installed tools; no third-party server of ours is involved, and nothing routes through the submitter's infrastructure.
- **License**: MIT (declared in the plugin manifest).
- **Install**: `/plugin marketplace add beastlabai/multi-llm-plugin`, then `/plugin install multi-llm`.

## Honest disclosures (please read before reviewing)

- **Star count is below the threshold**: the repo currently has **8 stars**, under the 10-star social-proof minimum in CONTRIBUTING.md. I'm not inflating or hiding that; if the auto-close policy applies, I understand, and I'll resubmit once it crosses 10.
- **AI assistance**: this PR was prepared and submitted with the help of Claude Code, acting on my direction. CONTRIBUTING.md asks for PRs that are not explicitly AI-generated/submitted, so I'm flagging this openly rather than pretending otherwise — I'd rather be disqualified honestly than merged on a false pretense. The plugin itself is my own project, human-designed, tested end-to-end, and dogfooded daily.

All links in the added row were tested. One item per PR, formatted to match the existing table rows.
