### PR TITLE
Add wentro — post-trip itinerary maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[wentro](https://github.com/ShawNova/wentro)** | Turn a finished trip into a shareable itinerary map — real walking/cycling/driving routes (OSRM) on an OpenStreetMap basemap, rendered as an interactive page plus a PNG share image; bilingual (EN/中文) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [wentro](https://github.com/ShawNova/wentro) to Individual Skills.

Wentro (温途) turns a finished trip into a shareable itinerary map: the user describes where they went in any language; the skill geocodes real places (Nominatim), fetches real walking/cycling/driving routes (FOSSGIS OSRM), stitches an OpenStreetMap basemap, and renders an interactive map page plus a static PNG share image. Conversational add/fix/delete of stops with a JSON file as the source of truth.

- Self-contained skill folder; installs with `npx skills add ShawNova/wentro` (Python deps bootstrap automatically on first use)
- MIT licensed, bilingual docs (EN / 中文), tested (48 unit tests + live builds for Rome and London itineraries)
- Respects OSM/Nominatim/OSRM usage policies (rate limits, tile budget, attribution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)