### PR TITLE
Add kavel-image skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[kavel-image](https://github.com/hanshs474/kavel-image-skill)** | Generate images and edit photos from a prompt with no API key and no account, through Kavel's anonymous endpoint — text-to-image plus face-preserving edits |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [kavel-image](https://github.com/hanshs474/kavel-image-skill) under **Individual Skills**.

Generates images and edits photos with **no API key and no account** — most image skills need a provider key before they do anything. It calls an anonymous endpoint, so a fresh install produces a picture on the first call (15 free credits, 5 per text-to-image; output is 1K and watermarked, which the skill states plainly).

The SKILL.md documents the real limits rather than the happy path: which model can and cannot take an image input, that the anonymous wallet cannot cover video at any setting, and the three failure modes that actually occur (content-filter refusal, queue waits, per-IP daily ceiling).

MIT licensed.