### PR TITLE
Add pc-doctor — bilingual computer health check skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[pc-doctor](https://github.com/Xplore-LAB/pc-doctor)** | Bilingual (EN/中文) Linux computer health check skill for Claude Code — light (~30s) and deep (~3-5min) modes, 0 dependencies, 0 network calls, conservative thresholds, read-only diagnostics across CPU/memory/disk/processes/network/services/SMART/security/updates |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Add [pc-doctor](https://github.com/Xplore-LAB/pc-doctor) — a Claude Code skill that performs bilingual (English / 中文) computer health checks on Linux systems.

## Why it fits this list

- **Standalone value**: zero dependencies, zero network calls (besides a connectivity ping), works on any Linux box with bash + standard utilities
- **Two modes for different needs**:
  - `/pc-doctor` (light, ~30s): OS, CPU, memory, disk, top processes, network, failed services
  - `/pc-doctor --deep` (~3-5min): adds SMART disk health, thermal, I/O, boot, logs, security audit, pending updates
- **Bilingual README + SKILL.md** — first-class EN/中文 support (one of the few skills explicitly designed for both languages)
- **Conservative thresholds** — under-warns rather than cries wolf
- **Read-only diagnostics** — no fixes, no mutations; safe to run on production machines

## Installation

```bash
git clone https://github.com/Xplore-LAB/pc-doctor.git ~/.claude/skills/pc-doctor
```

## Repository metadata

- License: MIT
- Topics: `claude-code`, `claude-skill`, `skill`, `health-check`, `bilingual`, `linux`, `sysadmin`, `computer-diagnostics`
- Maintainer: [@Xplore-LAB](https://github.com/Xplore-LAB)

Happy to move / rephrase / split per reviewer feedback.