### PR TITLE
Add propzapi to community skills (render-and-verify image/PDF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[propzapi](https://github.com/paperandbeyond23-gif/propzapi-skills)** | Render images and PDFs from HTML/CSS templates, screenshot any URL, and verify the exact text rendered as visible pixels, over the propzapi API |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds propzapi to the community Individual Skills table. It's a skill (and hosted MCP server) that renders images and PDFs from HTML/CSS templates, screenshots any URL, and verifies the exact text rendered. Repo: https://github.com/paperandbeyond23-gif/propzapi-skills - install: npx skills add paperandbeyond23-gif/propzapi-skills