### PR TITLE
Add personal-understanding (personal memory skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Skills for working with complex file formats:
 | **[claude-d3js-skill](https://github.com/chrisvoncsefalvay/claude-d3js-skill)** | Visualizations in d3.js |
 | **[claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** | Comprehensive collection of ready-to-use scientific skills, including working with specialized scientific libraries and databases |
 | **[web-asset-generator](https://github.com/alonw0/web-asset-generator)** | Generates web assets like favicons, app icons, and social media images |
+| **[personal-understanding](https://github.com/caix84476-netizen/personal-understanding)** | Verbatim-first personal memory: immutable word-for-word capture, evidence-chain derivation, anti-fabrication gates, audit dashboard |
 | **[loki-mode](https://github.com/asklokesh/claudeskill-loki-mode)** | Multi-agent autonomous startup system - orchestrates 37 AI agents across 6 swarms to build, deploy, and operate a complete startup from PRD to revenue |
 | **[Trail of Bits Security Skills](https://github.com/trailofbits/skills)** | Security skills for static analysis with CodeQL/Semgrep, variant analysis, code auditing, and vulnerability detection |
 | **[frontend-slides](https://github.com/zarazhangrui/frontend-slides)** | Create animation-rich HTML presentations — from scratch or by converting PowerPoint files |


### PR DESCRIPTION
Adds [personal-understanding](https://github.com/caix84476-netizen/personal-understanding) to Individual Skills — verbatim-first personal memory skill + MCP server for AI agents. Python stdlib only, local-first.