### PR TITLE
Add grant-compass to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[grant-compass](https://github.com/rx290/grant-compass)** | Finds fully-funded scholarships at any degree level and matching professors, scored against the applicant's grades and field, defaults to Europe |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds grant-compass, a Claude Code skill + CLI that finds fully-funded scholarships at any degree level (Bachelor's/Master's/PhD) and matching professors, scored against the applicant's grades and field. Defaults to Europe, extensible to other regions via a tagged source registry.

- More than a single SKILL.md: includes a CLI (`grantcompass init|professors|score|report`), a curated source registry (`sources.yaml`), a pure-Python scoring engine with unit tests, and a report generator.
- No paid third-party API required — the deterministic fetching/scoring runs in plain Python; only the live web-search step (for sources without a stable API) uses Claude Code's own WebSearch/WebFetch.
- MIT licensed.

Repo: https://github.com/rx290/grant-compass