### PR TITLE
Add humanize-mba-text skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[humanize-mba-text](https://github.com/stephenlzc/humanize-mba-text-skill)** | Detects and rewrites AI writing patterns in Chinese MBA theses toward natural academic style |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds humanize-mba-text-skill to the Individual Skills table. A Claude/AI coding skill that detects and rewrites AI writing patterns in Chinese MBA theses toward natural academic style, with detection + rewriting workflows, example outputs, and multilingual documentation (EN/JP/KR). 38+ stars, MIT licensed.