### PR TITLE
Add claude-carbon (carbon footprint tracking for Claude Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[claude-carbon](https://github.com/gwittebolle/claude-carbon)** | Carbon footprint tracking for Claude Code - live CO2 in the status line, `carbon-report` and `carbon-card` skills for session reports and shareable PNG cards |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [claude-carbon](https://github.com/gwittebolle/claude-carbon), an MIT-licensed tool that tracks the CO2 footprint of Claude Code sessions: live estimate in the status line, per-model session reports, and shareable PNG report cards (EN/FR). 160+ stars, actively maintained since April 2026, methodology publicly documented. I'm the author.
