### PR TITLE
Add alibaba-java-coding-guidelines-en skill (English edition)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Skills for working with complex file formats:
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
 | **[alibaba-java-coding-guidelines-en](https://github.com/Castlebin/alibaba-java-coding-guidelines-en)** | Enforce the official English Alibaba Java Coding Guidelines (5 sections, 181 rules) for Java development: code-time self-check, English review checklist, and an upstream Markdown sync pipeline |
 
+| **[alibaba-java-coding-guidelines-en](https://github.com/Castlebin/alibaba-java-coding-guidelines-en)** | Enforce the official English Alibaba Java Coding Guidelines (5 sections, 181 rules) for Java development: code-time self-check, English review checklist, and an upstream Markdown sync pipeline |
+
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[alibaba-java-coding-guidelines-en](https://github.com/Castlebin/alibaba-java-coding-guidelines-en)** | Enforce the official English Alibaba Java Coding Guidelines (5 sections, 181 rules) for Java development: code-time self-check, English review checklist, and an upstream Markdown sync pipeline |
+
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Add the **official English edition** of the Alibaba Java Coding Guidelines as an agent skill.

- Repo: https://github.com/Castlebin/alibaba-java-coding-guidelines-en
- Source: official English manual from `alibaba/Alibaba-Java-Coding-Guidelines` (GitBook Markdown, Apache-2.0, no PDF involved)
- Content: SKILL.md (portable frontmatter for WorkBuddy/Claude Code/Cursor/OpenCode), 181 rules (124 Mandatory / 57 Recommended / 24 For Reference) across 5 sections, tickable English review checklist, and an upstream Markdown sync pipeline
- Companion to the Chinese edition PR (Huangshan v1.7.1, 327 rules)