### PR TITLE
Add danshari-skill (断舍离.skill) to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[danshari-skill (断舍离.skill)](https://github.com/swaylq/danshari-skill)** | Audits every skill you have installed and archives the ones your current model, harness, or MCP servers already cover — three-way triage, blind-test evidence before any removal, and one-command restore instead of `rm` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [**danshari-skill (断舍离.skill)**](https://github.com/swaylq/danshari-skill) — MIT, zero dependencies, bilingual README (中文 / English).

**What it does.** The ecosystem is all addition — awesome lists collect thousands of skills, single repos ship three hundred. This one does subtraction: it audits every skill an agent has installed against the *current* model, harness, and MCP servers, and archives the ones that no longer earn their per-turn description-token cost.

- **Three-way triage** — *capability* skills (the ones model upgrades obsolete), *environment* skills (obsoleted by harness features and MCP servers), *knowledge* skills (private facts — protected, never removed).
- **Blind test before removal** — a capability skill is never cut on a hunch. A subagent that does *not* load it attempts the skill's most typical task first; only matching quality justifies removal.
- **Never `rm`** — every removal is a move into an archive directory with a MANIFEST and `tools/archive.sh --restore <name>`. Private facts buried in an obsolete skill are extracted before it is archived.
- Ships an end-to-end [demo audit](https://github.com/swaylq/danshari-skill/blob/main/examples/2026-08-17-demo/report.md): 12 skills → 5, description tax 2,160 → 735 tokens/turn (-66%), every verdict backed by evidence.

Install: `git clone https://github.com/swaylq/danshari-skill.git ~/.claude/skills/danshari-skill`

Happy to move it to a different category, shorten the description, or split the entry — just say the word.
