### PR TITLE
Add sktime-cli skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[sktime-cli](https://github.com/siddharth7113/sktime-cli)** | Time-series machine learning from the terminal: search sktime's estimator registry, load datasets, and run fit, predict, backtest, and scoring workflows with JSON output and structured errors |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds `sktime-cli` to Community Skills > Individual Skills.

**Skill:** time-series machine learning from the terminal, over
[sktime](https://github.com/sktime/sktime). Search the estimator registry,
load datasets, and run fit, predict, backtest, and scoring workflows.

**Repo:** https://github.com/siddharth7113/sktime-cli (BSD-3-Clause)
**Skill file:** https://github.com/siddharth7113/sktime-cli/blob/main/skills/sktime-cli/SKILL.md

The skill documents the agent-facing contract, which is the part an agent
cannot guess: always pass `--json` for exactly one JSON document on stdout,
read errors as JSON on stderr and follow the `hint` field, and branch on
stable exit codes. It then gives task recipes for discovery, data prep,
forecasting, uncertainty, transformation, detection, scoring, backtesting,
and classification.

Installs with the skills CLI straight from the repo:

```bash
npx skills add siddharth7113/sktime-cli
```

Used from Claude Code and Cursor. The CLI is tested in CI on Linux across
Python 3.10 through 3.14.