### PR TITLE
Add skill: australian-accounting-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[australian-accounting-skills](https://github.com/ryanduguid/australian-accounting-skills)** | Nine skills for Australian public-practice accounting: BAS, FBT, Division 7A, STP, month-end close and workpaper tie-outs. Primary-source-cited, MIT licensed |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **australian-accounting-skills** to the Individual Skills table.

**What it is:** Nine Claude Code skills for Australian public-practice accounting: BAS, FBT, Division 7A, STP, month-end close and workpaper tie-outs.

**Prerequisites/dependencies:** None beyond Claude Code; the skills are plain SKILL.md files.

**License:** MIT.

**Non-promotional:** No product, service or paid tier behind it. Written by a provisional CA ANZ member in his own time with no client data. Every skill cites primary sources (ATO rulings, legislation identifiers) rather than paraphrasing them, and releases are CI-gated with SBOM and provenance.

Happy to adjust placement or description length to match table conventions.