### PR TITLE
Add comfortable-roadtrip-planner to community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[comfortable-roadtrip-planner](https://github.com/CrazyRiceMaker/comfortable-roadtrip-planner)** | Comfort-first road trip / 自驾路书 skill: interactive HTML route app, A/B/C stops, pregnancy-friendly pacing, maps, meals, calendar .ics |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
Add [comfortable-roadtrip-planner](https://github.com/CrazyRiceMaker/comfortable-roadtrip-planner), an Agent Skill for Codex, Claude Code, Cursor, and OpenClaw.

It plans comfort-first multi-day self-drive trips around already-booked hotels and limited stamina, ranks stops A/B/C, and outputs a one-file interactive HTML route app (maps, meals, tickets, calendar .ics).

## Why it belongs here
- Public MIT skill with SKILL.md, evals, and a redacted golden HTML example
- Distinct from generic sightseeing dumps: hotels stay fixed, pacing is pregnancy/low-stamina aware
- Installable via git clone into standard skills directories

## Test plan
- [ ] Link resolves
- [ ] Description matches the repo

Made with [Cursor](https://cursor.com)