### PR TITLE
Add: free-vision-skill (local vision for vision-less models)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Skills for working with complex file formats:
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
+| **[free-vision-skill](https://github.com/niyongsheng/free-vision-skill)** | Fully-local OCR \& image understanding for vision-less models (DeepSeek V4 Flash etc.) via macOS Vision: text extraction, table detection, content description, QR decode. Zero network, zero API keys |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |


### PR DESCRIPTION
Adds [free-vision-skill](https://github.com/niyongsheng/free-vision-skill) to the Individual Skills table.

Fully-local image understanding skill for Claude Code, powered by macOS Vision Framework:
- OCR (Chinese & English) in reading order
- Table detection (`--layout`) with coordinates
- Content description (`--describe`) for vision-less models (e.g. DeepSeek V4 Flash)
- QR/barcode decode, zero network, zero API keys

Requires macOS 11+.