### PR TITLE
Add repo-cover to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[repo-cover](https://github.com/sjh9714/repo-cover)** | Designs GitHub social-preview cards (og:image) as a single self-contained HTML file, with four editorial moods, CJK-first typography, deterministic design checks, and a bundled render Action |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [repo-cover](https://github.com/sjh9714/repo-cover), following the table row pattern.

repo-cover is an agent skill that designs a repository's GitHub social-preview card (og:image, 1280x640) as one self-contained HTML file. There is no image model and no external service. The agent writes the HTML following a constrained design system, a stdlib Python checker validates canvas size, self-containment, WCAG contrast, and CJK line-breaking, and a bundled composite Action re-renders the PNG in CI. Four moods, MIT licensed, standalone value with nothing commercial attached.

On social proof, the project is young but concrete. The repo's own social preview is dogfooded output, every shipped example passes the checker in CI, and it installs through the Agent Skills CLI with `npx skills add sjh9714/repo-cover`.