### PR TITLE
Add Academic Claude Skills (research-lifecycle skill library)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[Academic Claude Skills](https://github.com/Nero1688/claude-academic-skills)** | 35 skills for the full research lifecycle (quant/qual/experimental/mixed): method selection, data scouting, causal identification (staggered DiD/IV/RDD), literature matrices, peer-review simulation, and reproducible replication packages, built on an anti-hallucination discipline (a citation miss fails loudly instead of fabricating one) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **Academic Claude Skills** — a free, open-source library of 35 Claude Skills covering the full research workflow (quantitative, qualitative, experimental, and mixed methods), with an anti-hallucination discipline: numbers trace back to a source, citations are checkable, and a data/citation miss fails loudly instead of fabricating a plausible-looking result.

- Category: **Individual Skills** (added in alphabetical order, following the existing entry format).
- Repo: https://github.com/Nero1688/claude-academic-skills

Thanks for maintaining this list!