### PR TITLE
Add pm-skills to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Skills for working with complex file formats:
   - Uses new techniques that are still being refined and tested (i.e. skills here may change over time)
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
+- **[product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills)** - Product management skill library with 68 skills spanning discovery, definition, delivery, measurement, and iteration
+  - 6 sub-agents, 12 multi-skill workflows, and 200+ real sample outputs
+  - Every skill is held to a CI-enforced contract and versioned with SemVer, so counts and behavior stay accurate as the library changes
+  - Follows the agentskills.io specification, Apache 2.0
+  - Installation: `npx skills add product-on-purpose/pm-skills`
 
 
 ### Individual Skills


### PR DESCRIPTION
Adds `pm-skills` to **Community Skills > Collections & Libraries**, alongside the other multi-skill libraries in that section.

### Social proof (per CONTRIBUTING)

The contributing guide requires a skill to have acquired community adoption, with a floor of 10 stars. Current numbers:

- **523 GitHub stars**, 68 forks
- **31.1K installs** on skills.sh
- 66 tagged releases since 2026-01-09, currently v2.31.1
- Listed in Anthropic's community plugin marketplace

This is not a newly created skill; it has been developed and released continuously for seven months.

### About the library

68 product management skills covering discovery, problem definition, solution design, delivery, measurement, and iteration, plus 6 sub-agents, 12 multi-skill workflows, and 200+ real sample outputs.

Each skill is held to a contract validated in CI and versioned with SemVer, so the description in this list will not drift as the library changes.

Apache 2.0, follows the agentskills.io specification.
