### PR TITLE
Add app-store-rejection-checker (iOS pre-submission audit skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[app-store-rejection-checker](https://github.com/dabodamjan/app-store-rejection-checker)** | Audits an iOS app repo for App Store rejection risks before submission, fetching the current App Store Review Guidelines so findings cite the live guideline or the upload validation they trip |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [app-store-rejection-checker](https://github.com/dabodamjan/app-store-rejection-checker) to the **Individual Skills** table.

**What it does:** audits an iOS app repo for App Store rejection risks before submission. Static checks on the mechanical rejection causes (privacy usage strings, entitlements, privacy manifests and required-reason APIs, Info.plist), plus it fetches the current App Store Review Guidelines at check time so every finding cites the live guideline number or the upload validation it would trip, with file and line evidence. Ranked by severity, validator-blocking first.

**Per the submission guidelines:**
- License: MIT. Free, standalone, no SaaS, no account, no paid product behind it.
- More than a single SKILL.md: the repo carries reference checklists the skill draws on, plus a README with the one-prompt install.
- Prerequisites: an agent CLI that reads skill files (Claude Code or similar) and an iOS app repo to point it at.
- Social proof / provenance: built by an indie dev with three shipped App Store apps (Itemlist, QRGenie, BarcodeCraft), dogfooded on a real release candidate before publishing. Launch write-up: https://dabo.dev/app-store-rejection-checker