### PR TITLE
Add alibaba-java-coding-guidelines skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[alibaba-java-coding-guidelines](https://github.com/Castlebin/alibaba-java-coding-guidelines)** | Enforce the Alibaba Java Coding Guidelines (Huangshan v1.7.1, 327 rules) for Java development: code-time self-check, review checklist, and a PDF → Markdown update pipeline |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [alibaba-java-coding-guidelines](https://github.com/Castlebin/alibaba-java-coding-guidelines) — the Alibaba Java Coding Guidelines (Huangshan v1.7.1, 327 rules: 193 mandatory / 97 recommended / 37 reference) packaged as an agent skill for Java development:

- **Code-time self-check**: SKILL.md triggers on Java code writing/refactoring and checks the affected chapters of the review checklist.
- **Review checklist**: `references/review-checklist.md` — checkable items organized by chapter (naming, OOP, collections, concurrency, exceptions, logging, unit tests, security, MySQL, engineering structure, design) plus a review-conclusion template.
- **Full manual**: `references/java-coding-guidelines.md` — complete transcript with all 正例/反例 examples and 78 Java code blocks.
- **Maintenance pipeline**: `scripts/update_guidelines.py` downloads the official PDF from alibaba/p3c and regenerates the markdown automatically.

Licensed Apache-2.0 (same as upstream alibaba/p3c).