### PR TITLE
Add llm-wiki-loop to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[llm-wiki-loop](https://github.com/PALAN-K/llm-wiki-loop)** | Production framework for self-improving LLM knowledge vaults with mechanical evidence linting, 0-hallucination checks, and auto-skillification |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
### What does this PR do?
Thanks to @travisvn for curating this great resource on Claude skills!

This PR adds **[llm-wiki-loop](https://github.com/PALAN-K/llm-wiki-loop)** to the Individual Skills table.

### Highlights
- Implements Karpathy's persistent LLM-wiki pattern for Claude Code with automated grounding verification.
- Enforces 0-hallucination rules by mechanically validating dates, numbers, and quotations against immutable raw sources.
- Self-organizing lifecycle with event-driven archival and auto-skill promotion for repeated workflows.
- Single command scaffolding via \
px llm-wiki init\.

Thank you for your consideration!