### PR TITLE
Add logo-finder to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[logo-finder](https://github.com/leadbeater/logo-finder-skill)** | Sources company logos to a human standard: confirms the right corporate entity, verifies real transparency, converts to black/white/grayscale, and normalizes visual scale for decks (PowerPoint, Google Slides, Canva, Figma) |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds logo-finder — a skill that sources company logos to a human standard (entity confirmation, transparency verification, black/white/grayscale conversion, visual-scale normalization for decks). Repo: https://github.com/leadbeater/logo-finder-skill — MIT licensed, follows the Agent Skills standard, includes bundled script and eval cases.