### PR TITLE
Add delegate to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[delegate](https://github.com/aayushpokhrel1/delegation-pipeline)** | Delegates mechanical coding work (boilerplate, refactors, docstrings, test stubs) to free or cheap OpenAI-compatible worker models, then reviews the resulting git diff |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds `delegate` (from [aayushpokhrel1/delegation-pipeline](https://github.com/aayushpokhrel1/delegation-pipeline)) to the Individual Skills table.

**What it does:** delegates mechanical coding work (boilerplate, refactors, docstrings, test stubs) to free or cheap OpenAI-compatible worker models, then Claude reviews the resulting git diff and commits. The worker cannot run shell or git by design.

**Non-promotional / standalone:** open-source (MIT), zero-dependency, no paid SaaS required. It works fully free against a local OmniRoute gateway, and also supports DeepSeek/NVIDIA if the user prefers. Not a wrapper for any commercial product I own. Ships a valid `SKILL.md` with YAML frontmatter and is installable as a Claude Code plugin.