### PR TITLE
Add write-like-human under Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[write-like-human](https://github.com/hamidkkhan/write-like-human)** | Removes AI tells from prose. Includes a dependency-free Python linter that measures sentence-length variance and structural patterns alongside the usual vocabulary checks |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds one entry to Community Skills → Individual Skills.

**[write-like-human](https://github.com/hamidkkhan/write-like-human)** — removes AI tells from prose.

Most anti-AI-writing tooling is a banned word list. Ban "delve" and the model writes "explore", so the tell moves rather than disappearing. This skill leads with structure instead: open with the fact, never close on a restatement, and vary sentence length. It ships a linter that reports the standard deviation of sentence length, which is measurable and correlates well with generated prose.

- MIT licensed
- `SKILL.md` at repo root, works as a plain `git clone` into `~/.claude/skills/`
- Also released as `.skill` and `.zip` for the desktop app and claude.ai upload
- Linter is a single Python file, no dependencies, exit code 1 on structural flags so it fits a pre-commit hook

Happy to adjust the wording or move it to a different section if you'd prefer.