### PR TITLE
Add SubFlow to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[SubFlow](https://github.com/IcaroPv01/subflow)** | 100% local subtitle pipeline (transcribe + translate + QC + ASR hallucination detection) for Claude Code. CLI + skill for PT-BR/EN documentaries |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds [SubFlow](https://github.com/IcaroPv01/subflow) to the **Individual Skills** section.

SubFlow is a 100% local subtitle pipeline (CLI + skill for Claude Code) that:
- Transcribes any video with Whisper locally (no API costs)
- Translates in batches (text-only, timing preserved)
- Runs Netflix-style QC automatically
- Detects ASR hallucinations (langcheck)
- Includes PT-BR presets for documentary translation

Use case: documentary translation, fan-subbing, accessibility — all 100% local and free.

Repo: https://github.com/IcaroPv01/subflow (v0.2.0, MIT)
Demo: https://www.youtube.com/watch?v=8wywC_Evx9E