### PR TITLE
Add wavespeed-skill (media generation via the WaveSpeed CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[wavespeed-skill](https://github.com/WaveSpeedAI/wavespeed-cli/tree/main/skills)** | Generate and edit images, video, audio, and 3D via the WaveSpeed platform's open-source CLI — live model catalog search, per-model schema introspection, local-file upload, price quotes before running |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds the WaveSpeed skill to Individual Skills.

- **Skill**: https://github.com/WaveSpeedAI/wavespeed-cli/tree/main/skills — the SKILL.md that `wavespeed skill install` writes for Claude Code / Cursor / Codex
- Lets the agent generate/edit images, video, audio and 3D through [WaveSpeed](https://wavespeed.ai): search the live model catalog, introspect any model's input schema, upload local files with `@path` markers, and quote prices before running
- CLI is MIT, maintained by the WaveSpeedAI org