### PR TITLE
Add simple-man to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[simple-man](https://github.com/Maksim-Burtsev/simple-man)** | Strips praise, recaps and filler from agent answers while keeping every fact you act on — findings carry their location and fix, tutorials stay long-form. Benchmarked on 1,793 preregistered live calls with raw records committed |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [simple-man](https://github.com/Maksim-Burtsev/simple-man): a communication policy that strips praise, recaps and filler from agent answers while keeping every fact you act on — every review or security finding carries its location, consequence and one-line fix, a refusal names the missing precondition and the safe procedure, and tutorials or detailed reports are still written in full.

MIT, working `SKILL.md`, installs into Claude Code with `npx skills add Maksim-Burtsev/simple-man -g -a claude-code -s simple-man -y`.

Measured rather than claimed: two preregistered runs on `claude-sonnet-5`, 1,793 live calls, all raw records committed — median answer 833 → 520 tokens (−32.4%) with required-fact retention equal to the no-policy baseline. Every published number is rebuilt from the raw records in CI.

One table row added at the end of the section.