### PR TITLE
Add WordPress Security Audit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[WordPress Security Audit](https://github.com/mwstech/wp-security-audit-skill)** | Audits a live WordPress site from outside its own runtime (SSH + external HTTP checks), so a compromised site can't feed the auditor clean results the way an in-site plugin can. Remote and full modes; findings tiered Critical/Important/Polish with the exact fix for each |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds a free, MIT-licensed skill under **Community Skills → Individual Skills**.

It audits a running WordPress site rather than a codebase. The distinguishing part: it works from outside the PHP runtime — SSH at the shell plus external HTTP checks — which is the thing an in-site security plugin structurally cannot do, since it runs inside the same runtime a compromise controls.

What it does:
- Cross-checks every plugin and theme against WPScan / Patchstack / NVD
- Reviews wp-config, file permissions, and users
- Sweeps for existing compromises (rogue admins, injected code, malware)
- Two modes: remote (URL only) and full (SSH/WP-CLI)
- Outputs findings tiered Critical / Important / Polish, each with the exact fix command

Read-only by design — no exploit attempts, no brute force.

Repo: https://github.com/mwstech/wp-security-audit-skill
