### PR TITLE
Add shipit-skill — one-pass launch pipeline for developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[shipit-skill](https://github.com/skyzhao1223/shipit-skill)** | One-pass launch pipeline for developer tools — engineering baseline, publish, directory listings, and promo material, via `pip install shipit-skill` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Add [skyzhao1223/shipit-skill](https://github.com/skyzhao1223/shipit-skill) to **Individual Skills**.

A one-pass launch pipeline Agent Skill + CLI for developer tools: engineering baseline (CI/Dockerfile) → publish (PyPI/npm) → directory listings (Glama/awesome) → promo. Ships as a Python package with `shipit-skill init|ci|publish|check-promo|check-glama|awesome-pr` subcommands. MIT.