### PR TITLE
Add dark-psychology-skills to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Skills for working with complex file formats:
   - Install from `superpowers-marketplace` plugin
 
 
+- **[YannisKiefer/dark-psychology-skills](https://github.com/YannisKiefer/dark-psychology-skills)** - 13 sales and negotiation skills distilled from 36 books: CIA psyop manuals, FBI behavioral research, propaganda science, persuasion classics
+  - Plain-English SKILL.md format; includes a deal-router skill that picks the right move for any incoming message
+  - Honest-influence filter: every tactic must still work when fully disclosed to the other side
+
 ### Individual Skills
 
 > These will be broken down into categories once there are enough community skills available to list


### PR DESCRIPTION
Adds [dark-psychology-skills](https://github.com/YannisKiefer/dark-psychology-skills) under Community Skills > Collections & Libraries.

13 negotiation and persuasion skills in standard SKILL.md format, distilled from 36 books read cover to cover: CIA psyop manuals, FBI behavioral work (*The Like Switch*), Ellul on propaganda, dark psychology taxonomies, and the direct-response classics (Hopkins, Schwartz, Sugarman, Halbert, Kennedy).

MIT licensed, CI-linted structure, plain-English writing, and a documented honest-influence filter: every tactic must still work when fully disclosed. Manipulation patterns are catalogued as defense material only.

Happy to adjust wording or category.