### PR TITLE
Add humanize-chinese to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[humanize-chinese](https://github.com/swaylq/humanize-chinese)** | Detect and rewrite AI-generated Chinese text — scene-aware detection (rule categories + statistical features + logistic-regression fusion) then rewriting that drops the AI score, with 8 style transforms. Pure Python, fully offline, no LLM and no API key |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [**humanize-chinese**](https://github.com/swaylq/humanize-chinese) — the Chinese-language counterpart to the AI-writing cleanup skills already on this list.

**What it does.** Two halves in one CLI: it *scores* Chinese text for how AI-generated it reads, then *rewrites* it to bring the score down.

- **Detection** combines 20+ rule categories with statistical features (sentence-length coefficient of variation, short-sentence fraction, comma density, perplexity, GLTR, DivEye) and a scene-aware logistic-regression fusion trained separately on three registers — general, academic, and long-form.
- **Rewriting** ships 8 style transforms (casual / Zhihu / Xiaohongshu / WeChat / academic / literary / Weibo / novel), multi-paragraph handling that watches paragraph-length variance and cross-paragraph trigram repetition, and best-of-N sampling.

**Why it fits here:** it runs as a Claude Code skill (`SKILL.md` plus a `claude-code/` command set for detect / humanize / academic / style), but the engine is **pure Python with no dependencies and no network** — no LLM call, no API key, nothing leaves the machine. That matters for its main use case, since people run it on unpublished papers and internal reports.

**Two things I'd rather flag than have you find later:**

1. **License:** MIT **Non-Commercial**, not plain MIT. Free to use, modify and redistribute; commercial use excluded. Close this if your list only takes OSI-approved licenses.
2. **Don't rely on the benchmark numbers currently in its README.** The maintainer is mid-way through a v6 rework and has re-measured them: the before/after score drops in the README were taken on hand-written exaggerated "AI-style" samples rather than real model output, and the detector's separation on 2026-era models is much weaker than the headline figure suggests. The tool and its approach are real; those specific numbers are being corrected. I've deliberately kept them out of this PR and out of the entry description.

Happy to move it to a different category, shorten the description, or hold the PR until v6 lands — your call.
