### PR TITLE
Add dsh-desktop-app — DeepSeek Harness desktop shell skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[dsh-desktop-app](https://github.com/happpsee/dsh-desktop-app)** | Packages the DeepSeek Harness web GUI into a Tauri 2 desktop app (macOS + Windows) with tray lifecycle and session sharing, including dual-platform install playbooks, China mirror bootstrap, and admin-free Windows toolchain recipes |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [dsh-desktop-app](https://github.com/happpsee/dsh-desktop-app) to the Individual Skills table.

A Claude/DSH-compatible SKILL.md skill that packages the DeepSeek Harness web GUI into a Tauri 2 desktop app (macOS + Windows, ~11MB): tray-resident lifecycle, single-instance, subprocess cleanup, and session sharing with the browser. Includes dual-platform install playbooks, China mirror bootstrap (rustup/cargo/npm/GitHub/NSIS), a subagent sentinel for download-timeout detection, and an admin-free Windows toolchain recipe (no VS Build Tools required).

- Non-promotional description
- MIT licensed code; icon CC BY-NC-SA 4.0 with attribution