### PR TITLE
Add UIZZE anti-UI-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[UIZZE anti-UI-slop](https://github.com/uizze/uizze)** | Portable UI quality gate for Claude Code that catches generic interfaces and missing interaction states before they ship, grounded in 800,000+ real web and iOS screens; install with `npx skills add https://uizze.com --skill anti-ui-slop` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds UIZZE to the community skills table as a portable UI quality gate for Claude Code. It catches generic interfaces and missing interaction states before they ship, and is grounded in 800,000+ real web and iOS screens.\n\n- Canonical repo: https://github.com/uizze/uizze\n- Product: https://uizze.com\n- Install: `npx skills add https://uizze.com --skill anti-ui-slop`\n- The listing describes the public free skill without provider metadata or private implementation details.