### PR TITLE
Add EnhancedSkills and ClawdBot Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,13 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[clawdbot-skills](https://sameerbajaj.com/tools/clawdbot-skills)** | Agent skills for Oura Ring health coaching and Readwise Reader knowledge retrieval for Claude Code |
 
 _More community skills coming soon! Submit a PR to add your skill._
 
 ### Tools
 
+- **[EnhancedSkills](https://sameerbajaj.com/tools/enhanced-skills)** - Native macOS app to manage AI skills across Claude Code and Codex with provider validation and one-click fixes
 - **[yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Convert documentation websites into Claude Skills
 
 ## ✏️ Creating Your First Skill


### PR DESCRIPTION
Adds [EnhancedSkills](https://sameerbajaj.com/tools/enhanced-skills) (macOS app to manage, validate, and fix Claude Code and Codex skills) to Tools and [ClawdBot Skills](https://sameerbajaj.com/tools/clawdbot-skills) (Oura coaching and Readwise Reader knowledge retrieval skills) to Community Skills.