### PR TITLE
Add ai-tell-detector to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[ai-tell-detector](https://github.com/aragossa/ai-tell-detector)** | Audits a finished draft for patterns that make text read as AI-generated (24 checks, EN + RU) and flags each with the line it's on and a suggested fix |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [ai-tell-detector](https://github.com/aragossa/ai-tell-detector) — a skill that audits a finished draft for the patterns that make text read as AI-generated (rhetorical symmetry, uniform rhythm, over-resolved arcs, fabricated personal experience and 20 more checks), flagging each with the line it's on and a suggested fix. MIT, English and Russian versions included, works in Claude Code / Claude.ai / any SKILL.md-compatible tool.

Fun fact from the README: the same three fully machine-generated test posts scored 95/85/90% AI on ChatGPT, 80/75/85% on Grok and 15/25/65% on Gemini — which is why the skill reports patterns with line numbers instead of a percentage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)