### PR TITLE
Add Claude Market to Community Skills > Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[Claude Market](https://claudemarket.ai)** - Directory of 13,891+ MCP servers, 3,688+ Claude Code plugins, and Agent Skills, searchable via web or `npx remoteopenclaw search <query>`
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
Adding Claude Market (claudemarket.ai) — a free directory of 13,891+ MCP servers, 3,688+ Claude Code plugins across 1,463 marketplaces, and Agent Skills for Claude Code, OpenClaw, Codex, and Hermes. Searchable via web or a free MCP server (`npx remoteopenclaw search <query>`, no API key).

Added one line under Community Skills > Tools, matching the existing entry format.