### PR TITLE
Add Study_via_AI to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[Study_via_AI](https://github.com/lowellran/Study_via_AI)** | Adaptive AI learning tutor featuring Socratic single-point immersion, Feynman dual-internalization testing, and automatic generation of 12 structured Markdown knowledge base files |
 
 _More community skills coming soon! Submit a PR to add your skill._
 
@@ -451,3 +452,4 @@ A: For skills from git repositories, pull the latest changes. For manually insta
 ## 🤝 Contributing
 
 Contributions welcome! See [contribution guidelines](CONTRIBUTING.md) for details. To add a skill or resource: fork, add to appropriate section, submit PR.
+


### PR DESCRIPTION
## Summary
Add [Study_via_AI](https://github.com/lowellran/Study_via_AI) to Individual Skills.

### What is Study_via_AI?
Study_via_AI is an adaptive AI learning tutor skill compatible with Claude Code, Codex CLI, and other AI agents.

**Key Highlights:**
- **Socratic Single-point Immersion:** Prevents information overload by guiding users step-by-step through a 5-level learning ladder.
- **Dual Internalization:** Includes AI examiner quizzes and 12-year-old Feynman technique feedback loops.
- **Structured Knowledge Base Archiving:** Automatically writes 12 clean Markdown learning archive files with clear navigation and flashcards.