### PR TITLE
Add zero-slop to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Skills for working with complex file formats:
 | **[ffuf-web-fuzzing](https://github.com/jthack/ffuf_claude_skill)** | Expert guidance for ffuf web fuzzing during penetration testing, including authenticated fuzzing with raw requests, auto-calibration, and result analysis |
 | **[playwright-skill](https://github.com/lackeyjb/playwright-skill)** | General-purpose browser automation using Playwright |
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
+| **[zero-slop](https://github.com/manavmishra/ZeroSlop)** | Scores prose 0-100 for AI slop, then rewrites it under a local fact gate that rejects any version changing a name, number, quotation or link. Offline, zero dependencies, MIT. |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |


### PR DESCRIPTION
Adds [zero-slop](https://github.com/manavmishra/ZeroSlop) as one row in the **Individual Skills** table, in the existing format.

It scores prose 0-100 for AI slop and then rewrites it under a local fact gate: any version that adds or drops a name, number, quotation, link, code block or table is rejected and redone. The gate is a program rather than an instruction, which is the difference from most skills in this space — a fluent rewrite that quietly changed a figure is the usual failure.

It is not an authorship detector. The score describes the writing and the docs are explicit that it says nothing about who wrote a text. The scorer is standard-library Python with zero third-party dependencies and makes no network call, so there is no account and no API key; your own model does the editing.

- `npx zero-slop install` (or `npx skills add manavmishra/ZeroSlop --global`)
- Works in Claude Code, Cursor, Zed, Codex, Warp and OpenCode
- Benchmark with the data committed: https://zero-slop.ai/benchmark/
- MIT, 2.7.7

Glad to shorten the description if the table prefers something tighter.