### PR TITLE
Add marketing-mindset — open agent skill for B2B marketing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Skills for working with complex file formats:
 | **[Expo Skills](https://github.com/expo/skills)** | Official skills by the Expo team for developing Expo apps |
 | **[shadcn/ui](https://ui.shadcn.com/docs/skills)** | Give Claude Code context on shadcn components as well as pattern enforcement |
 | **[get-shit-done](https://github.com/gsd-build/get-shit-done)** | Lightweight meta-prompting, context engineering, and spec-driven development system for Claude Code by TÂCHES |
+| **[marketing-mindset](https://github.com/axelfreeman/marketing-mindset)** | Marketing OS for AI agents — think like a marketer first, get tactics as the output |
 
 _More community skills coming soon! Submit a PR to add your skill._
 


### PR DESCRIPTION
Adds `marketing-mindset`, an open agent skill (SKILL.md) with tested rules for B2B marketing tests: how much volume before a result is trustworthy, when to kill a channel, pricing a first client, cold-email deliverability.

- page: https://axelfreeman.github.io/marketing-mindset/
- install: `npx marketing-mindset`

Happy to change the placement or format if the list prefers another section.