### PR TITLE
Add sell-unused-tokens skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
-| **[sell-unused-tokens](https://github.com/galleonlabs/sell-unused-tokens)** | List leftover LLM API credits on tokensto.cash and cash out USDC (Revolut, Monzo, Chime, Zelle) |
+| **[sell-unused-tokens](https://github.com/galleonlabs/sell-unused-tokens)** | List leftover LLM API credits on tokensto.cash and cash out USDC (Revolut, Monzo, Chime, Zelle direct; Venmo, Cash App, Wise, PayPal after a one-time USDCtoFiat Verify registration) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[sell-unused-tokens](https://github.com/ADWilkinson/tokenstocash/tree/main/skills/sell-unused-tokens)** | List leftover LLM API credits on tokensto.cash and cash out USDC (Revolut, Monzo, Chime, Zelle) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
-| **[sell-unused-tokens](https://github.com/ADWilkinson/tokenstocash/tree/main/skills/sell-unused-tokens)** | List leftover LLM API credits on tokensto.cash and cash out USDC (Revolut, Monzo, Chime, Zelle) |
+| **[sell-unused-tokens](https://github.com/galleonlabs/sell-unused-tokens)** | List leftover LLM API credits on tokensto.cash and cash out USDC (Revolut, Monzo, Chime, Zelle) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds the community `sell-unused-tokens` skill to the Individual Skills table.

The skill lists leftover LLM API credits on https://tokensto.cash (seller front door for Surplus Intelligence) and cashes out USDC. Live rails today: Revolut, Monzo, Chime, Zelle only. Venmo, Cash App, Wise, and PayPal are coming soon.

Skill folder: https://github.com/ADWilkinson/tokenstocash/tree/main/skills/sell-unused-tokens