### PR TITLE
Add pc-cleanup to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[pc-cleanup](https://github.com/DogukanK/claude-pc-cleanup)** | Scans a macOS machine for reclaimable disk space and cleans it up safely, tier by tier, with explicit confirmation before deleting anything |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds [pc-cleanup](https://github.com/DogukanK/claude-pc-cleanup), a Claude Code skill for macOS disk cleanup: read-only scan of caches/node_modules/venv/.terraform/Xcode DerivedData/Docker-Podman/Trash, tiered classification (safe & regenerable / needs judgment / never touch) with a stated reason per item, explicit confirmation before any deletion, and a guardrailed deletion script that independently re-checks an allow/deny list in code.

Opened as a draft for now — will mark ready for review shortly.