### PR TITLE
Add youtube-transcripts skill (BulkTranscripts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[youtube-transcripts](https://github.com/pratie/youtube-transcript-skill)** | Fetch YouTube transcripts, search YouTube, list channel/playlist videos, and track new uploads via the BulkTranscripts API — works with no API key on a free tier |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **youtube-transcripts** to Individual Skills.

- Repo: https://github.com/pratie/youtube-transcript-skill (SKILL.md at root, examples for summarize-video / research-channel / monitor-channel)
- What it does: fetch YouTube transcripts, search YouTube (videos/channels/playlists), search inside a channel, list channel or playlist videos, track new uploads — via the BulkTranscripts REST API
- Works with no API key on a free tier; `BULKTRANSCRIPTS_API_KEY` unlocks purchased credits
- Install: `npx skills add pratie/youtube-transcript-skill` or `curl https://bulktranscripts.co/skill.md`