### PR TITLE
Add SEO Skills by Gaznil to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ Skills for working with complex file formats:
   - Install from `superpowers-marketplace` plugin
 
 
+- **[gaznilmuzammil12-prog/seo-skills-by-gaznil](https://github.com/gaznilmuzammil12-prog/seo-skills-by-gaznil)** - 81-skill SEO library with no overlapping coverage: technical SEO, on-page, AI search (GEO/AEO/LLMO), ecommerce, international, backlinks, local, measurement, and a full blog content pipeline
+  - Filtered rather than merged: no two skills share a purpose, names are collision-checked against common SEO packs, and every internal cross-reference resolves
+  - [Docs with full catalogue](https://gaznilmuzammil12-prog.github.io/seo-skills-by-gaznil/) - all 81 skills categorised
+  - MIT licensed; assembled from MIT sources with attribution retained in [NOTICE.md](https://github.com/gaznilmuzammil12-prog/seo-skills-by-gaznil/blob/main/NOTICE.md)
+  - Installation: `npx skills add gaznilmuzammil12-prog/seo-skills-by-gaznil`
+
+
 ### Individual Skills
 
 > These will be broken down into categories once there are enough community skills available to list


### PR DESCRIPTION
Adds an 81-skill SEO library to **Collections & Libraries**.

### What it is

Full-surface SEO coverage for Claude: technical SEO, on-page optimization, AI search (GEO/AEO/LLMO), ecommerce SEO, international SEO, images and video, backlinks, local SEO, measurement, conversion, and a complete blog content pipeline.

### What makes it different from a merged bundle

It was filtered, not merged. Three verification passes:

1. **Purpose de-duplication** — no two skills solve the same problem; duplicates excluded regardless of popularity
2. **Name-collision checking** — all 81 names checked against each other and against widely-installed SEO packs, so nothing silently shadows an existing skill
3. **Dangling-reference tracing** — every internal see-also followed; missing targets added or documented in an alias table

Three skills whose upstream licence could not be established were excluded rather than published without attribution.

### Details

- Repository: https://github.com/gaznilmuzammil12-prog/seo-skills-by-gaznil
- Docs: https://gaznilmuzammil12-prog.github.io/seo-skills-by-gaznil/
- Licence: MIT, notices retained per author in NOTICE.md
- Verified installable end to end — `npx skills add` resolves all 81