### PR TITLE
Add usage-limits to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[usage-limits](https://github.com/ridelink0/claude-code-usage-limits)** | Reads how much of your 5-hour and weekly limit is left and reports it as turns of headroom rather than a percentage, then plans the work to fit before it runs out |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds `usage-limits` to the Individual Skills table.

It reads the 5-hour and weekly usage percentages Claude Code already caches locally, cross-references the session transcripts to work out what one percentage point of the limit costs on that account, and reports the remaining headroom as turns of work rather than a bare percentage. It then names which window binds first and whether it resets before you run out.

Also detects plan tier (Pro, Max 5x, Max 20x, Team, Enterprise), splits the window by model and by project, and has a `--status` mode for the status line that skips the transcript scan so it stays fast on every redraw.

Installs as a plain skill or as a plugin. Everything is read from local files: no network calls, no credentials read, no dependencies. MIT, 66 tests, passes `claude plugin validate --strict`.

https://github.com/ridelink0/claude-code-usage-limits