### PR TITLE
Add explain-for-dumb skill to skills list for code change explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[explain-for-dumb](https://github.com/MotleyWildside/explain-for-dumb)** | Explains agent-written code changes in plain language so you can stay aligned with your codebase after delegating implementation |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary

Adds [explain-for-dumb](https://github.com/MotleyWildside/explain-for-dumb), a free Claude Code skill.

It helps developers stay aligned with their codebase after delegating implementation to an agent: instead of reading a raw diff line by line, they can get either a plain-language before/after/how explanation or a per-file walkthrough.

## Notes

- MIT licensed
- No dependencies
- Includes installation instructions and usage examples