### PR TITLE
Add mubu-integration to Community Skills (Individual Skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Skills for working with complex file formats:
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 
+| **[Mubu (幕布) Integration](https://github.com/liuboacean/mubu-integration)** | Mubu (幕布) outline CLI & AI Agent Skill — import/export Markdown with true round-trip fidelity, plus OPML/FreeMind export. |
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
Hi! I'd like to add **mubu-integration** to this list.

**What it is:** Mubu (幕布) outline CLI & AI Agent Skill — import/export Markdown with true round-trip fidelity, plus OPML/FreeMind export.

- Repo: https://github.com/liuboacean/mubu-integration
- 中文落地页: https://github.com/liuboacean/mubu-integration/blob/main/README.zh-CN.md
- Positioned as an AI Agent Skill (Claude Code / Agents), not just a CLI.

Accurate description (no exaggeration): outline↔Markdown sync with lossless round-trip, OPML/FreeMind export.

Thanks for maintaining this awesome list!
