### PR TITLE
Add visualizer (video understanding) to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[visualizer](https://github.com/TomSchoe/visualizer)** | Lets Claude actually watch and analyze videos (YouTube, 100+ platforms, local files) via Gemini-native video understanding plus transcript and description-link extraction; transcript-only mode works without any API key |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[visualizer](https://github.com/TomSchoe/visualizer)** — lets Claude actually watch and analyze videos (YouTube, 100+ platforms via yt-dlp, local files) through Gemini-native video understanding (visuals + audio + timestamps) plus transcript and description-link extraction. MIT licensed; also installable in Codex/Cursor/Gemini CLI via `npx skills add TomSchoe/visualizer -g`. Transcript-only mode needs no API key at all.

Would be the first video-understanding skill in the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)