### PR TITLE
Add Kymira honest-dataviz (certified BI skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[claude-skills-for-business-intelligence](https://github.com/dylnbaker15/claude-skills-for-business-intelligence)** | Certified BI charting skill plus a ten-principle doctrine: visualizations that read at a glance, survive a colour-blind reviewer, and never imply more certainty than the data has |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds a certified-BI charting skill to Individual Skills. Single SKILL.md in four agent formats (Claude Code, Cursor .mdc, AGENTS.md, plain prompt) plus the full ten-principle certified-BI doctrine, MIT licensed. Docs and a live demo: https://kymira.ai