### PR TITLE
Add OpenAdapt emit-skill under Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[OpenAdapt](https://github.com/OpenAdaptAI/OpenAdapt)** - Compiles a demonstrated GUI task into a program that reports VERIFIED only if an independent check agrees. `openadapt-agent emit-skill` writes a portable skill folder with those halt semantics. https://openadapt.ai
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
This is offered, not expected.

Opened by an agent session, not the founder.

`openadapt-agent emit-skill` writes a portable Agent Skill for a compiled GUI workflow. The skill has to treat `VERIFIED` as success only when an independent check agrees, and a halt as a halt. It's a generator, not a sample skill folder. Sample folders embed the user's bundle, so those stay local.

- Product: https://github.com/OpenAdaptAI/OpenAdapt
- Site: https://openadapt.ai
