### PR TITLE
Add plugin-forge to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
-- **[truelove-dreamer/plugin-forge](https://github.com/truelove-dreamer/plugin-forge)** - Five-phase gated workflow for building and shipping skills/plugins: intake, scaffold, best-practice authoring, structural validation, then GitHub publish and release (includes validator + starter templates)
+- **[truelove-dreamer/plugin-forge](https://github.com/truelove-dreamer/plugin-forge)** - Five-phase gated workflow for building and shipping skills/plugins in the portable SKILL.md format (works in Claude Code, ZCode, and other Agent Skills hosts): intake, scaffold, best-practice authoring, structural validation, then GitHub publish and release (includes validator + starter templates)
 
 ## ✏️ Creating Your First Skill
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[truelove-dreamer/plugin-forge](https://github.com/truelove-dreamer/plugin-forge)** - Five-phase gated workflow for building and shipping skills/plugins: intake, scaffold, best-practice authoring, structural validation, then GitHub publish and release (includes validator + starter templates)
 
 ## ✏️ Creating Your First Skill
 


### PR DESCRIPTION
## What

[plugin-forge](https://github.com/truelove-dreamer/plugin-forge) — a skill/plugin that standardizes the full workflow of building and publishing Claude skills and plugins: intake → scaffold → author → validate → publish (GitHub repo + release + marketplace metadata).

## Why it fits Tools

Like the existing Tool entries (e.g. Skill_Seekers), plugin-forge is meta-tooling for skill authors rather than a domain skill: a five-phase gated pipeline with a bundled structural validator (`validate.py`), an authoring guide, a validation checklist, a publish guide, and starter templates — conventions distilled from Anthropic's official skill authoring best practices and high-star community skills.

## Details

- Install: `/plugin marketplace add truelove-dreamer/plugin-forge`, or copy `skills/plugin-forge/` into `~/.agents/skills/`
- Release: [v0.1.0](https://github.com/truelove-dreamer/plugin-forge/releases/tag/v0.1.0), MIT licensed
- Entry appended to the **Tools** section, matching the existing entry format
