### PR TITLE
Add flutter-smoke-auto (Flutter three-platform smoke testing + anti test-weakening gates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Skills for working with complex file formats:
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
+| **[flutter-smoke-auto](https://github.com/ceeyang/flutter-smoke-auto)** | Automated smoke testing for Flutter apps (Android/iOS/Web) — derives journeys from source, generates Maestro/Playwright suites from a selector contract, self-heals failures, and ships integrity gates that block AI agents from weakening tests |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |


### PR DESCRIPTION
Adds **[flutter-smoke-auto](https://github.com/ceeyang/flutter-smoke-auto)** — a Claude Code skill for fully automated Flutter smoke testing across Android, iOS, and Web.

What sets it apart from existing Maestro/Playwright entries:
- Full pipeline: derives user journeys from source → instruments the app (`Semantics(identifier:)`, shared across all three platforms) → generates Maestro flows + Playwright specs from a selector contract registry → executes → triages (TEST_DEFECT / APP_DEFECT / ENV_FLAKE) → self-heals → reports.
- Ships **framework-agnostic integrity gates** (zero-dependency Python, 43 regression tests) that block AI agents from weakening tests: deleted assertions, added skips, weakened matchers, inflated timeouts — usable standalone with Jest/pytest/Go test/JUnit/Cypress too.
- Deterministic CI: no LLM calls at execution time.

MIT licensed. Docs body currently in Chinese with a full English README; English translation on the roadmap.