### PR TITLE
Add skill: curyous/clear-agent-fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[clear-agent-fetch](https://github.com/curyous/clear-agent-fetch)** | Fetch a public URL as markdown via x402 ($0.005 USDC on Base); fail is free |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Type
- [x] Skill
- [ ] Article
- [ ] Video
- [ ] Fix

## Checklist
- [x] Link works
- [x] Relevant to Claude Skills
- [x] Formatting correct
- [x] Added to correct section
- [x] (Skills) Author prefix included

Adds [clear-agent-fetch](https://github.com/curyous/clear-agent-fetch): an Agent Skills `SKILL.md` that teaches agents to buy a public URL as markdown via x402 (`POST https://clear-agent-fetch.fly.dev/v1/fetch`, $0.005 USDC on Base). Fail is free.

Install: `npx skills add curyous/clear-agent-fetch`