### PR TITLE
Add falsify: scientific thinking protocol skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[falsify](https://github.com/263311487-ux/falsify)** | Scientific thinking protocol for AI agents — falsify before you believe. 5-stage protocol (axioms → hypothesis → adversarial test → evidence → calibrated verdict) that stops agents from giving confident answers they cannot falsify. Works with Claude Code, Codex, Cursor, Gemini CLI and 20+ agents. 28 evals, npm: falsify-skill |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Add [falsify](https://github.com/263311487-ux/falsify) to Community Skills → Individual Skills

**falsify** is the scientific thinking protocol for AI agents — axioms → hypothesis → adversarial test → evidence → calibrated verdict. It stops agents from giving confident answers they cannot falsify.

**Social proof / quality signals:**
- Single-Markdown skill, works with Claude Code + 20 other agents
- Accepted into `github/awesome-copilot` (CI green) and `heilcheng/awesome-agent-skills` (pending review)
- Published on npm as `falsify-skill` (npx falsify-skill)
- Indexed on skills.sh (Vercel leaderboard)
- 28 evaluation cases + 4/4 external dogfood cross-validation passed
- Distilled from 70+ community sources + ICML 2026 / NeurIPS / Kahneman / Galef / Snowden / Boyd