### PR TITLE
Add orca-code-review to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[orca-code-review](https://github.com/Continuum-AI-Corp/orca-code-review)** | Set up, reconfigure, troubleshoot, and remove an AI pull request review workflow in a GitHub repository |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [orca-code-review](https://github.com/Continuum-AI-Corp/orca-code-review) to the `Individual Skills` table.

The skill owns the full lifecycle of an AI pull request review workflow in a GitHub repository: asked to set it up it writes the GitHub Action, walks through the API key, and configures the merge gate; asked why a review did not run it checks the secret, the trigger, the base branch, and the gate; asked to remove it, it drops the required status check before deleting the workflow so the branch is not left blocked on a check that no longer reports.

Installable as a Claude Code plugin (`/plugin marketplace add Continuum-AI-Corp/orca-code-review`) or via `npx @orcarouter/code-review` for other agents. MIT licensed.