### PR TITLE
Add PolySkill to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[PolySkill](https://polyskill.ai)** - npm-style registry for Claude Code skills: search, install, create & publish from a CLI or the web. Open source, security-scanned listings
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
Adding [PolySkill](https://polyskill.ai) (my project) to the Tools section.

It's an open-source, npm-style registry for Claude Code skills — search, install, create & publish via CLI (`@polyskill/cli`) or the web. Every listing is security-scanned before it goes live, and skills work across LLM runtimes (adapters for Claude/OpenAI/Gemini/Grok/Kimi formats).

Repo: https://github.com/MrSpacemann/polyskill

Entry follows the existing format in the section. Happy to adjust wording or placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZA4TxoUxrSmTYvuP6L2BF