### PR TITLE
Add shipcheck to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[shipcheck](https://github.com/BakerVentures/shipcheck)** | Scans React Native / Expo projects and store-listing metadata against the live App Store Review Guidelines and Google Play policies, citing the exact clause and giving the fix |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds shipcheck: a Claude Code plugin that scans React Native / Expo projects and store-listing metadata against the live App Store Review Guidelines and Google Play policies, citing the exact clause and giving the fix.

- Corpus is fetched live from developer.apple.com and support.google.com, cached with a fetch date and sha256 (not hardcoded policy text)
- App Store Review Guidelines chunked into 137 numbered clauses with deep links
- Runs entirely in the user's own Claude Code session — no hosted backend sees project contents
- Repo: https://github.com/BakerVentures/shipcheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUsehYWpLMvV5hJVHuFZSo