### PR TITLE
Add Homespun to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[Homespun](https://github.com/homespunapps/homespun/tree/main/skills/homespun)** | Deploy a real multi-user web app from the conversation: its own URL, magic-link sign-in, a shared realtime database and per-role permissions. The agent keeps read and write access to the app's data afterwards, so it can query, watch and redeploy it later. Site at [homespun.dev](https://homespun.dev) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds one row to the **Individual Skills** table. Nothing else touched.

**Homespun** is a Claude Agent Skill that deploys a real, running multi-user web app from the conversation and keeps operating it: the skill authors an HTML page plus a manifest, then puts it live on its own URL with magic-link sign-in, a shared realtime database, per-role read/write/delete permissions, email notifications and file uploads. The agent keeps read and write access to the app's data afterwards, so it can query, watch and redeploy the app in later conversations.

The difference from an artifact or a code export is that other people sign in and use the result together, so what you get back is a running app rather than a preview.

- Skill: [`skills/homespun/SKILL.md`](https://github.com/homespunapps/homespun/blob/main/skills/homespun/SKILL.md)
- Also on the official MCP registry as `dev.homespun/homespun`, and in [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers)
- Works in Claude Code and via the remote connector at `https://homespun.dev/mcp`
- MIT licensed