### PR TITLE
Add lamarck - governed skill evolution from real usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Skills for working with complex file formats:
 | --- | --- |
 | **[ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** | iOS app building, navigation, and testing through automation |
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
+| **[lamarck](https://github.com/newdee/lamarck-skill)** | Governed skill evolution from real usage — hooks log every invocation, evidence-gated edits with user approval, regression replay from production traces, self-evolving with an audited changelog (`npx lamarck-skill`) |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |


### PR DESCRIPTION
Adds [lamarck](https://github.com/newdee/lamarck-skill) to Individual Skills (alphabetical order).

- Hooks log every real skill invocation (content-hash stamped); evidence-gated bounded edits, always user-approved
- Regression replay harvested from production traces, paired blind judging, atrophy pruning; evolves itself under the same rules (audited CHANGELOG)
- Evidence-first: 44-check selftest in CI (ubuntu/macos/windows), preregistered mutation bench (4/5 known-degraded variants caught, 0/2 false positives on improved ones)
- MIT, Node 18+, install: `npx lamarck-skill`