### PR TITLE
Add sijiao-skill (私教.skill) to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[sijiao-skill (私教.skill)](https://github.com/swaylq/sijiao-skill)** | Distils any skill you want to learn into a stateful tutor — it remembers where you are, sets and grades exercises at your level, and schedules spaced review, with the ceiling honestly capped at competent |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [**sijiao-skill (私教.skill)**](https://github.com/swaylq/sijiao-skill) — MIT, zero dependencies, bilingual README, [site](https://swaylq.github.io/sijiao-skill/).

**What it does.** Name a skill you want to learn. It runs eight parallel research tracks (knowledge map, canonical sources, expert paths, deliberate practice, common sticking points, assessment, feedback communities, motivation), distils a learning-science curriculum, and writes a **stateful tutor** — a self-contained directory with a prerequisite-ordered curriculum, the tutor's own SKILL.md, and a private learner-state file.

The difference from "ask an LLM for a study plan" is state: it remembers which module you're on, what you got wrong, and schedules SM-2 spaced review — every session clears due items before new material.

**Quality gate** (any single failure blocks generation):
- prerequisite graph must be acyclic, and every "learn A before B" traces to a source
- every module needs a *gradeable* exercise, never "read this book"
- "you've got it" must be behavioural ("can do X unaided"), not "understands X"
- canonical resources need 3 independent recommendations; SEO listicles rejected
- the ceiling is capped at Dreyfus *competent* — claiming to make you an expert is disqualifying

Ships **6 end-to-end samples** (Rust, linear algebra, English reading, fat loss, skincare, strength training — 79 modules total), all engine-validated, and 35 green tests over the tooling engine. The three physiological ones are there to show how the framework downgrades honestly when AI can't actually judge the work.

Happy to move it to a different category or trim the description.
