### PR TITLE
Add tubescout skills — six YouTube research skills (Individual Skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[tubescout skills](https://github.com/not0lucky/tubescout/tree/main/skills)** | Six YouTube research skills over the keyless tubescout MCP: skeptic's video breakdowns, idea mining, niche validation, channel intel, tutorial-to-playbook extraction, and demand-gap analysis |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds the [tubescout skill pack](https://github.com/not0lucky/tubescout/tree/main/skills) to Individual Skills.

Six SKILL.md research skills over the keyless [tubescout MCP server](https://github.com/not0lucky/tubescout) (`npx -y tubescout`): **yt-breakdown** (skeptic's video analysis — claims vs incentives vs verifiability), **yt-idea-mine**, **yt-validate**, **yt-channel-intel**, **yt-playbook** (tutorial → executable steps), **yt-gap** (demand-vs-supply gaps). Works in Claude Code (also as a plugin: `/plugin marketplace add not0lucky/tubescout`), Codex, and OpenCode. MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)