### PR TITLE
Add claw-hwp (Korean HWP .hwp/.hwpx editing skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[claw-hwp](https://github.com/DoHyun468/claw-hwp)** | Reads, creates, and edits Korean HWP (.hwp/.hwpx) documents in place, without Hancom Office or format conversion |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **claw-hwp** under Community Skills → Individual Skills.

claw-hwp is a Claude Code (and Codex) skill that reads, creates, and edits Korean Hangul Word Processor documents (.hwp/.hwpx) in place at the byte level, without Hancom Office or format conversion, preserving tables and styling. It verifies that edited files open uncorrupted in Hancom Office / Hancom Docs, and runs locally on macOS and Windows. Built on the rhwp WASM core; MIT-licensed.

Repo: https://github.com/DoHyun468/claw-hwp