### PR TITLE
Add collection-skill to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[collection-skill](https://github.com/Yuuqq/collection-skill)** | Discovers and catalogs 150+ scraping/collection tools on GitHub into five categories, then progressively recommends the right one and starts crawling — per-tool workflows for Scrapy, Playwright, Crawl4AI, MediaCrawler |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **collection-skill** to the Individual Skills table.

**What it is:** an agent skill that discovers and catalogs 150+ scraping/collection tools on GitHub (five categories: `web-scraper`, `dynamic-scraper`, `api-collector`, `agent-skill`, `dataset`), then progressively recommends the right tool and starts crawling. Ships per-tool, compliance-gated workflows for Scrapy, Playwright, Crawl4AI, and MediaCrawler; the catalog self-refreshes weekly via GitHub Action with LLM judging guarded by deterministic safe-pruning rules.

- Repo: https://github.com/Yuuqq/collection-skill
- Install: `npx skills add Yuuqq/collection-skill` (Claude Code / Cursor / Codex — open Agent Skills format)
- MIT licensed, README in EN / 简体中文 / 日本語 / Español
- Safety: respects `robots.txt`, rate limits, ToS; confirms scope before first crawl of a new domain
