### PR TITLE
Add synomega skill (retrosynthesis & reaction prediction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[synomega](https://github.com/zbc0315/synomega-skill)** | Retrosynthesis and reaction prediction for organic molecules via the synomega package — single-step retro/forward prediction, multi-step route planning, synthesizability scoring (SynScore), reaction-plausibility screening, and multi-component evolution; runs locally on RDKit + a D-MPNN model |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds the **synomega** skill to Individual Skills.

[synomega](https://github.com/zbc0315/synomega-skill) wraps the [synomega](https://pypi.org/project/synomega/) Python package ([docs](https://zbc0315.github.io/synomega/)) so an agent can do organic-chemistry retrosynthesis and reaction prediction locally:

- single-step retrosynthesis (product → reactants) and forward prediction (reactants → product)
- multi-step route planning down to purchasable building blocks
- a continuous synthesizability score (SynScore)
- reaction-plausibility screening
- multi-component evolution (grow a forward synthesis network from a set of reactants)

Runs entirely locally on RDKit + a D-MPNN model (installed via `pip install synomega`; `clawhub install synomega`). MIT-licensed, published on PyPI, GitHub and ClawHub. It carries an explicit dual-use safety-boundary section deferring hazardous/controlled-compound judgments to the host policy.