### PR TITLE
Add 'delete_when_unzip' skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[delete_when_unzip](https://github.com/auto-Dog/delete_when_unzip)** | Streamly extracting archives, automatically delete the unzipped part to save disk space and keep workspaces clean. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Added a new project link for 'delete_when_unzip' to the README. The project has 170+ stars.

[https://github.com/auto-Dog/delete_when_unzip](https://github.com/auto-Dog/delete_when_unzip)

Use when the user wants to extract/unpack large ZIP or RAR archives while disk space is limited, or mentions "delete when unzip",  "extract and delete processed parts", "flat/unpack files", or segmented (multi-volume) archives (.z01/.zip.001/.part1.rar/.r01) under low free space. This project streams archives chunk by chunk and deletes already-processed parts so you do not need 2x the archive size in free space. Covers which script to run, chunk-size math, and the critical warning that the source archive is destroyed.