### PR TITLE
Add finance-video-copywriting: viral Chinese finance short-video copywriting skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[finance-video-copywriting](https://github.com/SSRYLJRSS/finance-video-copywriting)** | Generates viral Chinese finance short-video voiceover scripts via a 7-step SOP: analyzes reference copy, verifies facts, drafts outlines and scripts, creates cover titles, and learns from user revisions (Chinese content, MIT, pure Markdown no scripts) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## What

Adds [finance-video-copywriting](https://github.com/SSRYLJRSS/finance-video-copywriting) to Individual Skills.

A Claude-style Agent Skill (SKILL.md format, MIT licensed) that generates viral Chinese finance short-video voiceover scripts via a 7-step SOP (S0-S7):
- Analyzes reference copy and extracts structure/emotion/key-lines
- Collects and cross-verifies facts with sources
- Drafts 1500-2000 char voiceover scripts in a punchy, colloquial style
- Creates cover titles, and learns from user revisions (self-improving experience library)

## Why
- Vertical & differentiated: Chinese-language finance content skill is scarce
- Pure instructions, no scripts: only Markdown rule files — no network calls, no credential access
- Battle-tested: v2.1.0, iterated over real production use, bilingual EN/ZH description

## Checklist
- [x] Forked & added to appropriate section
- [x] Follows existing table format
- [x] MIT License included