### PR TITLE
Add security-scan resource to Security & Best Practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _More community skills coming soon! Submit a PR to add your skill._
 ### Tools
 
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
+- **[Skills Directory](https://www.skillsdirectory.com)** - Searchable directory of 100,000+ skills with security grades and one-command install
 
 ## ✏️ Creating Your First Skill
 
@@ -320,6 +321,7 @@ _Video tutorials coming soon! Have a good video about Claude Skills? Submit a PR
 - **Review SKILL.md and all scripts** before enabling a skill
 - **Be cautious of skills** that request sensitive data access
 - **Audit carefully** before deploying to production or enterprise environments
+- **Use a scan report**: [Skills Directory Security Reports](https://www.skillsdirectory.com/security) - free automated scans of 100,000+ community skills, each graded A–F (prompt injection, exfiltration, dangerous shell patterns) with a public per-skill report to check before installing
 
 ### Security Concerns
 


### PR DESCRIPTION
The Security & Best Practices section tells readers to vet skills before installing but doesn't link any tooling for doing so. This PR adds one:

[Skills Directory Security Reports](https://www.skillsdirectory.com/security) — free automated security scans of 100,000+ community skills. Each skill gets an A–F grade and a public per-skill report covering prompt-injection patterns, exfiltration-capable network calls, credential reads, and dangerous shell patterns — so "review before enabling" has a concrete starting point.

Also adds the directory itself to Community Skills → Tools in the existing entry style.

Disclosure: I run this site. Both entries are free resources, no login required. Happy to drop the second entry if you'd prefer just the security resource.