### PR TITLE
Add Accordo (eleven CRM-building skills) to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ Skills for working with complex file formats:
 
 ### Collections & Libraries
 
+- **[Accordo](https://github.com/khaoss85/agent-crm)** - Eleven skills for building a custom CRM as code you own: modules, deterministic workflows, domain packages, commercial operations, contract activation, delivery and service
+  - Commercial policy is generated as code and proven by tests in the project's merge gate, so a rule the agent is asked to bypass fails a test rather than a prompt
+  - Ships a local project MCP; code generation stays dry-run until `--apply`
+  - Installation: `/plugin marketplace add khaoss85/agent-crm` then `/plugin install accordo`
+
 - **[obra/superpowers](https://github.com/obra/superpowers)** - Core skills library for Claude Code with 20+ battle-tested skills including TDD, debugging, and collaboration patterns
   - Features `/brainstorm`, `/write-plan`, `/execute-plan` commands and skills-search tool
   - [superpowers-skills](https://github.com/obra/superpowers-skills) - Community-editable skills repository


### PR DESCRIPTION
Adds Accordo under Community Skills → Collections & Libraries.

- Repository: https://github.com/khaoss85/agent-crm (MIT)
- Install: `/plugin marketplace add khaoss85/agent-crm` then `/plugin install accordo`
- Skills: eleven, each a `SKILL.md` with YAML frontmatter under `skills/`

The skills build CRM modules, deterministic workflows and domain packages
against an open-source framework in the same repository. Approval rules are
generated as code and proven by tests that run in the project's merge gate, so
a policy the agent is asked to bypass fails a test rather than a prompt.

Filed under Collections & Libraries rather than Individual Skills because it is
a plugin of eleven skills, not one.

Actively maintained: commits on the default branch this week.
