### PR TITLE
Add claude-nuxt-fullstack-scaffold (community skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[claude-nuxt-fullstack-scaffold](https://github.com/rga-rt/claude-nuxt-fullstack-scaffold)** | Scaffold production-ready Nuxt 3 apps with Tailwind, Vitest, and optional i18n, SQLite (Drizzle), or Supabase; installable as a Claude Code plugin |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [claude-nuxt-fullstack-scaffold](https://github.com/rga-rt/claude-nuxt-fullstack-scaffold) to the **Community Skills → Individual Skills** table, following the existing `| **[name](url)** | Description |` format.

A Claude skill for scaffolding production-ready Nuxt 3 apps with Tailwind, Vitest, ESLint, and optional i18n, SQLite (Drizzle), or Supabase. Ships 3 runnable, CI-tested examples and is installable as a Claude Code plugin.