### PR TITLE
Add workflow-design to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Skills for working with complex file formats:
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 
+| **[workflow-design](https://github.com/ghorbanies/workflow-design)** | Design, prove, measure, and safely change workflows — approval chains, ticketing, human gates over AI output. Four stdlib-only tools (flow linter, guard red-proof runner, transition-log metrics, log-vs-model conformance), each self-tested and red-proofed by shipped specs |
+
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools


### PR DESCRIPTION
Adds **[workflow-design](https://github.com/ghorbanies/workflow-design)** — a skill for designing, proving, measuring, and safely changing workflows (approval chains, review pipelines, ticketing, human gates over AI output).

Why it may earn a place on the list:

- **Fills an empty category**: as far as I can tell, no listed skill covers workflow/state-machine design, workflow test auditing, or transition-log metrics.
- **Substance over claims**: ships four stdlib-only Python tools (flow linter, guard red-proof runner, transition-log metrics, log-vs-model conformance). Each has a `--selftest`, and each is red-proofed by a shipped spec — including the red-proof runner itself, which found a hollow assertion in its own safety net on first run (documented in the repo).
- **Evaluated**: seven eval scenarios (including a negative control) run on fresh agents, 35/36 — results recorded in the CHANGELOG.
- **Non-promotional**: MIT, no SaaS, no external services; everything runs locally.

On social proof: the repo is newly published, so install counts and stars are still at zero — I'm submitting on the strength of the shipped evidence and happy to wait or resubmit later if the list prefers demonstrated traction first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)