### PR TITLE
Add seudesign (system design skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[seudesign](https://github.com/SeuPut0705/seudesign)** | Executable system design skill — generates design docs with capacity math and diagrams, audits codebase architecture (file:line findings), runs rubric-scored mock interviews, estimates capacity; 22 worked case studies and a bundled reviewer agent |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [seudesign](https://github.com/SeuPut0705/seudesign) to Individual Skills.

Executable system design skill for Claude Code & Codex: generates design docs (capacity math + mermaid diagrams), audits codebase architecture as file:line findings, runs rubric-scored mock interviews, and does capacity estimation. 22 worked case studies, 13 references, bundled read-only reviewer agent. MIT, CI-validated plugin marketplace install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)