### PR TITLE
Add skill-audit (security auditing CLI) to Tools + vetting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[FrankFu916/skill-audit](https://github.com/FrankFu916/skill-audit)** - Zero-dependency CLI that statically audits SKILL.md packages for prompt injection, credential exfiltration, destructive commands, and spec violations before you install them — 24 explainable rules, 0–100 health score per skill, SARIF/JSON output for CI (`npx @frankfu0916/skill-audit ~/.claude/skills`)
 
 ## ✏️ Creating Your First Skill
 
@@ -320,6 +321,7 @@ _Video tutorials coming soon! Have a good video about Claude Skills? Submit a PR
 - **Review SKILL.md and all scripts** before enabling a skill
 - **Be cautious of skills** that request sensitive data access
 - **Audit carefully** before deploying to production or enterprise environments
+- **Run an automated audit first**: [skill-audit](https://github.com/FrankFu916/skill-audit) scans any skill for prompt injection, credential exfiltration, and dangerous commands in seconds — `npx @frankfu0916/skill-audit <skill-path>`
 
 ### Security Concerns
 


### PR DESCRIPTION
## What

Two additions:

1. **Tools section** — lists [skill-audit](https://github.com/FrankFu916/skill-audit), a zero-dependency CLI that statically audits SKILL.md packages before installation.
2. **🔒 Security & Best Practices → Vetting Skills** — adds one bullet: run an automated audit first, with the exact command.

## Why

This list's own security section warns that *skills can execute arbitrary code* and recommends manual review of every SKILL.md and script. That review is exactly what most users skip. skill-audit automates the first pass:

```bash
npx @frankfu0916/skill-audit <skill-path>     # single skill or whole directory
```

- Detects prompt injection (instructional HTML comments, zero-width character smuggling), credential exfiltration (`~/.ssh`, AWS creds, `.env` reads paired with network calls in bundled scripts), destructive commands, obfuscated payloads, and spec violations
- 24 rules, every finding cites rule id + line + matched text; 0–100 score per skill
- SARIF output plugs into GitHub Code Scanning; JSON for CI gates
- Static analysis only — it never executes scanned content, fully offline, **zero runtime dependencies**

## Quality signals

- MIT, Node ≥ 18; 34 unit + e2e tests; CI matrix linux/macOS/windows × Node 18/20/22/24 ([all green](https://github.com/FrankFu916/skill-audit/actions))
- Rules calibrated against the official [anthropics/skills](https://github.com/anthropics/skills) corpus (audited all 19 official skills; fixed false positives on legitimate patterns like LibreOffice `-env:` flags)
- Published on npm: [`@frankfu0916/skill-audit`](https://www.npmjs.com/package/@frankfu0916/skill-audit)

Regarding the social-proof requirement: the repo is new, so I've kept the addition minimal and factual — happy to trim further if you prefer it only in the Security section until the project matures.