### PR TITLE
Add kaoyan-skills to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[kaoyan-skills](https://github.com/CAlM123451/kaoyan-skills)** | Chinese exam-prep skills: study planning, mistake analysis, English reading, medical mnemonics, self-testing, Ebbinghaus spaced repetition |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add kaoyan-skills

Adding [kaoyan-skills](https://github.com/CAlM123451/kaoyan-skills) to the Individual Skills table.

**kaoyan-skills** is a collection of Chinese exam-prep skills for Claude Code / AI agents:
- Study planning with phased schedules
- Mistake analysis and weak point identification
- English reading comprehension (long sentence parsing)
- Medical mnemonics generation
- Self-testing with exam-style questions
- Ebbinghaus spaced repetition scheduling

Pure markdown skills, MIT licensed, compatible with Claude Code's skill system.