### PR TITLE
Add fabling (behavior-profile skill, blind-judge benchmarked)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[fabling](https://github.com/gncdev/fabling)** | Behavioral profile that makes Opus 5 (and Sonnet 5) work like Fable 5: baseline-diff verification, render-before-claiming, full-sweep discipline. Blind judges preferred it over the reference 12/12; includes a fast variant at ~1.1x Fable's wall clock |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds fabling: two skills (full + fast variant) that give Opus 5 and Sonnet 5 the working character of Fable 5. Built via ten iterations of blind A/B duels against the reference model; methodology and full benchmark tables are in the repo (docs/BENCHMARKS.md). MIT, plain SKILL.md files with YAML frontmatter, packaged .skill files included.