### PR TITLE
Add Neuro-NLP-booster skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[Neuro-NLP-booster](https://github.com/dankofly/Neuro-NLP-booster)** | Neuromarketing copywriting: Limbic motive targeting, Milton Model language patterns, neuro-scoring, and a 5-voice internal council that vetoes cringe and manipulative copy before it ships |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [Neuro-NLP-booster](https://github.com/dankofly/Neuro-NLP-booster) to Individual Skills.

A copywriting skill that turns Claude into a neuromarketing copywriter: Limbic motive targeting, Milton Model patterns, Sleight of Mouth reframes, 0-100 neuro-scoring, and a 5-voice council (3 optimists, 2 critics) that vetoes cringe and manipulative copy before it ships. Grounded in published sources (Häusel, O'Connor, Dilts). Covers copy and matching design specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)