### PR TITLE
Add skill-governance-oss to Collections & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Skills for working with complex file formats:
   - [Blog post about its development](https://blog.fsck.com/2025/10/23/naming-claude-plugins/)
   - Install from `superpowers-marketplace` plugin
 
+- **[skill-governance-oss](https://github.com/0mandrock1/skill-governance-oss)** - Governance spec + three linters (`validate_registry`, `lint_dependencies`, `audit_triggers`) for large Claude Skills collections
+  - Models each skill as a class: state = fields, trigger phrases + Inter-Skill API = public interface, `Inherits from:` = inheritance
+  - Catches semantic trigger-collisions and orphaned state-ownership across a whole collection — defects a per-file linter can't see by definition
+  - Case study on a real 116-skill collection: 37 FAIL / 22 WARN — [CASE.md](https://github.com/0mandrock1/skill-governance-oss/blob/main/CASE.md)
+  - MIT, no roadmap, no support promise
+
 
 ### Individual Skills
 


### PR DESCRIPTION
Adds a governance spec + three linters (`validate_registry`, `lint_dependencies`, `audit_triggers`) for large Claude Skills collections — models each skill as a class and catches semantic trigger-collisions and orphaned state-ownership across the whole collection, defects a per-file linter can't see by definition.

Case study included: real run against a 116-skill collection, 37 FAIL / 22 WARN, three defects shown in full with how each linter caught them.

MIT, no roadmap, no support promise.

https://github.com/0mandrock1/skill-governance-oss