### PR TITLE
Add unslopify to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[unslopify](https://github.com/youngfreezy/unslopify)** | Deterministic linter and rewrite skill for AI-writing patterns, with named rules, CI gates, and a phrase bank that flags repeated phrasing across documents |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [unslopify](https://github.com/youngfreezy/unslopify) to the Individual Skills table: a deterministic linter and rewrite skill for AI-writing patterns, with 29 named rules, a public before/after catalog, CI and pre-commit gates, and a phrase bank that flags repeated phrasing across documents. MIT, on PyPI, installable via npx skills add youngfreezy/unslopify.