### PR TITLE
Add Suede Creator Skills to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills)** - Library of 74 skills for Claude Code and Codex, led by design: `suede-design` and `johnny-suede-design` cover design tokens, visual hierarchy, dark mode, and visual QA on shipped screens
+  - Also covers code review with a blunt A-F ship grade, CI ship gates, AI evals, SEO and AEO audits, and creator-rights tooling
+  - MIT, with adapted components under their upstream notices
+  - Installation: `/plugin marketplace add JasonColapietro/suede-creator-skills`
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adds [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) to `Collections & Libraries`.

A library of 74 skills for Claude Code and Codex, installed as one plugin marketplace. The design lane leads: `suede-design` and `johnny-suede-design` cover design tokens, visual hierarchy, dark mode, and visual QA on shipped screens. The rest covers code review with a blunt A-F ship grade, CI ship gates, AI eval scaffolding, SEO and AEO audits, and creator-rights tooling.

Same shape as `obra/superpowers` already in that section: a multi-skill library with a marketplace and an install command, rather than a single skill.

Against the stated bars:

- 129 stars, so past the 10-star threshold
- Not a SaaS. No server calls, no accounts, no telemetry
- Every skill is a plain `skills/<name>/SKILL.md` you can read before running it
- MIT for the original work; adapted components keep their upstream notices, including BSD-3-Clause for Graph of Thoughts

One line plus three sub-bullets, nothing else touched.