### PR TITLE
Add marketing-mindset skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[marketing-mindset](https://github.com/axelfreeman/marketing-mindset)** | Marketing OS for AI agents — think like a marketer first, get tactics as the output |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds **[marketing-mindset](https://github.com/axelfreeman/marketing-mindset)** — a marketing OS for AI agents (think like a marketer first, get tactics as the output). SKILL.md + README + llms.txt + AGENTS.md + .cursorrules + demo transcript.