### PR TITLE
Add erupt-admin to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[erupt-admin](https://github.com/plinian/erupt-skill)** | Generates a complete runnable Java admin backend — login, CRUD, search, Excel import/export, and RBAC — from a single sentence |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds one row to **Community Skills → Individual Skills**. No other lines touched (+1 / -0).

```markdown
| **[erupt-admin](https://github.com/plinian/erupt-skill)** | Generates a complete runnable Java admin backend — login, CRUD, search, Excel import/export, and RBAC — from a single sentence |
```

### What it is

A skill that produces a **running system**, not just a workflow. From one sentence ("build a library admin backend") the model writes only `@Erupt`-annotated Java entities; the [erupt](https://www.erupt.xyz) framework renders the admin UI, REST APIs, RBAC and Excel import/export from those annotations at runtime.

That keeps token cost low — in the `vscode-admin` case in the repo the model produced 406 lines / ~4K output tokens, versus ~10,000+ lines for a hand-written equivalent, because the framework code is reused at zero token cost.

It also needs no dev environment: with no system JDK it fetches one on demand and uses an embedded H2 file database, so someone who does not write Java can still stand up a working internal tool. Repo is ~1 MB, so cloning into a skills directory is instant.

### Checks

- Apache-2.0, public, `SKILL.md` with valid YAML frontmatter
- Actively maintained (latest commit Aug 31, 2026)
- I am the author
- Follows the open [Agent Skills](https://agentskills.io) standard, so it also loads in Codex CLI, Cursor, Trae and CodeBuddy
- Landing page with the token benchmark: https://skill.erupt.xyz
