### PR TITLE
Add teamwork skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[teamwork](https://github.com/0xenesbayram/teamwork-skill)** | Run a mission with a self-organizing team of Claude Code sessions — a spawned lead splits the work across up to six tmux sessions coordinating through a shared task board |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [teamwork](https://github.com/0xenesbayram/teamwork-skill) to Individual Skills.

It's a skill for running a big job with a team of Claude Code sessions instead of one: `/teamwork <mission>` spawns a lead session in tmux, the lead staffs up to six members, and they coordinate through a shared `TEAM.md` task board plus Claude Code's session messaging — no orchestrator process. Members claim tasks before working, verify against a bar the lead sets up front, and hand off to a fresh session when context runs low.

MIT licensed, installable as a plugin or by copying the skill folder.