### PR TITLE
Add computer-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Skills for working with complex file formats:
 
 | Skill | Description |
 | --- | --- |
+| **[computer-use](https://github.com/ridelink0/claude-computer-use)** | Codex-style computer use for Windows and macOS through the accessibility tree instead of screenshots: exact targeting, ~20x cheaper than a screenshot, and works on the same desktop while you keep working |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |


### PR DESCRIPTION
Adds **computer-use** to the Individual Skills table: Codex-style computer use for Windows and macOS through the accessibility tree instead of screenshots (exact targeting, ~20x cheaper than a screenshot), able to work on the same desktop while you keep working. Repo https://github.com/ridelink0/claude-computer-use (MIT).