### PR TITLE
Add EdgeVerdict to Individual Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[EdgeVerdict](https://github.com/edgeverdict/edgeverdict-make-me-money-trading)** | Read-only agent skill for Path A $0.10 micropay signal receipts (unpaid HTTP 402 until paid) + paper waitlist Path B. Method card: https://edgeverdict.io/receipts — `npx skills add edgeverdict/edgeverdict-make-me-money-trading` |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
-| **[EdgeVerdict](https://github.com/edgeverdict/edgeverdict-make-me-money-trading)** | Free research-first: health → receipts → /math → `npx skills add edgeverdict/edgeverdict-make-me-money-trading` · https://edgeverdict.io/llms.txt · /receipts · https://www.skills.sh/edgeverdict/edgeverdict-make-me-money-trading — Paper ≠ live. No custody. No sleeve. |
+| **[EdgeVerdict](https://github.com/edgeverdict/edgeverdict-make-me-money-trading)** | Free research-first skill: health → method receipts → install. `npx skills add edgeverdict/edgeverdict-make-me-money-trading` · https://edgeverdict.io/llms.txt · https://edgeverdict.io/receipts · https://www.skills.sh/edgeverdict/edgeverdict-make-me-money-trading — Paper ≠ live. No custody. No sleeve recipe. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
-| **[EdgeVerdict](https://github.com/edgeverdict/edgeverdict-make-me-money-trading)** | Free research-first skill: health → method receipts → install. `npx skills add edgeverdict/edgeverdict-make-me-money-trading` · https://edgeverdict.io/llms.txt · https://edgeverdict.io/receipts · https://www.skills.sh/edgeverdict/edgeverdict-make-me-money-trading — Paper ≠ live. No custody. No sleeve recipe. |
+| **[EdgeVerdict](https://github.com/edgeverdict/edgeverdict-make-me-money-trading)** | Free research-first: health → receipts → /math → install. `npx skills add edgeverdict/edgeverdict-make-me-money-trading` · https://edgeverdict.io/llms.txt · https://edgeverdict.io/receipts · https://edgeverdict.io/math · https://www.skills.sh/edgeverdict/edgeverdict-make-me-money-trading — Paper ≠ live. No custody. No sleeve recipe. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
-| **[EdgeVerdict](https://github.com/edgeverdict/edgeverdict-make-me-money-trading)** | Free research-first: health → receipts → /math → `npx skills add edgeverdict/edgeverdict-make-me-money-trading` · edgeverdict.io/llms.txt · /receipts · skills.sh. Paper ≠ live. No custody. No sleeve. |
+| **[EdgeVerdict](https://github.com/edgeverdict/edgeverdict-make-me-money-trading)** | Free research-first: health → receipts → /math → `npx skills add edgeverdict/edgeverdict-make-me-money-trading` · https://edgeverdict.io/llms.txt · /receipts · https://www.skills.sh/edgeverdict/edgeverdict-make-me-money-trading — Paper ≠ live. No custody. No sleeve. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
-| **[EdgeVerdict](https://github.com/edgeverdict/edgeverdict-make-me-money-trading)** | Read-only agent skill for Path A $0.10 micropay signal receipts (unpaid HTTP 402 until paid) + paper waitlist Path B. Method card: https://edgeverdict.io/receipts — `npx skills add edgeverdict/edgeverdict-make-me-money-trading` |
+| **[EdgeVerdict](https://github.com/edgeverdict/edgeverdict-make-me-money-trading)** | Free research-first: health → receipts → /math → `npx skills add edgeverdict/edgeverdict-make-me-money-trading` · edgeverdict.io/llms.txt · /receipts · skills.sh. Paper ≠ live. No custody. No sleeve. |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
## Summary
Adds **EdgeVerdict** to the Community Skills → Individual Skills table.

Free research-first skill for agents/humans: health → receipts → /math → install.
`npx skills add edgeverdict/edgeverdict-make-me-money-trading`
https://edgeverdict.io/llms.txt · https://edgeverdict.io/receipts · https://edgeverdict.io/math · https://www.skills.sh/edgeverdict/edgeverdict-make-me-money-trading
Paper ≠ live. No custody. No sleeve recipe.

- Skill repo: https://github.com/edgeverdict/edgeverdict-make-me-money-trading
- Health: https://api.edgeverdict.io/v1/verdict/health
- Method receipts: https://edgeverdict.io/receipts
- Fees & fairness: https://edgeverdict.io/math
- Agent brief: https://edgeverdict.io/llms.txt
- skills.sh: https://www.skills.sh/edgeverdict/edgeverdict-make-me-money-trading
- Optional paper waitlist: https://edgeverdict.io/waitlist (interest ≠ purchase)
- License: MIT (SKILL.md frontmatter)

## Notes
- Read-only decisions/reports. No custody. No sleeve source. Paper ≠ live promise.
- No Path A / $0.10 / micropay price hero in this listing blurb.
- No “listed” claim beyond this PR until merge+README on upstream.